### PR TITLE
wx add the scatter op

### DIFF
--- a/DIOPI-IMPL/camb/device_configs.py
+++ b/DIOPI-IMPL/camb/device_configs.py
@@ -809,15 +809,16 @@ device_configs = {
         ),
     ),
 
+    # When not performing a reduce operation, the accuracy comparison of scatter needs to be performed on the CPU
+    # Currently, the shape of src tensor and index tensor must be the same
     'scatter': dict(
         name=['scatter'],
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32), Skip(Dtype.float16),
-                              Skip(Dtype.int64), Skip(Dtype.int32), Skip(Dtype.int16),
-                              Skip(Dtype.int8), Skip(Dtype.uint8), Skip(Dtype.bool)],
+                    "dtype": [Skip(Dtype.float32), Skip(Dtype.float64), Skip(Dtype.float16), Skip(Dtype.int16),
+                              Skip(Dtype.int32), Skip(Dtype.int64), Skip(Dtype.uint8), Skip(Dtype.int8), Skip(Dtype.bool)],
                 },
             ]
         ),
@@ -825,23 +826,21 @@ device_configs = {
 
     'scatter_reduce': dict(
         name=['scatter'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32)],
-                },
-            ]
+        para=dict(
+            # The reduction operation of multiply is not supported by cnnl
+            reduce=[Skip('multiply')], 
         ),
     ),
 
+    # When not performing a reduce operation, the accuracy comparison of scatter needs to be performed on the CPU
+    # Currently, the shape of src tensor and index tensor must be the same
     'scatter_scalar': dict(
         name=['scatter'],
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32)],
+                    "dtype": [Skip(Dtype.float32), Skip(Dtype.float64)],
                 },
             ]
         ),
@@ -849,13 +848,9 @@ device_configs = {
 
     'scatter_reduce_scalar': dict(
         name=['scatter'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32)],
-                },
-            ]
+        para=dict(
+            # The reduction operation of multiply is not supported by cnnl
+            reduce=[Skip('multiply')],
         ),
     ),
 

--- a/DIOPI-IMPL/camb/functions/scatter.cpp
+++ b/DIOPI-IMPL/camb/functions/scatter.cpp
@@ -29,7 +29,7 @@ bool compareVectors(const std::vector<int64_t>& vec1, const std::vector<int64_t>
     return true;
 }
 
-diopiError_t Scatter(diopiContextHandle_t ctx, DiopiTensor outTensor, DiopiTensor inputTensor, int64_t dim, DiopiTensor srcTensor, DiopiTensor indexTensor,
+diopiError_t scatter(diopiContextHandle_t ctx, DiopiTensor outTensor, DiopiTensor inputTensor, int64_t dim, DiopiTensor srcTensor, DiopiTensor indexTensor,
                      const char* reduce) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
@@ -86,7 +86,7 @@ diopiError_t diopiScatter(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
 
     DIOPI_CHECK(strcmp(reduce, "") == 0 || strcmp(reduce, "add") == 0, "The reduction operation of multiply is not supported by cnnl");
     DIOPI_CHECK(compareVectors(srcTensor.shape(), indexTensor.shape()), "Currently, the shape of src tensor and index tensor must be the same");
-    DIOPI_CALL(Scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
+    DIOPI_CALL(scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
     return diopiSuccess;
 }
 
@@ -99,7 +99,7 @@ diopiError_t diopiScatterInp(diopiContextHandle_t ctx, diopiTensorHandle_t input
 
     DIOPI_CHECK(strcmp(reduce, "") == 0 || strcmp(reduce, "add") == 0, "The reduction operation of multiply is not supported by cnnl");
     DIOPI_CHECK(compareVectors(srcTensor.shape(), indexTensor.shape()), "Currently, the shape of src tensor and index tensor must be the same");
-    DIOPI_CALL(Scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
+    DIOPI_CALL(scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
     return diopiSuccess;
 }
 
@@ -115,7 +115,7 @@ diopiError_t diopiScatterScalar(diopiContextHandle_t ctx, diopiTensorHandle_t ou
 
     DIOPI_CHECK(strcmp(reduce, "") == 0 || strcmp(reduce, "add") == 0, "The reduction operation of multiply is not supported by cnnl");
     DIOPI_CHECK(compareVectors(srcTensor.shape(), indexTensor.shape()), "Currently, the shape of src tensor and index tensor must be the same");
-    DIOPI_CALL(Scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
+    DIOPI_CALL(scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
     return diopiSuccess;
 }
 
@@ -131,7 +131,7 @@ diopiError_t diopiScatterInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t
 
     DIOPI_CHECK(strcmp(reduce, "") == 0 || strcmp(reduce, "add") == 0, "The reduction operation of multiply is not supported by cnnl");
     DIOPI_CHECK(compareVectors(srcTensor.shape(), indexTensor.shape()), "Currently, the shape of src tensor and index tensor must be the same");
-    DIOPI_CALL(Scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
+    DIOPI_CALL(scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
     return diopiSuccess;
 }
 

--- a/DIOPI-IMPL/camb/functions/scatter.cpp
+++ b/DIOPI-IMPL/camb/functions/scatter.cpp
@@ -1,0 +1,140 @@
+/**
+ * @file
+ * @author DeepLink
+ * @copyright  (c) 2023, DeepLink.
+ */
+
+#include <diopi/functions.h>
+
+#include <vector>
+
+#include "../cnnl_helper.hpp"
+#include "../common/common.hpp"
+
+namespace impl {
+namespace camb {
+extern "C" {
+
+bool compareVectors(const std::vector<int64_t>& vec1, const std::vector<int64_t>& vec2) {
+    if (vec1.size() != vec2.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < vec1.size(); ++i) {
+        if (vec1[i] != vec2[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+diopiError_t Scatter(diopiContextHandle_t ctx, DiopiTensor outTensor, DiopiTensor inputTensor, int64_t dim, DiopiTensor srcTensor, DiopiTensor indexTensor,
+                     const char* reduce) {
+    cnnlHandle_t handle = cnnlHandlePool.get(ctx);
+
+    DiopiTensor outTensorTmp = outTensor;
+    DiopiTensor inputTensorTmp = inputTensor;
+    DiopiTensor srcTensorTmp = srcTensor;
+
+    std::vector<DiopiTensor*> tensor{&indexTensor};
+    DIOPI_CALL(autoCastTensorType(ctx, tensor, {diopi_dtype_int32, diopi_dtype_int64}));
+
+    cnnlScatterMode_t mode = CNNL_SCATTER;
+    if (strcmp(reduce, "") == 0) {
+        mode = CNNL_SCATTER;
+        std::vector<DiopiTensor*> tensors{&outTensorTmp, &inputTensorTmp, &srcTensorTmp};
+        std::set<diopiDtype_t> supportedDtypes{
+            diopi_dtype_bool, diopi_dtype_int8, diopi_dtype_int16, diopi_dtype_int32, diopi_dtype_float16, diopi_dtype_float32};
+        DIOPI_CALL(autoCastTensorType(ctx, tensors, supportedDtypes));
+
+    } else if (strcmp(reduce, "add") == 0) {
+        mode = CNNL_SCATTER_ADD;
+        std::vector<DiopiTensor*> tensors{&outTensorTmp, &inputTensorTmp, &srcTensorTmp};
+        std::set<diopiDtype_t> supportedDtypes{diopi_dtype_int32, diopi_dtype_float16, diopi_dtype_float32};
+        DIOPI_CALL(autoCastTensorType(ctx, tensors, supportedDtypes));
+    }
+
+    CnnlTensorDesc outDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc inputDesc(inputTensorTmp, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc srcDesc(srcTensorTmp, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc indexDesc(indexTensor, CNNL_LAYOUT_ARRAY);
+
+    DIOPI_CALLCNNL(cnnlScatter(handle,
+                               dim,
+                               inputDesc.get(),
+                               inputTensorTmp.data(),
+                               indexDesc.get(),
+                               indexTensor.data(),
+                               srcDesc.get(),
+                               srcTensorTmp.data(),
+                               outDesc.get(),
+                               outTensorTmp.data(),
+                               mode));
+    if (outTensor.dtype() != outTensorTmp.dtype()) {
+        DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
+    }
+    return diopiSuccess;
+}
+
+diopiError_t diopiScatter(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, int64_t dim, diopiConstTensorHandle_t src,
+                          diopiConstTensorHandle_t index, const char* reduce) {
+    DiopiTensor outTensor(out);
+    DiopiTensor inputTensor(input);
+    DiopiTensor srcTensor(src);
+    DiopiTensor indexTensor(index);
+
+    DIOPI_CHECK(strcmp(reduce, "") == 0 || strcmp(reduce, "add") == 0, "The reduction operation of multiply is not supported by cnnl");
+    DIOPI_CHECK(compareVectors(srcTensor.shape(), indexTensor.shape()), "Currently, the shape of src tensor and index tensor must be the same");
+    DIOPI_CALL(Scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
+    return diopiSuccess;
+}
+
+diopiError_t diopiScatterInp(diopiContextHandle_t ctx, diopiTensorHandle_t input, int64_t dim, diopiConstTensorHandle_t src, diopiConstTensorHandle_t index,
+                             const char* reduce) {
+    DiopiTensor outTensor(input);
+    DiopiTensor inputTensor(input);
+    DiopiTensor srcTensor(src);
+    DiopiTensor indexTensor(index);
+
+    DIOPI_CHECK(strcmp(reduce, "") == 0 || strcmp(reduce, "add") == 0, "The reduction operation of multiply is not supported by cnnl");
+    DIOPI_CHECK(compareVectors(srcTensor.shape(), indexTensor.shape()), "Currently, the shape of src tensor and index tensor must be the same");
+    DIOPI_CALL(Scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
+    return diopiSuccess;
+}
+
+diopiError_t diopiScatterScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, int64_t dim, const diopiScalar_t* value,
+                                diopiConstTensorHandle_t index, const char* reduce) {
+    DiopiTensor outTensor(out);
+    DiopiTensor inputTensor(input);
+    DiopiTensor indexTensor(index);
+    DiopiTensor srcTensor(index);
+    DIOPI_CALL(dataTypeCast(ctx, srcTensor, inputTensor.dtype()));
+    diopiTensorHandle_t src = srcTensor.tensorHandle();
+    DIOPI_CALL(diopiFill(ctx, src, value));
+
+    DIOPI_CHECK(strcmp(reduce, "") == 0 || strcmp(reduce, "add") == 0, "The reduction operation of multiply is not supported by cnnl");
+    DIOPI_CHECK(compareVectors(srcTensor.shape(), indexTensor.shape()), "Currently, the shape of src tensor and index tensor must be the same");
+    DIOPI_CALL(Scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
+    return diopiSuccess;
+}
+
+diopiError_t diopiScatterInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t input, int64_t dim, const diopiScalar_t* value, diopiConstTensorHandle_t index,
+                                   const char* reduce) {
+    DiopiTensor outTensor(input);
+    DiopiTensor inputTensor(input);
+    DiopiTensor indexTensor(index);
+    DiopiTensor srcTensor(index);
+    DIOPI_CALL(dataTypeCast(ctx, srcTensor, inputTensor.dtype()));
+    diopiTensorHandle_t src = srcTensor.tensorHandle();
+    DIOPI_CALL(diopiFill(ctx, src, value));
+
+    DIOPI_CHECK(strcmp(reduce, "") == 0 || strcmp(reduce, "add") == 0, "The reduction operation of multiply is not supported by cnnl");
+    DIOPI_CHECK(compareVectors(srcTensor.shape(), indexTensor.shape()), "Currently, the shape of src tensor and index tensor must be the same");
+    DIOPI_CALL(Scatter(ctx, outTensor, inputTensor, dim, srcTensor, indexTensor, reduce));
+    return diopiSuccess;
+}
+
+}  // extern "C"
+}  // namespace camb
+}  // namespace impl


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add the scatter op.

## Description
<!--- Describe your changes in detail. -->
Add the scatter op and modify the corresponding config file for it. When not performing a reduce operation, the accuracy comparison of scatter needs to be performed on the CPU. Currently, the shape of src tensor and index tensor must be the same.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

