### PR TITLE
fix inplace backward

### DIFF
--- a/DIOPI-TEST/python/conformance/conformance_test.py
+++ b/DIOPI-TEST/python/conformance/conformance_test.py
@@ -421,16 +421,17 @@ class ConformanceTest(object):
             kwargs = function_paras['kwargs']
             func_call_list = []
             func_call_list.append(f"{module}.{test_func_name}(**kwargs)")
-            is_inplace = False
+            is_inplaces = []
             if "inplace" in kwargs.keys():
-                is_inplace = kwargs["inplace"]
+                is_inplaces.append(kwargs["inplace"])
             else:
-                is_inplace = data["cfg"].get("is_inplace", False)
-                if is_inplace:
+                is_inplaces.append(False)
+                if data["cfg"].get("is_inplace", False):
+                    is_inplaces.append(True)
                     func_call_list.append(f"{module}.{test_func_name}(**kwargs, inplace=True)")
 
             ignore_paras_for_input_check = ops_with_states.get(test_func_name, set())
-            for func_call in func_call_list:
+            for func_call, is_inplace in zip(func_call_list, is_inplaces):
                 if is_inplace:
                     if test_tag and test_tag[-1] == 'backward':
                         test_tag.pop()


### PR DESCRIPTION
## Motivation and Context
Fix bug of conformance test for inplace operators

## Description
When setting is_inplace=True in diopi configs, it will test both cases where inplace is false and true. For the case where inplace is false, we need to test backward if is required. However, in current conformance test,  backward will not be tested. In this pr, I've fixed this problem.

## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

