### PR TITLE
 feature: add index_put op and optimize debug info

### DIFF
--- a/DIOPI-IMPL/camb/common/debug.hpp
+++ b/DIOPI-IMPL/camb/common/debug.hpp
@@ -38,7 +38,7 @@ void printDevDataInternal(diopiContextHandle_t ctx, void* data, int64_t len, int
     std::cout << "]" << std::endl;
 }
 
-inline void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor, std::string name="name") {
+inline void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor, std::string name = "name") {
     int64_t len = tensor.numel();
     void* dataIn = tensor.data();
     int64_t maxLen = 20;

--- a/DIOPI-IMPL/camb/common/debug.hpp
+++ b/DIOPI-IMPL/camb/common/debug.hpp
@@ -31,16 +31,28 @@ void printDevDataInternal(diopiContextHandle_t ctx, void* data, int64_t len, int
     std::cout << "data address:" << data << std::endl;
     cnrtMemcpyAsync(ptr.get(), data, bytes, getStream(ctx), cnrtMemcpyDevToHost);
     syncStreamInCtx(ctx);
+    std::cout << "[";
     for (int i = 0; i < len && i < maxLen; ++i) {
         std::cout << static_cast<CastT>(reinterpret_cast<RealT*>(ptr.get())[i]) << " ";
     }
-    std::cout << std::endl;
+    std::cout << "]" << std::endl;
 }
 
-inline void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor) {
+inline void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor, std::string name="name") {
     int64_t len = tensor.numel();
     void* dataIn = tensor.data();
-    int64_t maxLen = 10;
+    int64_t maxLen = 20;
+    int dim = tensor.dim();
+    std::cout << "DiopiTensor[" << name << "]: dim" << dim << ", dtype: " << DiopiDataType::dataTypeStr(tensor.dtype()) << ", shape: [";
+    for (size_t i = 0; i < dim; i++) {
+        std::cout << tensor.shape()[i] << ", ";
+    }
+    std::cout << "], stride: [";
+    for (size_t i = 0; i < dim; i++) {
+        std::cout << tensor.stride()[i] << ", ";
+    }
+    std::cout << "], is_contiguous: " << tensor.isContiguous();
+    std::cout << ", is_contiguous(channelsLast): " << tensor.isContiguous(MemoryFormat::ChannelsLast) << std::endl;
     switch (tensor.dtype()) {
         case diopi_dtype_bool:
             printDevDataInternal<bool, int32_t>(ctx, dataIn, len, maxLen);

--- a/DIOPI-IMPL/camb/device_configs.py
+++ b/DIOPI-IMPL/camb/device_configs.py
@@ -859,44 +859,20 @@ device_configs = {
         ),
     ),
 
-    'index_put_acc': dict(
-        name=['index_put'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32)],
-                },
-            ]
-        ),
-    ),
-
-    'index_put_acc_one_indices': dict(
-        name=['index_put'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32)],
-                },
-            ]
-        ),
-    ),
-
     'index_put': dict(
         name=['index_put'],
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32), Skip(Dtype.float16),
-                              Skip(Dtype.int64), Skip(Dtype.int32),
-                              Skip(Dtype.int8), Skip(Dtype.uint8), Skip(Dtype.bool)],
+                    "dtype": [Skip(Dtype.uint8),    # overflow issue 
+                              Skip(Dtype.bool)],    # not supported by camb kernel when accumulate is true
                 },
             ]
         ),
     ),
 
+    # when accumulate is True and dtype of indices is bool, can't get the correct result
     'index_put_acc_bool_indices': dict(
         name=['index_put'],
         tensor_para=dict(
@@ -906,18 +882,6 @@ device_configs = {
                     "dtype": [Skip(Dtype.float64), Skip(Dtype.float32), Skip(Dtype.float16),
                               Skip(Dtype.int64), Skip(Dtype.int32),
                               Skip(Dtype.int8), Skip(Dtype.uint8), Skip(Dtype.bool)],
-                },
-            ]
-        ),
-    ),
-
-    'index_put_one_indices': dict(
-        name=['index_put'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32)],
                 },
             ]
         ),

--- a/DIOPI-IMPL/camb/diopi_helper.hpp
+++ b/DIOPI-IMPL/camb/diopi_helper.hpp
@@ -107,6 +107,11 @@ public:
 class DiopiTensor final {
 public:
     DiopiTensor() = default;
+
+    // default shallow copy/assignment, it will not change the address of tensor_
+    DiopiTensor(const DiopiTensor&) = default; 
+    DiopiTensor& operator=(const DiopiTensor&) = default;
+
     explicit DiopiTensor(const diopiTensorHandle_t& tensor) : tensor_(tensor) {
         if (tensor_ != nullptr) {
             diopiSize_t diopiShape;

--- a/DIOPI-IMPL/camb/diopi_helper.hpp
+++ b/DIOPI-IMPL/camb/diopi_helper.hpp
@@ -109,7 +109,7 @@ public:
     DiopiTensor() = default;
 
     // default shallow copy/assignment, it will not change the address of tensor_
-    DiopiTensor(const DiopiTensor&) = default; 
+    DiopiTensor(const DiopiTensor&) = default;
     DiopiTensor& operator=(const DiopiTensor&) = default;
 
     explicit DiopiTensor(const diopiTensorHandle_t& tensor) : tensor_(tensor) {

--- a/DIOPI-IMPL/camb/functions/index_put.cpp
+++ b/DIOPI-IMPL/camb/functions/index_put.cpp
@@ -45,7 +45,8 @@ diopiError_t diopiIndexPut(diopiContextHandle_t ctx, diopiTensorHandle_t out, di
             DIOPI_CHECK(indiceTensor.dim() > 0, "zero-dimensional tensor cannot be concatenated");
             DIOPI_CHECK(indiceTensor.dtype() == diopi_dtype_int32 || indiceTensor.dtype() == diopi_dtype_bool || indiceTensor.dtype() == diopi_dtype_uint8,
                         "indiceTensor's dtype should be `int`, `bool` or `uint8`");
-            DIOPI_CHECK(!(accumulate && indiceTensor.dtype() == diopi_dtype_bool), "when accumulate is true, and indices dtype is bool, the result is not corrected in camb");
+            DIOPI_CHECK(!(accumulate && indiceTensor.dtype() == diopi_dtype_bool),
+                        "when accumulate is true, and indices dtype is bool, the result is not corrected in camb");
             savedIndicesTensors.emplace_back(indiceTensor);
             indicesPtrList.emplace_back(indiceTensor.data());
             savedIndicesDescs[i].set(indiceTensor, layout);

--- a/DIOPI-IMPL/camb/functions/index_put.cpp
+++ b/DIOPI-IMPL/camb/functions/index_put.cpp
@@ -1,0 +1,92 @@
+/**
+ * @file
+ * @author DeepLink
+ * @copyright  (c) 2023, DeepLink.
+ */
+
+#include <diopi/functions.h>
+
+#include "../cnnl_helper.hpp"
+#include "../common/common.hpp"
+
+namespace impl {
+namespace camb {
+
+extern "C" {
+
+diopiError_t diopiIndexPut(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t values,
+                           diopiConstTensorHandle_t* indices, int64_t indicesCounts, bool accumulate) {
+    cnnlHandle_t handle = cnnlHandlePool.get(ctx);
+    DiopiTensor inputTensor(input);
+    DiopiTensor valuesTensor(values);
+    DiopiTensor outputTensor(out);
+
+    DIOPI_CHECK(inputTensor.isContiguous(), "input tensor should be contiguous");
+    DIOPI_CHECK(valuesTensor.isContiguous(), "values tensor should be contiguous");
+    DIOPI_CHECK(outputTensor.isContiguous(), "output tensor should be contiguous");
+    DIOPI_CHECK(inputTensor.dtype() == valuesTensor.dtype(), "input and values must have same dtype");
+
+    cnnlTensorLayout_t layout = CNNL_LAYOUT_ARRAY;
+    CnnlTensorDesc inputDesc(inputTensor, layout);
+    CnnlTensorDesc valuesDesc(valuesTensor, layout);
+    CnnlTensorDesc outputDesc(outputTensor, layout);
+
+    // to preserve descriptor and tensor, make sure it's not destructed
+    std::vector<CnnlTensorDesc> savedIndicesDescs(indicesCounts);
+    std::vector<DiopiTensor> savedIndicesTensors;
+
+    std::vector<cnnlTensorDescriptor_t> indicesDescs;
+    std::vector<void*> indicesPtrList;
+
+    for (auto i = 0; i < indicesCounts; ++i) {
+        DiopiTensor indiceTensor(indices[i]);
+        if (indiceTensor.defined()) {
+            DIOPI_CHECK(indiceTensor.isContiguous(), "indice tensor should be contiguous");
+            DIOPI_CHECK(indiceTensor.dim() > 0, "zero-dimensional tensor cannot be concatenated");
+            DIOPI_CHECK(indiceTensor.dtype() == diopi_dtype_int32 || indiceTensor.dtype() == diopi_dtype_bool || indiceTensor.dtype() == diopi_dtype_uint8,
+                        "indiceTensor's dtype should be `int`, `bool` or `uint8`");
+            DIOPI_CHECK(!(accumulate && indiceTensor.dtype() == diopi_dtype_bool), "when accumulate is true, and indices dtype is bool, the result is not corrected in camb");
+            savedIndicesTensors.emplace_back(indiceTensor);
+            indicesPtrList.emplace_back(indiceTensor.data());
+            savedIndicesDescs[i].set(indiceTensor, layout);
+            indicesDescs.emplace_back(savedIndicesDescs[i].get());
+        } else {
+            indicesPtrList.emplace_back(nullptr);
+            indicesDescs.emplace_back(nullptr);
+        }
+    }
+
+    size_t workspaceSize = 0;
+    DIOPI_CALLCNNL(
+        cnnlGetIndexPutWorkspaceSize(handle, inputDesc.get(), indicesDescs.data(), indicesDescs.size(), valuesDesc.get(), accumulate, &workspaceSize));
+
+    void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
+
+    DIOPI_CALLCNNL(cnnlIndexPut(handle,
+                                inputDesc.get(),
+                                inputTensor.data(),
+                                indicesDescs.data(),
+                                indicesPtrList.data(),
+                                indicesDescs.size(),
+                                valuesDesc.get(),
+                                valuesTensor.data(),
+                                workspacePtr,
+                                workspaceSize,
+                                accumulate,
+                                true,
+                                outputDesc.get(),
+                                outputTensor.data()));
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiIndexPutInp(diopiContextHandle_t ctx, diopiTensorHandle_t input, diopiConstTensorHandle_t values, diopiConstTensorHandle_t* indices,
+                              int64_t indicesCounts, bool accumulate) {
+    DIOPI_CALL(diopiIndexPut(ctx, input, input, values, indices, indicesCounts, accumulate));
+    return diopiSuccess;
+}
+
+}  // extern "C"
+
+}  // namespace camb
+}  // namespace impl


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
feature: add index_put op and optimize debug info


## Description
update in index_put.cpp and debug.hpp

- overflow问题：When accumulate = true and the data type of input is int32, int16, int8 or uint8, the accumation result supports overflow on MLU500 series(excluding tp_520) and higher platforms; on the platforms earlier than MLU500 series, the overflow is not supported and undefined behaviour may occur if the overflow arises. 
- indices为bool dtype问题：当accumulate为True的时候计算错误
- input dtype为bool是不被kernel支持的


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

