### PR TITLE
[New Operator] add bceloss and bceloss_backward operators

### DIFF
--- a/DIOPI-IMPL/camb/device_configs.py
+++ b/DIOPI-IMPL/camb/device_configs.py
@@ -56,14 +56,8 @@ device_configs = {
 
     'binary_cross_entropy': dict(
         name=["binary_cross_entropy"],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float64), Skip(Dtype.float32)],
-                },
-            ],
-        ),
+        atol=1e-2,
+        rtol=1e-2,
     ),
 
     'binary_cross_entropy_with_logits': dict(

--- a/DIOPI-IMPL/camb/functions/bce_loss.cpp
+++ b/DIOPI-IMPL/camb/functions/bce_loss.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file
+ * @author DeepLink
+ * @copyright  (c) 2023, DeepLink.
+ */
+
+#include <diopi/functions.h>
+
+#include <cstring>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+#include "../cnnl_helper.hpp"
+#include "../common/common.hpp"
+
+namespace impl {
+namespace camb {
+
+extern "C" {
+/**
+ * @brief Measures the Binary Cross Entropy between the target and input probabilities.
+ * @param[in] ctx Context environment.
+ * @param input Tensor of arbitrary shape as unnormalized scores (often referred to as logits). type = [float32, float64].
+ * @param target Tensor of the same shape as input with values between 0 and 1. type = [float32, float64].
+ * @param weight a manual rescaling weight given to the loss of each batch element. If given, has to be a Tensor of size nbatch. type = [float32, float64].
+ * @param reduction Specifies the reduction to apply to the output
+ * @param[out] out the output tensor. type = [float32, float64].
+ */
+
+static diopiError_t convertBCEReduction(cnnlBceLossReduction_t *bceReduction, const diopiReduction_t reduction) {
+    switch (reduction) {
+        case ReductionNone:
+            *bceReduction = CNNL_BCE_LOSS_NONE;
+            break;
+        case ReductionMean:
+            *bceReduction = CNNL_BCE_LOSS_MEAN;
+            break;
+        case ReductionSum:
+            *bceReduction = CNNL_BCE_LOSS_SUM;
+            break;
+        default:
+            DIOPI_CHECK(false, "[diopiBCELoss] unexpected bce_loss reduciton mode");
+            return diopiErrorOccurred;
+    }
+    return diopiSuccess;
+}
+
+DIOPI_API diopiError_t diopiBCELoss(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t target,
+                                    diopiConstTensorHandle_t weight, diopiReduction_t reduction) {
+    cnnlHandle_t handle = cnnlHandlePool.get(ctx);
+
+    DiopiTensor inputTensor(input);
+    DiopiTensor targetTensor(target);
+    DiopiTensor weightTensor(weight);
+    DiopiTensor outTensor(out);
+
+    if (!weightTensor.defined()) {
+        weightTensor = ones(ctx, inputTensor.shape(), inputTensor.dtype());
+    }
+    DIOPI_CALL(broadcastHelper(ctx, weightTensor, inputTensor, &weightTensor));
+
+    std::vector<DiopiTensor *> tensorsVecPtr{&inputTensor, &targetTensor, &weightTensor, &outTensor};
+    std::set<diopiDtype_t> supportedDtypes{diopi_dtype_float32, diopi_dtype_float32};
+    DIOPI_CALL(autoCastTensorType(ctx, tensorsVecPtr, supportedDtypes));
+    inputTensor = *tensorsVecPtr[0];
+    targetTensor = *tensorsVecPtr[1];
+    weightTensor = *tensorsVecPtr[2];
+    DiopiTensor outCastedTensor = *tensorsVecPtr[3];
+
+    CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc targetDesc(targetTensor, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc weightDesc(weightTensor, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc outCastedDesc(outCastedTensor, CNNL_LAYOUT_ARRAY);
+
+    size_t workspaceSize = 0;
+    void *workspace = nullptr;
+    DIOPI_CALLCNNL(cnnlGetBceLossWorkspaceSize(handle, inputDesc.get(), weightDesc.get(), &workspaceSize));
+    if (workspaceSize > 0) {
+        workspace = requiresBuffer(ctx, workspaceSize).data();
+    }
+
+    cnnlBceLossReduction_t bceReduction;
+    convertBCEReduction(&bceReduction, reduction);
+
+    DIOPI_CALLCNNL(cnnlBceLoss(handle,
+                               inputDesc.get(),
+                               inputTensor.data(),
+                               targetDesc.get(),
+                               targetTensor.data(),
+                               weightDesc.get(),
+                               weightTensor.data(),
+                               bceReduction,
+                               workspace,
+                               workspaceSize,
+                               outCastedDesc.get(),
+                               outCastedTensor.data()));
+    DIOPI_CALL(dataTypeCast(ctx, outTensor, outCastedTensor));
+    return diopiSuccess;
+}
+
+DIOPI_API diopiError_t diopiBCELossBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gradInput, diopiConstTensorHandle_t gradOutput,
+                                            diopiConstTensorHandle_t input, diopiConstTensorHandle_t target, diopiConstTensorHandle_t weight,
+                                            diopiReduction_t reduction) {
+    cnnlHandle_t handle = cnnlHandlePool.get(ctx);
+
+    DiopiTensor inputTensor(input);
+    DiopiTensor targetTensor(target);
+    DiopiTensor weightTensor(weight);
+    DiopiTensor gradInputTensor(gradInput);
+    DiopiTensor gradOutputTensor(gradOutput);
+
+    if (!weightTensor.defined()) {
+        weightTensor = ones(ctx, targetTensor.shape(), targetTensor.dtype());
+    }
+    DIOPI_CALL(broadcastHelper(ctx, weightTensor, inputTensor, &weightTensor));
+
+    std::vector<DiopiTensor *> tensorsVecPtr{&inputTensor, &targetTensor, &weightTensor, &gradInputTensor, &gradOutputTensor};
+    std::set<diopiDtype_t> supportedDtype{diopi_dtype_float32, diopi_dtype_float64};
+    DIOPI_CALL(autoCastTensorType(ctx, tensorsVecPtr, supportedDtype));
+    inputTensor = *tensorsVecPtr[0];
+    targetTensor = *tensorsVecPtr[1];
+    weightTensor = *tensorsVecPtr[2];
+    DiopiTensor gradInputCastedTensor = *tensorsVecPtr[3];
+    gradOutputTensor = *tensorsVecPtr[4];
+
+    CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc targetDesc(targetTensor, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc weightDesc(weightTensor, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc gradInputDesc(gradInputCastedTensor, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc gradOutputDesc(gradOutputTensor, CNNL_LAYOUT_ARRAY);
+
+    size_t workspaceSize = 0;
+    void *workspace = nullptr;
+    DIOPI_CALLCNNL(cnnlGetBceLossBackwardWorkspaceSize(handle, targetDesc.get(), weightDesc.get(), &workspaceSize));
+    if (workspaceSize > 0) {
+        workspace = requiresBuffer(ctx, workspaceSize).data();
+    }
+
+    cnnlBceLossReduction_t bceReduction;
+    convertBCEReduction(&bceReduction, reduction);
+
+    DIOPI_CALLCNNL(cnnlBceLossBackward(handle,
+                                       gradOutputDesc.get(),
+                                       gradOutputTensor.data(),
+                                       inputDesc.get(),
+                                       inputTensor.data(),
+                                       targetDesc.get(),
+                                       targetTensor.data(),
+                                       weightDesc.get(),
+                                       weightTensor.data(),
+                                       bceReduction,
+                                       workspace,
+                                       workspaceSize,
+                                       gradInputDesc.get(),
+                                       gradInputCastedTensor.data()));
+    DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputCastedTensor));
+    return diopiSuccess;
+}
+
+}  // extern "C"
+}  // namespace camb
+}  // namespace impl


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[New Operator] add bceloss and bcelossbackward operators for cambricon.



## Description
<!--- Describe your changes in detail. -->
1. add diopiBCELoss and diopiBCELossBackward operators.
2. reset the precise parameters for bce case in device_configs.py.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

