### PR TITLE
Yb/fix bug

### DIFF
--- a/DIOPI-IMPL/camb/common/debug.hpp
+++ b/DIOPI-IMPL/camb/common/debug.hpp
@@ -24,14 +24,36 @@ namespace camb {
 template <typename T>
 void printDevData(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len, T) {
     int bytes = sizeof(T) * len;
-    void* ptr = malloc(bytes);
-    std::cout << "data:" << data << std::endl;
-    cnrtMemcpyAsync(ptr, data, bytes, getStream(ctx), cnrtMemcpyDevToHost);
+    std::unique_ptr ptr(new char[bytes]);
+    std::cout << "data address:" << data << std::endl;
+    cnrtMemcpyAsync(ptr.get(), data, bytes, getStream(ctx), cnrtMemcpyDevToHost);
     syncStreamInCtx(ctx);
     for (int i = 0; i < len && i < max_len; ++i) {
-        std::cout << reinterpret_cast<T*>(ptr)[i] << " ";
+        std::cout << reinterpret_cast<T*>(ptr.get())[i] << " ";
     }
     std::cout << std::endl;
+}
+
+void printDevDataUint8Int8(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len) {
+    int bytes = len;
+    std::unique_ptr ptr(new char[bytes]);
+    std::cout << "data address:" << data << std::endl;
+    cnrtMemcpyAsync(ptr.get(), data, bytes, getStream(ctx), cnrtMemcpyDevToHost);
+    syncStreamInCtx(ctx);
+    for (int i = 0; i < len && i < max_len; ++i) {
+        std::cout << static_cast<int32>(reinterpret_cast<T*>(ptr.get())[i]) << " ";
+    }
+    std::cout << std::endl;
+}
+
+template<>
+void printDevData<int8_t>(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len, int8_t _) {
+    printDevDataUint8Int8(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len);
+}
+
+template<>
+void printDevData<uint8_t>(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len, uint8_t _) {
+    printDevDataUint8Int8(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len);
 }
 
 static void print_backtrace() {

--- a/DIOPI-IMPL/camb/common/debug.hpp
+++ b/DIOPI-IMPL/camb/common/debug.hpp
@@ -34,7 +34,8 @@ void printDevData(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max
     std::cout << std::endl;
 }
 
-void printDevDataUint8Int8(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len) {
+template<>
+void printDevData<int8_t>(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len, int8_t _) {
     int bytes = len;
     std::unique_ptr ptr(new char[bytes]);
     std::cout << "data address:" << data << std::endl;
@@ -47,13 +48,8 @@ void printDevDataUint8Int8(diopiContextHandle_t ctx, void* data, int64_t len, in
 }
 
 template<>
-void printDevData<int8_t>(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len, int8_t _) {
-    printDevDataUint8Int8(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len);
-}
-
-template<>
 void printDevData<uint8_t>(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len, uint8_t _) {
-    printDevDataUint8Int8(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len);
+    printDevData<int8_t>(ctx, data, len, max_len, static_cast<int8_t>(_));
 }
 
 static void print_backtrace() {

--- a/DIOPI-IMPL/camb/diopi_helper.hpp
+++ b/DIOPI-IMPL/camb/diopi_helper.hpp
@@ -380,7 +380,7 @@ inline cnrtQueue_t getStream(diopiContextHandle_t ctx) {
 
 template <typename T>
 inline std::vector<T> diopiSize_t2Vector(diopiSize_t size, T) {
-    return std::vector<T>(size.data(), size.data() + size.len);
+    return std::vector<T>(size.data, size.data + size.len);
 }
 
 inline diopiSize_t vec2diopiSize_t(const std::vector<int64_t>& sizeIn) {


### PR DESCRIPTION
## Motivation and Context
* printDevData 
* diopiSize_t2Vector


## Description
* fix printDevData function bug,  the print is garbled  when the data type is uint8_t or int8_t and forgets to free the memory allocated
* fix diopiSize_t2Vector bug.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

