### PR TITLE
fix contiguous in adaptor

### DIFF
--- a/DIOPI-ADAPTOR/codegen/op_template.py
+++ b/DIOPI-ADAPTOR/codegen/op_template.py
@@ -116,7 +116,7 @@ inline bool isContiguous(diopiSize_t size, diopiSize_t stride_diopi, diopiMemory
     auto shape = size.data;
     auto strides = stride_diopi.data;
     int64_t stride = 1;
-        
+
     if (format == diopiMemoryFormat_t::Contiguous) {
         for (int64_t i = dim - 1; i >= 0; i--) {
             const auto& shapeD = shape[i];
@@ -149,7 +149,7 @@ inline bool isContiguous(diopiSize_t size, diopiSize_t stride_diopi, diopiMemory
                 }
             }
             stride *= shape[i];
-        } 
+        }
     }
     else if (format == diopiMemoryFormat_t::ChannelsLast1d) {
         if (dim != 3) return false;
@@ -172,8 +172,8 @@ ${cast_strategy}
 
 diopiMemoryFormat_t getTargetMemoryFormat(int ndims, std::vector<diopiMemoryFormat_t> supportMemoryFormats) {
     switch (ndims) {
-        case 1:             
-        case 2: 
+        case 1:
+        case 2:
             for (auto i : supportMemoryFormats) {
                 if (i == diopiMemoryFormat_t::Contiguous) {
                     return i;
@@ -205,7 +205,7 @@ diopiMemoryFormat_t getTargetMemoryFormat(int ndims, std::vector<diopiMemoryForm
             break;
         }
         default: {
-            assert(false && "ndims not supported.");
+            return diopiMemoryFormat_t::Contiguous;
         }
     }
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
when the dims > 5,  the `getTargetMemoryFormat` in the adaptor will fail.



## Description
fix contiguous in the adaptor.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

