### PR TITLE
zzf/fix bug of cumsum

### DIFF
--- a/DIOPI-IMPL/camb/device_configs.py
+++ b/DIOPI-IMPL/camb/device_configs.py
@@ -747,18 +747,6 @@ device_configs = {
         ),
     ),
 
-    'cumsum': dict(
-        name=["cumsum"],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.uint8)],
-                },
-            ],
-        ),
-    ),
-
     'cdist': dict(
         name=['cdist'],
         tensor_para=dict(

--- a/DIOPI-IMPL/camb/functions/cumsum.cpp
+++ b/DIOPI-IMPL/camb/functions/cumsum.cpp
@@ -25,13 +25,7 @@ DIOPI_API diopiError_t diopiCumsum(diopiContextHandle_t ctx, diopiTensorHandle_t
 
     DiopiTensor input_tensor(input);
     DiopiTensor out_tensor(out);
-    if (input_tensor.dtype() == diopi_dtype_int64 || input_tensor.dtype() == diopi_dtype_int16 || input_tensor.dtype() == diopi_dtype_int8) {
-        DIOPI_CALL(dataTypeCast(ctx, input_tensor, diopi_dtype_int32));
-    } else if (input_tensor.dtype() == diopi_dtype_float64) {
-        DIOPI_CALL(dataTypeCast(ctx, input_tensor, diopi_dtype_float32));
-    } else if (input_tensor.dtype() == diopi_dtype_bool || input_tensor.dtype() == diopi_dtype_uint8) {
-        DIOPI_CALL(dataTypeCast(ctx, input_tensor, diopi_dtype_float16));
-    }
+    DIOPI_CALL(autoCastTensorType(ctx, {&input_tensor}, {diopi_dtype_int32, diopi_dtype_float32, diopi_dtype_float16}));
 
     CnnlTensorDesc input_desc(input_tensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc out_desc(out_tensor, CNNL_LAYOUT_ARRAY);


### PR DESCRIPTION
## Motivation and Context
fix ci bug of the op cumsum. when the dtype of input is uint8, and the value item of input is 255. it might encounter failed.

## Description
delete the Skip config of cumsum op.
fix the data convert method of op cumsum.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

