### PR TITLE
add other

### DIFF
--- a/impl/CMakeLists.txt
+++ b/impl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.14)
 project(diopi_impl)
 
 option(TEST "Whether to compile DIOPI with runtime" OFF)

--- a/impl/camb/CMakeLists.txt
+++ b/impl/camb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.14)
 project(camb_impl)
 
 option(TEST "whether to test by using conformance test" OFF)

--- a/impl/camb/common/common.hpp
+++ b/impl/camb/common/common.hpp
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "../cnnl_helper.hpp"
-#include "debug.hpp"
 
 namespace impl {
 namespace camb {

--- a/impl/camb/common/debug.hpp
+++ b/impl/camb/common/debug.hpp
@@ -25,20 +25,20 @@ namespace camb {
 
 // print the data on dev
 template <typename RealT, typename CastT>
-void printDevDataInternal(diopiContextHandle_t ctx, void* data, int64_t len, int64_t maxLen) {
+void printDevDataInternal(diopiContextHandle_t ctx, void* data, int64_t len, int64_t maxLen, int64_t beginIdx) {
     int bytes = sizeof(RealT) * len;
     std::unique_ptr<char> ptr(new char[bytes]);
     std::cout << "data address:" << data << std::endl;
     cnrtMemcpyAsync(ptr.get(), data, bytes, getStream(ctx), cnrtMemcpyDevToHost);
     syncStreamInCtx(ctx);
     std::cout << "[";
-    for (int i = 0; i < len && i < maxLen; ++i) {
+    for (int i = beginIdx; i < len && i < maxLen; ++i) {
         std::cout << static_cast<CastT>(reinterpret_cast<RealT*>(ptr.get())[i]) << " ";
     }
     std::cout << "]" << std::endl;
 }
 
-inline void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor, std::string name = "name", int maxLen = 20) {
+inline void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor, std::string name = "name", int maxLen = 20, int beginIdx = 0) {
     if (!tensor.defined()) {
         std::cout << "Tensor " << name << " is not defined. Please check it before using `printDevData`." << std::endl;
         return;
@@ -58,40 +58,40 @@ inline void printDevData(diopiContextHandle_t ctx, DiopiTensor tensor, std::stri
     std::cout << ", is_contiguous(channelsLast): " << tensor.isContiguous(MemoryFormat::ChannelsLast) << std::endl;
     switch (tensor.dtype()) {
         case diopi_dtype_bool:
-            printDevDataInternal<bool, int32_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<bool, int32_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_uint8:
-            printDevDataInternal<uint8_t, int32_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<uint8_t, int32_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_int8:
-            printDevDataInternal<int8_t, int32_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<int8_t, int32_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_uint16:
-            printDevDataInternal<uint16_t, uint16_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<uint16_t, uint16_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_int16:
-            printDevDataInternal<int16_t, int16_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<int16_t, int16_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_uint32:
-            printDevDataInternal<uint32_t, uint32_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<uint32_t, uint32_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_int32:
-            printDevDataInternal<int32_t, int32_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<int32_t, int32_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_uint64:
-            printDevDataInternal<uint64_t, uint64_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<uint64_t, uint64_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_int64:
-            printDevDataInternal<int64_t, int64_t>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<int64_t, int64_t>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_float16:
-            printDevDataInternal<half_float::half, float>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<half_float::half, half_float::half>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_float32:
-            printDevDataInternal<float, float>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<float, float>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         case diopi_dtype_float64:
-            printDevDataInternal<double, double>(ctx, dataIn, len, maxLen);
+            printDevDataInternal<double, double>(ctx, dataIn, len, maxLen, beginIdx);
             break;
         default:
             std::cout << "unsupported dtype" << std::endl;

--- a/impl/camb/common/dtype_cast.cpp
+++ b/impl/camb/common/dtype_cast.cpp
@@ -62,11 +62,8 @@ static diopiError_t dataTypeCastTwice(diopiContextHandle_t ctx, DiopiTensor& des
         DIOPI_CALL(dataTypeCast(ctx, dest, mid));
     } else {
         // TODO(waiting for dispatch) : cast through cpu
-        setLastErrorString("Can not cast from %s to %s at %s:%d ",
-                           DiopiDataType::dataTypeStr(srcDtype).c_str(),
-                           DiopiDataType::dataTypeStr(destDtype).c_str(),
-                           __FILE__,
-                           __LINE__);
+        setLastErrorString(
+            "Can not cast from %s to %s at %s:%d ", DiopiDataType::dataTypeStr(srcDtype), DiopiDataType::dataTypeStr(destDtype), __FILE__, __LINE__);
         return diopiDtypeNotSupported;
     }
     return diopiSuccess;

--- a/impl/camb/diopi_helper.hpp
+++ b/impl/camb/diopi_helper.hpp
@@ -63,7 +63,7 @@ class DiopiDataType final {
 public:
     static bool isInteger(diopiDtype_t dtype) { return dtype < 8; }
     static bool isFloatPoint(diopiDtype_t dtype) { return dtype <= 10 && dtype >= 8 || dtype == 12 || dtype == 13; }
-    static std::string dataTypeStr(diopiDtype_t dtype) {
+    static const char* dataTypeStr(diopiDtype_t dtype) {
         switch (dtype) {
             case diopi_dtype_int8:
                 return "diopi_dtype_int8";

--- a/impl/camb/functions/fill.cpp
+++ b/impl/camb/functions/fill.cpp
@@ -100,7 +100,7 @@ diopiError_t diopiFill(diopiContextHandle_t ctx, diopiTensorHandle_t input, cons
             break;
         }
         default: {
-            DIOPI_CHECK(false, "the input tensor dtype %s is not allown", DiopiDataType::dataTypeStr(inputTensorTemp.dtype()).c_str());
+            DIOPI_CHECK(false, "the input tensor dtype %s is not allown", DiopiDataType::dataTypeStr(inputTensorTemp.dtype()));
         }
     }
 

--- a/impl/torch/CMakeLists.txt
+++ b/impl/torch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.14)
 project(torch_impl)
 
 option(HIP "Whether to use HIP when available" OFF)


### PR DESCRIPTION

## Motivation and Context
* cmake minimum version need to update.
* the return type of `dataTypeStr` is not suitable.

## Description
* modify cmake_minimum_required to 3.14.
* modify return type of `dataTypeStr` to `const char *`
* modify printDevData to support printing data in the range.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

