### PR TITLE
delete op_dat and modify timiing

### DIFF
--- a/adaptor/codegen/op_template.py
+++ b/adaptor/codegen/op_template.py
@@ -20,22 +20,30 @@ class OpTemplate(object):
 #include <chrono>
 #include <fstream>
 #include <ostream>
-#include <stdlib.h>
+#include <cstdlib>
+#include <cstring>
 
 namespace diopiadaptor {
 
-class TimeElapsedRecord : public std::ofstream {
+class TimeElapsedRecord {
 public:
-    TimeElapsedRecord(const char* fileName):std::ofstream(fileName, std::ios::out | std::ios::trunc), enableTiming_(false) {
-        if (getenv("DIOPI_ENABLE_TIMING")){
+    TimeElapsedRecord(const char* fileName) : enableTiming_(false) {
+        const char* enableEnvVar = getenv("DIOPI_ENABLE_TIMING");
+        if (enableEnvVar && strcmp(enableEnvVar, "OFF") && strcmp(enableEnvVar, "0")){
             enableTiming_ = true;
+            stream_ = std::move(std::ofstream(fileName, std::ios::out | std::ios::trunc));
         }
     }
-    bool isEnableTiming(){
+    bool isEnableTiming() {
         return enableTiming_;
     }
+    std::ofstream& getOStream(){
+        return stream_;
+    }
+
 private:
     bool enableTiming_;
+    std::ofstream stream_;
 };
 
 
@@ -51,7 +59,7 @@ public:
             auto end = std::chrono::steady_clock::now();
             std::chrono::duration<double, std::milli> elapsed = end - start_;  // ms
             double elapsedTime = elapsed.count();
-            timeElapsedRecord_ << opName_ << ": " << elapsedTime << "ms" << std::endl;
+            timeElapsedRecord_.getOStream() << opName_ << ": " << elapsedTime << "ms" << std::endl;
         }
     }
 private:


### PR DESCRIPTION

## Motivation and Context
* delete the op_time.dat
*  the op_time.dat is created once the program run, that is not necessary except that the env variable DIOPI_ENABLE_TIMING is set


## Description



## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

