### PR TITLE
fix diopiCopyInp dest tensor error

### DIFF
--- a/DIOPI-IMPL/camb/functions/copy.cpp
+++ b/DIOPI-IMPL/camb/functions/copy.cpp
@@ -29,7 +29,7 @@ diopiError_t diopiCopyInp(diopiContextHandle_t ctx, diopiConstTensorHandle_t src
 
 
     if (src_tr.dtype() != dest_tr.dtype()) {
-        DIOPI_CALL(dataTypeCast(ctx, src_tr, dest_tr.dtype()));
+        DIOPI_CALL(dataTypeCast(ctx, dest_tr, src_tr));
     }
 
     CnnlTensorDesc input_desc(dest_tr, CNNL_LAYOUT_ARRAY);


### PR DESCRIPTION
## Motivation and Context
fix diopiCopyInp dest tensor error, which may cause output tensor of copy is nan


## Description
update DIOPI/DIOPI-IMPL/camb/functions/copy.cpp


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

