### PR TITLE
wx/fix the softmax(log softmax) backward op and add the log info about the element of the max diff

### DIFF
--- a/DIOPI-IMPL/camb/functions/softmax.cpp
+++ b/DIOPI-IMPL/camb/functions/softmax.cpp
@@ -80,7 +80,7 @@ diopiError_t softmaxForward(diopiContextHandle_t ctx, DiopiTensor input, DiopiTe
 }
 
 diopiError_t softmaxBackward(diopiContextHandle_t ctx, DiopiTensor gradInputTensor, DiopiTensor gradOutputTensor, DiopiTensor outputTensor, int64_t dim,
-                              bool isLog = false) {
+                             bool isLog = false) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
     DiopiTensor gradInputCasted = gradInputTensor;
@@ -96,6 +96,7 @@ diopiError_t softmaxBackward(diopiContextHandle_t ctx, DiopiTensor gradInputTens
 
     const size_t inputDim = 3;
     int mode = dim;
+    mode = (mode < 0) ? (mode + inputRank) : mode;
     std::vector<int> outputShape(inputDim, 1);
     if (inputRank != 0) {
         if (inputRank <= 3) {
@@ -114,8 +115,6 @@ diopiError_t softmaxBackward(diopiContextHandle_t ctx, DiopiTensor gradInputTens
             outputShape[2] = reduceDim(srcOutputShape, flag ? mode : (mode + 1), (inputRank - 1));
         }
     }
-
-    mode = (mode < 0) ? (mode + inputRank) : mode;
 
     cnnlSoftmaxMode_t modeTmp;
     if (inputRank == 3 && mode == 0) {

--- a/DIOPI-TEST/python/conformance/conformance_test.py
+++ b/DIOPI-TEST/python/conformance/conformance_test.py
@@ -73,13 +73,13 @@ def allclose(cfg: dict, tensor1: np.ndarray, tensor2: np.ndarray, sum_to_compare
         sum1 = tensor1.sum()
         sum2 = tensor2.sum()
         mask = np.isclose(tensor1, tensor2, rtol, atol, True)
-        count = np.count_nonzero(mask == False)  
+        count = np.count_nonzero(np.equal(mask, False))
         if tensor1.dtype == np.bool_:
             max_diff = 1
             logger.info(f"The count of elements that do not meet the accuracy requirement is {count}.")
             logger.info(f"Max of diff is {max_diff}.")
             logger.debug(f"Sum of {var_name} is {sum1}, Sum of {var_name}_ref is {sum2}, Max of diff is {max_diff}. \
-                     \n" + f"{var_name} is {tensor1},\n{var_name}_ref is {tensor2},\nMask is {mask}\n")            
+                    \n" + f"{var_name} is {tensor1},\n{var_name}_ref is {tensor2},\nMask is {mask}\n")
         else:
             diff = np.abs(tensor1 - tensor2)
             max_diff = np.abs(tensor1 - tensor2).max()
@@ -89,8 +89,8 @@ def allclose(cfg: dict, tensor1: np.ndarray, tensor2: np.ndarray, sum_to_compare
             logger.info(f"The count of elements that do not meet the accuracy requirement is {count}.")
             logger.info(f"The max of diff is {max_diff}. Specifically, the actual val is {max_diff_elem} and the expected is {max_diff_elem_ref}.")
             logger.debug(f"Sum of {var_name} is {sum1}, Sum of {var_name}_ref is {sum2}, Max of diff is {max_diff}. \
-                     \n" + f"{var_name} is {tensor1},\n{var_name}_ref is {tensor2},\nMask is {mask}\n")     
-            logger.debug(f"The max of diff is {max_diff}. Specifically, the actual val is {max_diff_elem} and the expected is {max_diff_elem_ref}.\n")          
+                    \n" + f"{var_name} is {tensor1},\n{var_name}_ref is {tensor2},\nMask is {mask}\n")
+            logger.debug(f"The max of diff is {max_diff}. Specifically, the actual val is {max_diff_elem} and the expected is {max_diff_elem_ref}.\n")
     return passed
 
 

--- a/DIOPI-TEST/python/conformance/conformance_test.py
+++ b/DIOPI-TEST/python/conformance/conformance_test.py
@@ -73,13 +73,24 @@ def allclose(cfg: dict, tensor1: np.ndarray, tensor2: np.ndarray, sum_to_compare
         sum1 = tensor1.sum()
         sum2 = tensor2.sum()
         mask = np.isclose(tensor1, tensor2, rtol, atol, True)
+        count = np.count_nonzero(mask == False)  
         if tensor1.dtype == np.bool_:
             max_diff = 1
+            logger.info(f"The count of elements that do not meet the accuracy requirement is {count}.")
+            logger.info(f"Max of diff is {max_diff}.")
+            logger.debug(f"Sum of {var_name} is {sum1}, Sum of {var_name}_ref is {sum2}, Max of diff is {max_diff}. \
+                     \n" + f"{var_name} is {tensor1},\n{var_name}_ref is {tensor2},\nMask is {mask}\n")            
         else:
+            diff = np.abs(tensor1 - tensor2)
             max_diff = np.abs(tensor1 - tensor2).max()
-        logger.info(f"Max of diff is {max_diff}.")
-        logger.debug(f"Sum of {var_name} is {sum1}, Sum of {var_name}_ref is {sum2}, Max of diff is {max_diff}. \
-                     \n" + f"{var_name} is {tensor1},\n{var_name}_ref is {tensor2},\nMask is {mask}\n")
+            max_diff_index = np.unravel_index(np.argmax(diff), diff.shape)
+            max_diff_elem = tensor1[max_diff_index]
+            max_diff_elem_ref = tensor2[max_diff_index]
+            logger.info(f"The count of elements that do not meet the accuracy requirement is {count}.")
+            logger.info(f"The max of diff is {max_diff}. Specifically, the actual val is {max_diff_elem} and the expected is {max_diff_elem_ref}.")
+            logger.debug(f"Sum of {var_name} is {sum1}, Sum of {var_name}_ref is {sum2}, Max of diff is {max_diff}. \
+                     \n" + f"{var_name} is {tensor1},\n{var_name}_ref is {tensor2},\nMask is {mask}\n")     
+            logger.debug(f"The max of diff is {max_diff}. Specifically, the actual val is {max_diff_elem} and the expected is {max_diff_elem_ref}.\n")          
     return passed
 
 

--- a/DIOPI-TEST/python/conformance/diopi_configs.py
+++ b/DIOPI-TEST/python/conformance/diopi_configs.py
@@ -1972,7 +1972,7 @@ diopi_configs = {
                 {
                     "ins": ['input'],
                     "requires_grad": [True],
-                    "shape": ((78, 24), (2, 92, 29), (2, 150, 512, 512), (4 ,12, 577, 577)),
+                    "shape": ((78, 24), (2, 92, 29), (2, 150, 512, 512), (4, 12, 577, 577)),
                     "dtype": [Dtype.float32, Dtype.float64],
                     "gen_fn": Genfunc.randn,
                 },
@@ -1993,7 +1993,7 @@ diopi_configs = {
                 {
                     "ins": ['input'],
                     "requires_grad": [True],
-                    "shape": ((2, 24), (2, 128, 24), (8, 16, 49, 49), (4 ,12, 577, 577)),
+                    "shape": ((2, 24), (2, 128, 24), (8, 16, 49, 49), (4, 12, 577, 577)),
                     "dtype": [Dtype.float32, Dtype.float64],
                     "gen_fn": Genfunc.randn,
                 },

--- a/DIOPI-TEST/python/conformance/diopi_configs.py
+++ b/DIOPI-TEST/python/conformance/diopi_configs.py
@@ -1965,14 +1965,14 @@ diopi_configs = {
         name=["log_softmax"],
         saved_args=dict(output=0),
         para=dict(
-            dim=[-1, 1, 0],
+            dim=[-1, 1, 0, -1],
         ),
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
                     "requires_grad": [True],
-                    "shape": ((78, 24), (2, 92, 29), (2, 150, 512, 512)),
+                    "shape": ((78, 24), (2, 92, 29), (2, 150, 512, 512), (4 ,12, 577, 577)),
                     "dtype": [Dtype.float32, Dtype.float64],
                     "gen_fn": Genfunc.randn,
                 },
@@ -1986,14 +1986,14 @@ diopi_configs = {
         rtol=1e-5,
         saved_args=dict(output=0),
         para=dict(
-            dim=[-1, 1, 0],
+            dim=[-1, 1, 0, -1],
         ),
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
                     "requires_grad": [True],
-                    "shape": ((2, 24), (2, 128, 24), (8, 16, 49, 49)),
+                    "shape": ((2, 24), (2, 128, 24), (8, 16, 49, 49), (4 ,12, 577, 577)),
                     "dtype": [Dtype.float32, Dtype.float64],
                     "gen_fn": Genfunc.randn,
                 },


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix the bug of softmax(log softmax) backward op and refine test cases.
Add the log info about the element of the max diff.

## Description
<!--- Describe your changes in detail. -->
Fix the bug of softmax(log softmax) backward op and add the corresponding test case in the diopi_configs.py file.
Add the log info about the element of the max diff.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

