### PR TITLE
wx modify the normal and uniform op using MTGP32 generator on MLU300 …

### DIFF
--- a/impl/camb/functions/normal.cpp
+++ b/impl/camb/functions/normal.cpp
@@ -6,12 +6,24 @@
 
 #include <diopi/functions.h>
 
+#include <random>
+
 #include "../cnnl_helper.hpp"
 
 namespace impl {
 namespace camb {
 
-extern "C" diopiError_t diopiNormal(diopiContextHandle_t ctx, diopiTensorHandle_t out, double mean, double std) {
+extern "C" {
+
+static uint32_t getSeed() {
+    std::random_device rd;
+    std::mt19937 generator(rd());
+    std::uniform_int_distribution<uint32_t> distribution(0, std::numeric_limits<uint32_t>::max());
+    uint32_t seed = distribution(generator);
+    return seed;
+}
+
+diopiError_t diopiNormal(diopiContextHandle_t ctx, diopiTensorHandle_t out, double mean, double std) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
     DiopiTensor tensor(out);
@@ -22,31 +34,24 @@ extern "C" diopiError_t diopiNormal(diopiContextHandle_t ctx, diopiTensorHandle_
     cnnlDataType_t dtype;
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, tensor.dtype()));
     cnnlRandGenerator_t generator;
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&generator, CNNL_RAND_RNG_FAST));
+    // cnnlRandRngType_t rng_type is recommended to be set as CNNL_RAND_RNG_MTGP32 on MLU300 series and CNNL_RAND_RNG_FAST on MLU200 series.
+    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&generator, CNNL_RAND_RNG_MTGP32));
 
-    DIOPI_CALLCNNL(cnnlRandGenerateNormal(handle, generator, dtype, nullptr, tensor.numel(), mean, std, tensor.data()));
+    size_t stateSize = 0;
+    DIOPI_CALLCNNL(cnnlRandGetMTGP32StateSize(generator, &stateSize));
+    DiopiTensor state = requiresBuffer(ctx, stateSize);
 
+    uint32_t seed = getSeed();
+    DIOPI_CALLCNNL(cnnlRandMakeMTGP32KernelState(handle, state.data(), nullptr, nullptr, seed));
+    DIOPI_CALLCNNL(cnnlRandGenerateNormal(handle, generator, dtype, state.data(), tensor.numel(), mean, std, tensor.data()));
     DIOPI_CALLCNNL(cnnlRandDestroyGenerator(generator));
     return diopiSuccess;
 }
 
-extern "C" diopiError_t diopiNormalInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout, double mean, double std) {
-    cnnlHandle_t handle = cnnlHandlePool.get(ctx);
-
-    DiopiTensor tensor(inout);
-    if (!tensor.defined()) {
-        return diopiSuccess;
-    }
-
-    cnnlDataType_t dtype;
-    DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, tensor.dtype()));
-    cnnlRandGenerator_t generator;
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&generator, CNNL_RAND_RNG_FAST));
-
-    DIOPI_CALLCNNL(cnnlRandGenerateNormal(handle, generator, dtype, nullptr, tensor.numel(), mean, std, tensor.data()));
-
-    DIOPI_CALLCNNL(cnnlRandDestroyGenerator(generator));
+diopiError_t diopiNormalInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout, double mean, double std) {
+    DIOPI_CALL(diopiNormal(ctx, inout, mean, std));
     return diopiSuccess;
+}
 }
 
 }  // namespace camb

--- a/impl/camb/functions/uniform.cpp
+++ b/impl/camb/functions/uniform.cpp
@@ -6,27 +6,47 @@
 
 #include <diopi/functions.h>
 
+#include <random>
+
 #include "../cnnl_helper.hpp"
 
 namespace impl {
 namespace camb {
 
-extern "C" diopiError_t diopiUniformInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout, double from, double to, int64_t idx) {
+extern "C" {
+
+static uint32_t getSeed() {
+    std::random_device rd;
+    std::mt19937 generator(rd());
+    std::uniform_int_distribution<uint32_t> distribution(0, std::numeric_limits<uint32_t>::max());
+    uint32_t seed = distribution(generator);
+    return seed;
+}
+
+diopiError_t diopiUniformInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout, double from, double to, int64_t idx) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
     DiopiTensor tensor(inout);
     if (!tensor.defined()) {
         return diopiSuccess;
     }
+
     cnnlDataType_t dtype;
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, tensor.dtype()));
     cnnlRandGenerator_t generator;
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&generator, CNNL_RAND_RNG_FAST));
+    // cnnlRandRngType_t rng_type is recommended to be set as CNNL_RAND_RNG_MTGP32 on MLU300 series and CNNL_RAND_RNG_FAST on MLU200 series.
+    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&generator, CNNL_RAND_RNG_MTGP32));
 
-    DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, generator, dtype, nullptr, tensor.numel(), from, to, tensor.data()));
+    size_t stateSize = 0;
+    DIOPI_CALLCNNL(cnnlRandGetMTGP32StateSize(generator, &stateSize));
+    DiopiTensor state = requiresBuffer(ctx, stateSize);
 
+    uint32_t seed = getSeed();
+    DIOPI_CALLCNNL(cnnlRandMakeMTGP32KernelState(handle, state.data(), nullptr, nullptr, seed));
+    DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, generator, dtype, state.data(), tensor.numel(), from, to, tensor.data()));
     DIOPI_CALLCNNL(cnnlRandDestroyGenerator(generator));
     return diopiSuccess;
+}
 }
 
 }  // namespace camb


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Modify the normal and uniform op using MTGP32 generator on MLU300 series.

## Description
<!--- Describe your changes in detail. -->
Modify the normal and uniform op using MTGP32 generator on MLU300 series.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

