### PR TITLE
add three ascend ops

### DIFF
--- a/impl/ascend/CMakeLists.txt
+++ b/impl/ascend/CMakeLists.txt
@@ -40,7 +40,7 @@ if(EXISTS "${PROJECT_SOURCE_DIR}/convert_config.yaml")
     set(ADAPTOR_GEN_PATH "${CMAKE_SOURCE_DIR}/../adaptor/codegen")
     add_custom_target(adaptor_code_gen COMMAND python3 ${ADAPTOR_GEN_PATH}/gen.py
         --diopi_dir=${CMAKE_SOURCE_DIR}/../ --output_dir=${CMAKE_SOURCE_DIR}/../proto/include/diopi/
-        --config_device=torch)
+        --config_device=ascend)
     set(USE_ADAPTOR "true")
     add_dependencies(${DEVICEIMPL} adaptor_code_gen)
     add_definitions(-DTEST_USE_ADAPTOR)

--- a/impl/ascend/common/acloprunner.hpp
+++ b/impl/ascend/common/acloprunner.hpp
@@ -56,38 +56,7 @@ namespace ascend {
         std::abort();                                \
     }
 
-inline aclDataType getAclDataType(diopiConstTensorHandle_t th) {
-    diopiDtype_t type;
-    diopiGetTensorDtype(th, &type);
-    switch (type) {
-        case diopi_dtype_float16:
-            return ACL_FLOAT16;
-        case diopi_dtype_float32:
-            return ACL_FLOAT;
-        case diopi_dtype_float64:
-            return ACL_DOUBLE;
-        case diopi_dtype_int8:
-            return ACL_INT8;
-        case diopi_dtype_uint8:
-            return ACL_UINT8;
-        case diopi_dtype_int16:
-            return ACL_INT16;
-        case diopi_dtype_uint16:
-            return ACL_UINT16;
-        case diopi_dtype_int32:
-            return ACL_INT32;
-        case diopi_dtype_uint32:
-            return ACL_UINT32;
-        case diopi_dtype_int64:
-            return ACL_INT64;
-        case diopi_dtype_uint64:
-            return ACL_UINT64;
-        case diopi_dtype_bool:
-            return ACL_BOOL;
-    }
-    check_args(false, "acl not support dioptDtype_t:%d", type);
-    return ACL_DT_UNDEFINED;
-}
+aclDataType getAclDataType(diopiConstTensorHandle_t th);
 
 inline std::string dumpTensor(diopiConstTensorHandle_t th) {
     std::stringstream stream;
@@ -399,6 +368,7 @@ public:
                                           CompileType,
                                           nullptr,
                                           stream));
+        CALL_ACLRT(aclrtSynchronizeStream(stream));
         // check_args(errorcode == ACL_SUCCESS, dumpRunnerInfo().c_str());
         //   Get environment variables once when run is called for the first time
         static int PARROTS_DEBUG_ACLOPRUNNER = std::getenv("DIOPI_DEBUG_ACLOPRUNNER") == nullptr ? 0 : 1;
@@ -410,6 +380,10 @@ public:
     }
 };
 
+diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t* scalar, diopiTensorHandle_t* out);
+diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t* scalar, diopiTensorHandle_t* out, diopiDtype_t dtype);
+diopiError_t makeTensorFromSize(diopiContextHandle_t ctx, const diopiSize_t* size, diopiTensorHandle_t* out);
+diopiError_t makeTensorFromTensor(diopiContextHandle_t ctx, diopiTensorHandle_t* out, diopiTensorHandle_t input);
 }  // namespace ascend
 }  // namespace impl
 

--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -1,0 +1,90 @@
+#include "acloprunner.hpp"
+
+namespace impl {
+namespace ascend {
+diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t* scalar, diopiTensorHandle_t* out) {
+    int64_t sizeTmp[1] = {1};
+    diopiSize_t sSize(sizeTmp, 1);
+    float val = static_cast<float>(scalar->ival);
+    diopiRequireTensor(ctx, out, &sSize, nullptr, scalar->stype, diopi_device);
+    AclOpRunner<1, 1>("Fills").addInput(*out).setAttr<float>("value", val).addOutput(*out).run(ctx);
+    ;
+    return diopiSuccess;
+}
+
+diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t* scalar, diopiTensorHandle_t* out, diopiDtype_t dtype) {
+    int64_t sizeTmp[1] = {1};
+    diopiSize_t sSize(sizeTmp, 1);
+    float val = static_cast<float>(scalar->ival);
+    diopiRequireTensor(ctx, out, &sSize, nullptr, dtype, diopi_device);
+    AclOpRunner<1, 1>("Fills").addInput(*out).setAttr<float>("value", val).addOutput(*out).run(ctx);
+    ;
+    return diopiSuccess;
+}
+
+diopiError_t makeTensorFromSize(diopiContextHandle_t ctx, const diopiSize_t* size, diopiTensorHandle_t* out) {
+    int64_t len = size->getLen();
+    int64_t buffersize = len * aclDataTypeSize(ACL_INT32);
+    int64_t sizeTmp[1] = {len};
+    diopiSize_t sSize(sizeTmp, 1);
+    diopiRequireTensor(ctx, out, &sSize, nullptr, diopi_dtype_int32, diopi_device);
+    if (len > 0) {
+        void* ptr;
+        CALL_ACLRT(aclrtMallocHost(&ptr, buffersize));
+        for (int i = 0; i < len; i++) {
+            ((int32_t*)ptr)[i] = (int32_t)size->data[i];
+        }
+        diopiTensorCopyFromBuffer(ctx, const_cast<void*>(ptr), *out);
+    }
+    return diopiSuccess;
+}
+
+diopiError_t makeTensorFromTensor(diopiContextHandle_t ctx, diopiTensorHandle_t* out, diopiTensorHandle_t input) {
+    diopiSize_t shape, stride;
+    diopiDtype_t dtype;
+    diopiDevice_t dev;
+    diopiGetTensorShape(input, &shape);
+    diopiGetTensorStride(input, &stride);
+    diopiGetTensorDtype(input, &dtype);
+    diopiGetTensorDevice(input, &dev);
+
+    diopiRequireTensor(ctx, out, &shape, &stride, dtype, dev);
+
+    return diopiSuccess;
+}
+
+
+aclDataType getAclDataType(diopiConstTensorHandle_t th) {
+    diopiDtype_t type;
+    diopiGetTensorDtype(th, &type);
+    switch (type) {
+        case diopi_dtype_float16:
+            return ACL_FLOAT16;
+        case diopi_dtype_float32:
+            return ACL_FLOAT;
+        case diopi_dtype_float64:
+            return ACL_DOUBLE;
+        case diopi_dtype_int8:
+            return ACL_INT8;
+        case diopi_dtype_uint8:
+            return ACL_UINT8;
+        case diopi_dtype_int16:
+            return ACL_INT16;
+        case diopi_dtype_uint16:
+            return ACL_UINT16;
+        case diopi_dtype_int32:
+            return ACL_INT32;
+        case diopi_dtype_uint32:
+            return ACL_UINT32;
+        case diopi_dtype_int64:
+            return ACL_INT64;
+        case diopi_dtype_uint64:
+            return ACL_UINT64;
+        case diopi_dtype_bool:
+            return ACL_BOOL;
+    }
+    check_args(false, "acl not support dioptDtype_t:%d", type);
+    return ACL_DT_UNDEFINED;
+}
+}  // namespace ascend
+}  // namespace impl

--- a/impl/ascend/functions/adptive_ave_pool2.cpp
+++ b/impl/ascend/functions/adptive_ave_pool2.cpp
@@ -1,0 +1,37 @@
+#include <diopi/functions.h>
+
+#include <iostream>
+
+#include <memory>
+
+#include "../common/acloprunner.hpp"
+
+namespace impl {
+namespace ascend {
+
+
+extern "C" DIOPI_API diopiError_t diopiAdaptiveAvgPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input,
+                                                         diopiSize_t output_size) {
+    AclOpRunner<1, 1> runner("AdaptiveAvgPool2d");
+    runner.addInput(input);
+    runner.setAttr("output_size", std::vector<int32_t>{output_size.data[0], output_size.data[1]});
+    runner.addOutput(out);
+    runner.run(ctx);
+    return diopiSuccess;
+}
+
+
+extern "C" DIOPI_API diopiError_t diopiAdaptiveAvgPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                                                 diopiConstTensorHandle_t input) {
+    diopiSize_t shape;
+    diopiGetTensorShape(input, &shape);
+    AclOpRunner<1, 1> runner("AdaptiveAvgPool2dGrad");
+    runner.addInput(grad_output);
+    runner.setAttr("orig_input_shape", std::vector<int32_t>{shape.data[0], shape.data[1], shape.data[2], shape.data[3]});
+    runner.addOutput(grad_input);
+    runner.run(ctx);
+    return diopiSuccess;
+}
+
+}  // namespace ascend
+}  // namespace impl

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -1,0 +1,140 @@
+#include <diopi/functions.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "../common/acloprunner.hpp"
+
+namespace impl {
+namespace ascend {
+
+namespace {
+diopiError_t batch_norm_training_reduce(diopiContextHandle_t ctx, diopiTensorHandle_t sum, diopiTensorHandle_t square_sum, diopiConstTensorHandle_t input,
+                                        double eps) {
+    AclOpRunner<1, 2>("BNTrainingReduce").addInput(input).setAttr("epsilon", static_cast<float>(eps)).addOutput(sum, square_sum).run(ctx);
+    return diopiSuccess;
+}
+
+diopiError_t batch_norm_training_update(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t save_mean, diopiTensorHandle_t save_invstd,
+                                        diopiConstTensorHandle_t input, diopiTensorHandle_t sum, diopiTensorHandle_t square_sum,
+                                        diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiTensorHandle_t running_mean,
+                                        diopiTensorHandle_t running_var, double momentum, double eps) {
+    AclOpRunner<7, 5> runner("BNTrainingUpdate");
+    runner.addInput(input, sum, square_sum, weight, bias, running_mean, running_var);
+    runner.setAttr("epsilon", static_cast<float>(eps)).setAttr("factor", static_cast<float>(momentum));
+    runner.addOutput(out, running_mean, running_mean, save_mean, save_invstd);
+    runner.run(ctx);
+    return diopiSuccess;
+}
+
+diopiError_t batch_norm_infer(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
+                              diopiConstTensorHandle_t bias, diopiTensorHandle_t running_mean, diopiTensorHandle_t running_var, double eps) {
+    AclOpRunner<5, 1> runner("BNInfer");
+    runner.addInput(input, weight, bias, running_mean, running_var);
+    runner.setAttr("epsilon", static_cast<float>(eps));
+    runner.addOutput(out);
+    runner.run(ctx);
+    return diopiSuccess;
+}
+// Backward
+
+diopiError_t batch_norm_backward_training_reduce(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight,
+                                                 diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
+                                                 diopiConstTensorHandle_t weight, diopiConstTensorHandle_t save_mean, diopiConstTensorHandle_t save_invstd,
+                                                 double eps) {
+    AclOpRunner<7, 1> runner("BNTrainingReduceGrad");
+    runner.addInput(grad_output, input, grad_weight, grad_bias, weight, save_mean, save_invstd);
+    runner.setAttr("epsilon", static_cast<float>(eps));
+    runner.addOutput(grad_input);
+    runner.run(ctx);
+    return diopiSuccess;
+}
+
+diopiError_t batch_norm_backward_training_update(diopiContextHandle_t ctx, diopiTensorHandle_t grad_weight, diopiTensorHandle_t grad_bias,
+                                                 diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiConstTensorHandle_t save_mean,
+                                                 diopiConstTensorHandle_t save_invstd, double eps) {
+    AclOpRunner<4, 2> runner("BNTrainingUpdateGrad");
+    runner.addInput(grad_output, input, save_mean, save_invstd);
+    runner.setAttr("epsilon", static_cast<float>(eps));
+    runner.addOutput(grad_weight, grad_bias);
+    runner.run(ctx);
+    return diopiSuccess;
+}
+
+diopiError_t batch_norm_infer(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t weight,
+                              diopiConstTensorHandle_t running_var, double eps) {
+    AclOpRunner<3, 1> runner("BNInferGrad");
+    runner.addInput(grad_output, weight, running_var);
+    runner.setAttr("epsilon", static_cast<float>(eps));
+    runner.addOutput(grad_input);
+    runner.run(ctx);
+    return diopiSuccess;
+}
+
+}  // namespace
+
+/**
+ * @brief Applies Batch Normalization for each channel across a batch of data.
+ * @param[in] ctx Context environment.
+ * @param input input tensor. type = [float32, float16, float64].
+ * @param weight weight tensor. type = [float32, float16, float64].
+ * @param bias bias tensor. type = [float32, float16, float64].
+ * @param running_mean weighted average tensor. type = [float32, float16, float64].
+ * @param running_var weighted variance tensor. type = [float32, float16, float64].
+ * @param training check if in training mode.
+ * @param momentum Used to calculate the running mean and variance during runtime. type = [float32, float64]
+ * @param eps The value added to the denominator during batch normalization to ensure numerical stability. type = [float32, float64]
+ * @param[out] out normalized result. type = [float32, float16, float64].
+ * @param save_mean Mean tensor,the mean value for each feature channel of the input tensor. type = [float32, float16, float64].
+ * @param save_invstd Backup of inverse standard deviation computed during training. type = [float32, float16, float64].
+ */
+extern "C" DIOPI_API diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t save_mean,
+                                                 diopiTensorHandle_t save_invstd, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
+                                                 diopiConstTensorHandle_t bias, diopiTensorHandle_t running_mean, diopiTensorHandle_t running_var,
+                                                 bool training, double momentum, double eps) {
+    if (!training) {
+        CALL_ACLRT(batch_norm_infer(ctx, out, input, weight, bias, running_mean, running_var, eps));
+        return diopiSuccess;
+    }
+
+    diopiTensorHandle_t sum = nullptr, square_sum = nullptr;
+    makeTensorFromTensor(ctx, &sum, running_mean);
+    makeTensorFromTensor(ctx, &square_sum, running_mean);
+
+    CALL_ACLRT(batch_norm_training_reduce(ctx, sum, square_sum, input, eps));
+
+    CALL_ACLRT(batch_norm_training_update(ctx, out, save_mean, save_invstd, input, sum, square_sum, weight, bias, running_mean, running_var, momentum, eps));
+
+    return diopiSuccess;
+}
+
+/**
+ * @brief compute the backward pass of batch normalization
+ * @param[in] grad_output Gradient of normalized layer output, with the same shape as the forward pass output. type=[float32, float16, float64].
+ * @param[out] grad_input Gradient of the input data, with the same shape as the input data. type = [float32, float16, float64].
+ * @param grad_weight Gradient of the weight parameter, with the same shape as the weight parameter. type = [float32, float16, float64].
+ * @param grad_bias Gradient of the bias parameter, with the same shape as the bias parameter. type = [float32, float16, float64].
+ * @sa Other parameters refer to diopiBatchNorm().
+ */
+extern "C" DIOPI_API diopiError_t diopiBatchNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight,
+                                                         diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
+                                                         diopiConstTensorHandle_t weight, diopiConstTensorHandle_t running_mean,
+                                                         diopiConstTensorHandle_t running_var, diopiConstTensorHandle_t save_mean,
+                                                         diopiConstTensorHandle_t save_invstd, bool training, double eps) {
+    if (!training) {
+        CALL_ACLRT(batch_norm_infer(ctx, grad_input, grad_output, weight, running_var, eps));
+        return diopiSuccess;
+    }
+    
+    CALL_ACLRT(batch_norm_backward_training_update(ctx, grad_weight, grad_bias, grad_output, input, save_mean, save_invstd, eps));
+
+    CALL_ACLRT(batch_norm_backward_training_reduce(ctx, grad_input, grad_weight, grad_bias, grad_output, input, weight, save_mean, save_invstd, eps));
+
+    return diopiSuccess;
+}
+
+}  // namespace ascend
+}  // namespace impl

--- a/impl/ascend/functions/softmax.cpp
+++ b/impl/ascend/functions/softmax.cpp
@@ -1,0 +1,51 @@
+#include <diopi/functions.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "../common/acloprunner.hpp"
+
+namespace impl {
+namespace ascend {
+
+extern "C" DIOPI_API diopiError_t diopiSoftmax(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, int64_t dim) {
+    std::vector<int64_t> dim_list = {dim};
+    AclOpRunner<1, 1>("SoftmaxV2").addInput(input, ACL_FORMAT_ND).setAttr<int64_t>("axes", dim_list).addOutput(out, ACL_FORMAT_ND).run(ctx);
+    return diopiSuccess;
+}
+
+extern "C" DIOPI_API diopiError_t diopiSoftmaxBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                                       diopiConstTensorHandle_t output, int64_t dim) {
+    std::vector<int64_t> dim_list = {dim};
+    AclOpRunner<2, 1>("SoftmaxGrad")
+        .addInput(grad_output, ACL_FORMAT_ND)
+        .addInput(output, ACL_FORMAT_ND)
+        .setAttr<int64_t>("axes", dim_list)
+        .addOutput(grad_input, ACL_FORMAT_ND)
+        .run(ctx);
+    return diopiSuccess;
+}
+
+extern "C" DIOPI_API diopiError_t diopiLogSoftmax(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, int64_t dim) {
+    std::vector<int64_t> dim_list = {dim};
+    AclOpRunner<1, 1>("LogSoftmaxV2").addInput(input, ACL_FORMAT_ND).setAttr("axes", dim_list).addOutput(out, ACL_FORMAT_ND).run(ctx);
+    return diopiSuccess;
+}
+
+extern "C" DIOPI_API diopiError_t diopiLogSoftmaxBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                                          diopiConstTensorHandle_t output, int64_t dim) {
+    std::vector<int64_t> dim_list = {dim};
+    AclOpRunner<2, 1>("LogSoftmaxGrad")
+        .addInput(grad_output, ACL_FORMAT_ND)
+        .addInput(output, ACL_FORMAT_ND)
+        .setAttr("axes", dim_list)
+        .addOutput(grad_input, ACL_FORMAT_ND)
+        .run(ctx);
+    return diopiSuccess;
+}
+
+}  // namespace ascend
+}  // namespace impl


### PR DESCRIPTION


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
add some ops for resnet50 in ascend

## Description
<!--- Describe your changes in detail. -->
add  log_softmax, batch_norm, adaptive_avg_pool2d  for resnet in ascend


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

