### PR TITLE
yb/fix conv2d bug

### DIFF
--- a/impl/camb/functions/conv_2d.cpp
+++ b/impl/camb/functions/conv_2d.cpp
@@ -49,8 +49,14 @@ diopiError_t convForward(diopiContextHandle_t ctx, DiopiTensor input, DiopiTenso
     DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
     size_t workspaceSize;
-    DIOPI_CALLCNNL(cnnlGetConvolutionForwardWorkspaceSize(
-        handle, inputDesc.get(), weightDesc.get(), outputDesc.get(), biasDesc.get(), convDesc.get(), CNNL_CONVOLUTION_FWD_ALGO_DIRECT, &workspaceSize));
+    DIOPI_CALLCNNL(cnnlGetConvolutionForwardWorkspaceSize(handle,
+                                                          inputDesc.get(),
+                                                          weightDesc.get(),
+                                                          outputDesc.get(),
+                                                          bias.tensorHandle() ? biasDesc.get() : nullptr,
+                                                          convDesc.get(),
+                                                          CNNL_CONVOLUTION_FWD_ALGO_DIRECT,
+                                                          &workspaceSize));
 
     void *workspace = nullptr;
     if (0 != workspaceSize) {


### PR DESCRIPTION
## Motivation and Context
when bias is none, the tensor descriptor of bias has an error, which will result in the conv2d failing after updating the camb software stack to sdk1.13.


## Description
when bias is none, set the tensor descriptor nullptr.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

