### PR TITLE
fix min and max

### DIFF
--- a/DIOPI-IMPL/camb/common/common.hpp
+++ b/DIOPI-IMPL/camb/common/common.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "../cnnl_helper.hpp"
+#include "debug.hpp"
 
 namespace impl {
 namespace camb {

--- a/DIOPI-IMPL/camb/common/debug.hpp
+++ b/DIOPI-IMPL/camb/common/debug.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "../diopi_helper.hpp"
+#include "float16.hpp"
 
 namespace impl {
 namespace camb {
@@ -41,7 +42,7 @@ void printDevDataInternal(diopiContextHandle_t ctx, void* data, int64_t len, int
 void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor) {
     int64_t len = tensor.numel();
     void* dataIn = tensor.data();
-    int64_t maxLen = 10;
+    int64_t maxLen = 1000;
     switch (tensor.dtype()) {
         case diopi_dtype_bool:
             printDevDataInternal<bool, int32_t>(ctx, dataIn, len, maxLen);
@@ -69,6 +70,9 @@ void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor) {
             break;
         case diopi_dtype_int64:
             printDevDataInternal<int64_t, int64_t>(ctx, dataIn, len, maxLen);
+            break;
+        case diopi_dtype_float16:
+            printDevDataInternal<half_float::half, float>(ctx, dataIn, len, maxLen);
             break;
         case diopi_dtype_float32:
             printDevDataInternal<float, float>(ctx, dataIn, len, maxLen);

--- a/DIOPI-IMPL/camb/common/debug.hpp
+++ b/DIOPI-IMPL/camb/common/debug.hpp
@@ -22,24 +22,21 @@
 namespace impl {
 namespace camb {
 
-namespace {
-
 // print the data on dev
-// T is the dtype such as  float, int64_t, double.
 template <typename RealT, typename CastT>
-void printDevDataInternal(diopiContextHandle_t ctx, void* data, int64_t len, int64_t max_len) {
+void printDevDataInternal(diopiContextHandle_t ctx, void* data, int64_t len, int64_t maxLen) {
     int bytes = sizeof(RealT) * len;
     std::unique_ptr<char> ptr(new char[bytes]);
     std::cout << "data address:" << data << std::endl;
     cnrtMemcpyAsync(ptr.get(), data, bytes, getStream(ctx), cnrtMemcpyDevToHost);
     syncStreamInCtx(ctx);
-    for (int i = 0; i < len && i < max_len; ++i) {
+    for (int i = 0; i < len && i < maxLen; ++i) {
         std::cout << static_cast<CastT>(reinterpret_cast<RealT*>(ptr.get())[i]) << " ";
     }
     std::cout << std::endl;
 }
 
-void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor) {
+inline void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor) {
     int64_t len = tensor.numel();
     void* dataIn = tensor.data();
     int64_t maxLen = 10;
@@ -95,33 +92,32 @@ void printVec(std::vector<T> vec) {
     std::cout << std::endl;
 }
 
-static void print_backtrace() {
-    const int MAX_STACK_FRAMES = 64;
-    void* stack_traces[MAX_STACK_FRAMES];
-    int stack_frames = backtrace(stack_traces, MAX_STACK_FRAMES);
+inline void printBacktrace() {
+    const int maxStackFrames = 64;
+    void* stackTraces[maxStackFrames];
+    int stackFrames = backtrace(stackTraces, maxStackFrames);
 
-    char** stack_strings = backtrace_symbols(stack_traces, stack_frames);  // do not forget to free stack_strings
-    for (int i = 0; i < stack_frames; i++) {
-        printf("%s\n", stack_strings[i]);
+    char** stackStrings = backtrace_symbols(stackTraces, stackFrames);  // do not forget to free stack_strings
+    for (int i = 0; i < stackFrames; i++) {
+        printf("%s\n", stackStrings[i]);
 
         // Try to demangle the symbol name
-        char* symbol = stack_strings[i];
-        char* mangled_start = strchr(symbol, '(');
-        char* mangled_end = strchr(mangled_start, '+');
-        if (mangled_start && mangled_end) {
-            *mangled_start++ = '\0';
-            *mangled_end = '\0';
+        char* symbol = stackStrings[i];
+        char* mangledStart = strchr(symbol, '(');
+        char* mangledEnd = strchr(mangledStart, '+');
+        if (mangledStart && mangledEnd) {
+            *mangledStart++ = '\0';
+            *mangledEnd = '\0';
             int status;
-            char* demangled = abi::__cxa_demangle(mangled_start, nullptr, nullptr, &status);
+            char* demangled = abi::__cxa_demangle(mangledStart, nullptr, nullptr, &status);
             if (status == 0) {
                 printf("  %s\n", demangled);
             }
         }
     }
-    free(stack_strings);
+    free(stackStrings);
 }
 
-}  // namespace
 }  // namespace camb
 }  // namespace impl
 

--- a/DIOPI-IMPL/camb/common/debug.hpp
+++ b/DIOPI-IMPL/camb/common/debug.hpp
@@ -42,7 +42,7 @@ void printDevDataInternal(diopiContextHandle_t ctx, void* data, int64_t len, int
 void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor) {
     int64_t len = tensor.numel();
     void* dataIn = tensor.data();
-    int64_t maxLen = 1000;
+    int64_t maxLen = 10;
     switch (tensor.dtype()) {
         case diopi_dtype_bool:
             printDevDataInternal<bool, int32_t>(ctx, dataIn, len, maxLen);

--- a/DIOPI-IMPL/camb/diopi_helper.hpp
+++ b/DIOPI-IMPL/camb/diopi_helper.hpp
@@ -79,9 +79,9 @@ public:
             case diopi_dtype_uint16:
                 return "diopi_dtype_uint16";
             case diopi_dtype_int32:
-                return "diopi_dtype_uint32";
-            case diopi_dtype_uint32:
                 return "diopi_dtype_int32";
+            case diopi_dtype_uint32:
+                return "diopi_dtype_uint32";
             case diopi_dtype_int64:
                 return "diopi_dtype_int64";
             case diopi_dtype_uint64:

--- a/DIOPI-IMPL/camb/functions/reduce.cpp
+++ b/DIOPI-IMPL/camb/functions/reduce.cpp
@@ -198,7 +198,10 @@ diopiError_t diopiMin(diopiContextHandle_t ctx, diopiTensorHandle_t min, diopiTe
     DiopiTensor outputTr(min);
     DiopiTensor indexTr(minIndices);
     // Note: camb index out is int32 dtype
-    auto indexTmpTr = requiresTensor(ctx, indexTr.shape(), diopi_dtype_int32);
+    auto indexTmpTr = indexTr;
+    if (indexTmpTr.dtype() != diopi_dtype_int32) {
+        indexTmpTr = requiresTensor(ctx, indexTr.shape(), diopi_dtype_int32);
+    }
 
     DIOPI_CALL(reduceDimImpl(ctx, outputTr, indexTmpTr, inputTr, {dim}, false, CNNL_REDUCE_MIN));
 
@@ -220,7 +223,10 @@ diopiError_t diopiMax(diopiContextHandle_t ctx, diopiTensorHandle_t max, diopiTe
     DiopiTensor inputTr(input);
     DiopiTensor outputTr(max);
     DiopiTensor indexTr(maxIndices);
-    auto indexTmpTr = requiresTensor(ctx, indexTr.shape(), diopi_dtype_int32);
+    auto indexTmpTr = indexTr;
+    if (indexTmpTr.dtype() != diopi_dtype_int32) {
+        indexTmpTr = requiresTensor(ctx, indexTr.shape(), diopi_dtype_int32);
+    }
 
     DIOPI_CALL(reduceDimImpl(ctx, outputTr, indexTmpTr, inputTr, {dim}, false, CNNL_REDUCE_MAX));
 


### PR DESCRIPTION

## Motivation and Context
* diopiMin and diopiMax have  bugs about the dtype while using adaptor


## Description
fix the diopiMin and diopiMax bug.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

