### PR TITLE
yb/add op time recording

### DIFF
--- a/adaptor/codegen/op_template.py
+++ b/adaptor/codegen/op_template.py
@@ -398,7 +398,7 @@ ${adaptors}
 """)
 
     adaptor_template = CodeTemplate("""\
-static diopiError_t diopi${op_name}(${attrs}) {
+inline diopiError_t diopi${op_name}(${attrs}) {
     TimeElapsed adaptorTimeElapsed("${op_name}_adaptor");
     ${new_input}
     ${cast_input}


### PR DESCRIPTION
## Motivation and Context
record the time elapsed by adaptor func and diopi func

## Description
export DIOPI_ENABLE_TIMING to any value to enable recording the time elapsed by diopi func and adaptor func. 
and the result will be written in the op_time.dat in the current directory.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

