### PR TITLE
jg/check_contiguous_in_conv2d

### DIFF
--- a/DIOPI-IMPL/camb/functions/conv_2d.cpp
+++ b/DIOPI-IMPL/camb/functions/conv_2d.cpp
@@ -58,9 +58,9 @@ extern "C" diopiError_t diopiConvolution2d(diopiContextHandle_t ctx, diopiTensor
 
     DIOPI_CHECK(true, input_tensor.is_contiguous() || input_tensor.is_contiguous(MemoryFormat::ChannelsLast),
                 "[diopiConvolution2d] the memory format is not supportted.");
-    DIOPI_CHECK(true, weight_tensor.is_contiguous() || weight_tensor.is_contiguous(MemoryFormat::ChannelsLast), 
+    DIOPI_CHECK(true, weight_tensor.is_contiguous() || weight_tensor.is_contiguous(MemoryFormat::ChannelsLast),
                 "[diopiConvolution2d] the memory format is not supportted.");
-    DIOPI_CHECK(true, output_tensor.is_contiguous() || output_tensor.is_contiguous(MemoryFormat::ChannelsLast), 
+    DIOPI_CHECK(true, output_tensor.is_contiguous() || output_tensor.is_contiguous(MemoryFormat::ChannelsLast),
                 "[diopiConvolution2d] the memory format is not supportted.");
 
     DiopiTensor input_tensor_casted = input_tensor;
@@ -256,7 +256,7 @@ extern "C" diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx, dio
 
     DIOPI_CALL(diopiTensorPermute2D(ctx, grad_input_casted, grad_input_t, MemoryFormat::Contiguous));
     DIOPI_CALL(diopiTensorPermute2D(ctx, grad_weight_casted, grad_weight_t, MemoryFormat::Contiguous));
-    
+
     DIOPI_CALL(dataTypeCast(ctx, grad_input_tensor, grad_input_casted));
     DIOPI_CALL(dataTypeCast(ctx, grad_weight_tensor, grad_weight_casted));
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixup: add DIOPI_CHECK for conv2d operator.

## Description
<!--- Describe your changes in detail. -->
1. add DIOPI_CHECK for tensors.
2. add memory layout check for tensor permutation. 

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

