### PR TITLE
wx modify the defined and reshape interfaces to align with the semantics of PyTorch

### DIFF
--- a/impl/camb/diopi_helper.hpp
+++ b/impl/camb/diopi_helper.hpp
@@ -373,10 +373,7 @@ public:
         return *this;
     }
 
-    bool defined() const {
-        if (tensor_ == nullptr) return false;
-        return this->numel() != 0;
-    }
+    bool defined() const { return tensor_ != nullptr; }
 
     DiopiTensor& view(const std::vector<int64_t> shape) {
         // must be contiguous

--- a/impl/camb/diopi_helper.hpp
+++ b/impl/camb/diopi_helper.hpp
@@ -378,7 +378,7 @@ public:
         return this->numel() != 0;
     }
 
-    DiopiTensor& reshape(const std::vector<int64_t> shape) {
+    DiopiTensor& view(const std::vector<int64_t> shape) {
         // must be contiguous
         std::vector<int64_t> stride(shape.size());
         this->shape_ = shape;

--- a/impl/camb/functions/batch_norm.cpp
+++ b/impl/camb/functions/batch_norm.cpp
@@ -52,12 +52,12 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     if (3 == dim) {
         inputTr.unsqueeze(3);
-        outputTr.reshape(inputTr.shape());
+        outputTr.view(inputTr.shape());
     }
     if (2 == dim) {
         inputTr.unsqueeze(2);
         inputTr.unsqueeze(3);
-        outputTr.reshape(inputTr.shape());
+        outputTr.view(inputTr.shape());
     }
 
     std::vector<DiopiTensor*> pTensors{&inputTr, &weightTr, &biasTr};
@@ -170,14 +170,14 @@ diopiError_t diopiBatchNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_
     if (3 == dim) {
         inputTr.unsqueeze(3);
         gradOutputTr.unsqueeze(3);
-        gradInputTr.reshape(inputTr.shape());
+        gradInputTr.view(inputTr.shape());
     }
     if (2 == dim) {
         inputTr.unsqueeze(2);
         inputTr.unsqueeze(3);
         gradOutputTr.unsqueeze(2);
         gradOutputTr.unsqueeze(3);
-        gradInputTr.reshape(inputTr.shape());
+        gradInputTr.view(inputTr.shape());
     }
 
     std::vector<DiopiTensor*> pTensors{&gradOutputTr, &inputTr, &weightTr};

--- a/impl/camb/functions/cdist.cpp
+++ b/impl/camb/functions/cdist.cpp
@@ -101,16 +101,16 @@ diopiError_t diopiCdist(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
     std::vector<int64_t> input1ShapeCnnl{expandBatchProduct, r1, c1};
     DiopiTensor input1TensorExpand = requiresTensor(ctx, input1TensorExpandSize, input1Tensor.dtype());
     DIOPI_CALL(expand(ctx, input1Tensor, input1TensorExpand));
-    input1TensorExpand.reshape(input1ShapeCnnl);
+    input1TensorExpand.view(input1ShapeCnnl);
 
     std::vector<int64_t> input2ShapeCnnl{expandBatchProduct, r2, c2};
     DiopiTensor input2TensorExpand = requiresTensor(ctx, input2TensorExpandSize, input2Tensor.dtype());
     DIOPI_CALL(expand(ctx, input2Tensor, input2TensorExpand));
-    input2TensorExpand.reshape(input2ShapeCnnl);
+    input2TensorExpand.view(input2ShapeCnnl);
 
     std::vector<int64_t> outputShape = outTensor.shape();
     std::vector<int64_t> outputShapeCnnl{expandBatchProduct, r1, r2};
-    outTensorTmp.reshape(outputShapeCnnl);
+    outTensorTmp.view(outputShapeCnnl);
 
     CnnlTensorDesc outDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc input1Desc(input1TensorExpand, CNNL_LAYOUT_ARRAY);
@@ -118,7 +118,7 @@ diopiError_t diopiCdist(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
 
     DIOPI_CALLCNNL(cnnlCdistForward(
         handle, input1Desc.get(), input1TensorExpand.data(), input2Desc.get(), input2TensorExpand.data(), p, outDesc.get(), outTensorTmp.data()));
-    outTensorTmp.reshape(outputShape);
+    outTensorTmp.view(outputShape);
     if (outTensor.dtype() != outTensorTmp.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     }
@@ -177,21 +177,21 @@ diopiError_t diopiCdistBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gr
     std::vector<int64_t> input1ShapeCnnl{expandBatchProduct, r1, c1};
     DiopiTensor input1TensorExpand = requiresTensor(ctx, input1TensorExpandSize, input1Tensor.dtype());
     DIOPI_CALL(expand(ctx, input1Tensor, input1TensorExpand));
-    input1TensorExpand.reshape(input1ShapeCnnl);
+    input1TensorExpand.view(input1ShapeCnnl);
 
     std::vector<int64_t> input2ShapeCnnl{expandBatchProduct, r2, c2};
     DiopiTensor input2TensorExpand = requiresTensor(ctx, input2TensorExpandSize, input2Tensor.dtype());
     DIOPI_CALL(expand(ctx, input2Tensor, input2TensorExpand));
-    input2TensorExpand.reshape(input2ShapeCnnl);
+    input2TensorExpand.view(input2ShapeCnnl);
 
     std::vector<int64_t> gradInputShapeCnnl{expandBatchProduct, r1, c1};
-    gradInputTensorTmp.reshape(gradInputShapeCnnl);
+    gradInputTensorTmp.view(gradInputShapeCnnl);
 
     std::vector<int64_t> gradOutputShapeCnnl{expandBatchProduct, r1, r2};
-    gradOutputTensor.reshape(gradOutputShapeCnnl);
+    gradOutputTensor.view(gradOutputShapeCnnl);
 
     std::vector<int64_t> cdistShapeCnnl{expandBatchProduct, r1, r2};
-    cdistTensor.reshape(cdistShapeCnnl);
+    cdistTensor.view(cdistShapeCnnl);
 
     CnnlTensorDesc gradInputDesc(gradInputTensorTmp, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc gradOutputDesc(gradOutputTensor, CNNL_LAYOUT_ARRAY);

--- a/impl/camb/functions/im2col.cpp
+++ b/impl/camb/functions/im2col.cpp
@@ -150,7 +150,7 @@ extern "C" diopiError_t diopiIm2Col(diopiContextHandle_t ctx, diopiTensorHandle_
     int64_t nOutputPlane = nInputPlane * kernelWidth * kernelHeight;
     int64_t outputLength = outputHeight * outputWidth;
 
-    outTr.reshape({batchSize, outputLength, nOutputPlane});
+    outTr.view({batchSize, outputLength, nOutputPlane});
     DiopiTensor outputTr;
     outputTr = requiresTensor(ctx, outTr.shape(), outTr.dtype());
     DIOPI_CALL(im2colOutInternal(ctx, outputTr, inputTr, kernelVec, dilationVec, paddingVec, strideVec));

--- a/impl/camb/functions/loss.cpp
+++ b/impl/camb/functions/loss.cpp
@@ -62,7 +62,7 @@ diopiError_t diopiNLLLoss(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
         for (int i = 2; i < inputTensor.dim(); ++i) {
             inputLastSize *= inputTensor.shape()[i];
         }
-        inputTensor.reshape({inputTensor.shape()[0], inputTensor.shape()[1], 1, inputLastSize});
+        inputTensor.view({inputTensor.shape()[0], inputTensor.shape()[1], 1, inputLastSize});
 
         inputContiguous = inputTensor.contiguous(ctx, MemoryFormat::ChannelsLast);
         DIOPI_CALL(cnnlTranspose(ctx, handle, inputTensor, inputContiguous, CNNL_LAYOUT_NCHW, CNNL_LAYOUT_NHWC));
@@ -181,7 +181,7 @@ diopiError_t diopiNLLLossBackward(diopiContextHandle_t ctx, diopiTensorHandle_t 
         for (int i = 2; i < inputTensor.dim(); ++i) {
             inputLastSize *= inputTensor.shape()[i];
         }
-        inputTensor.reshape({inputTensor.shape()[0], inputTensor.shape()[1], 1, inputLastSize});
+        inputTensor.view({inputTensor.shape()[0], inputTensor.shape()[1], 1, inputLastSize});
 
         inputContiguous = inputTensor.contiguous(ctx, MemoryFormat::ChannelsLast);
         DIOPI_CALL(cnnlTranspose(ctx, handle, inputTensor, inputContiguous, CNNL_LAYOUT_NCHW, CNNL_LAYOUT_NHWC));
@@ -239,8 +239,8 @@ diopiError_t diopiNLLLossBackward(diopiContextHandle_t ctx, diopiTensorHandle_t 
                                        gradInputRealTensor.data()));
     if (dim > 2) {
         // NHWC -> NCHW and dealing with data type
-        gradInputRealTensor.reshape(inputContiguous.shape());
-        gradInputTensor.reshape(inputContiguous.shape());
+        gradInputRealTensor.view(inputContiguous.shape());
+        gradInputTensor.view(inputContiguous.shape());
 
         DiopiTensor gradInputTmpTensor = gradInputTensor;
         if (gradInputTensor.dtype() != gradInputRealTensor.dtype()) {

--- a/impl/camb/functions/matmul.cpp
+++ b/impl/camb/functions/matmul.cpp
@@ -162,11 +162,11 @@ static diopiError_t matMulMat(diopiContextHandle_t ctx, DiopiTensor out, DiopiTe
 
 static diopiError_t matMulVector(diopiContextHandle_t ctx, DiopiTensor outTensor, DiopiTensor inputTensor, DiopiTensor vectorTensor) {
     if (inputTensor.shape()[1] != vectorTensor.shape()[0]) {
-        vectorTensor.reshape({1, vectorTensor.shape()[0]});
-        outTensor.reshape({vectorTensor.shape()[0], 1});
+        vectorTensor.view({1, vectorTensor.shape()[0]});
+        outTensor.view({vectorTensor.shape()[0], 1});
     } else {
-        vectorTensor.reshape({vectorTensor.shape()[0], 1});
-        outTensor.reshape({inputTensor.shape()[0], 1});
+        vectorTensor.view({vectorTensor.shape()[0], 1});
+        outTensor.view({inputTensor.shape()[0], 1});
     }
 
     DIOPI_CALL(matMulMat(ctx, outTensor, inputTensor, vectorTensor));
@@ -286,7 +286,7 @@ static diopiError_t tensorMatmulTensor(diopiContextHandle_t ctx, DiopiTensor out
             std::vector<int64_t> tempShape(2);
             tempShape[0] = otherTensor.shape()[0];
             tempShape[1] = 1;
-            otherTensor.reshape(tempShape);
+            otherTensor.view(tempShape);
         } else {
             outputSize.push_back(otherTensor.shape()[1]);
         }
@@ -294,9 +294,9 @@ static diopiError_t tensorMatmulTensor(diopiContextHandle_t ctx, DiopiTensor out
         std::vector<int64_t> shape(2);
         shape[1] = inputTensor.shape()[inputTensor.dim() - 1];
         shape[0] = inputTensor.numel() / shape[1];
-        inputTensor.reshape(shape);
+        inputTensor.view(shape);
         shape[1] = otherTensor.shape()[1];
-        outTensor.reshape(shape);
+        outTensor.view(shape);
         DIOPI_CALL(matMulMat(ctx, outTensor, inputTensor, otherTensor));
         return diopiSuccess;
     } else if ((inputTensor.dim() == 1 || inputTensor.dim() == 2) && otherTensor.dim() >= 3) {
@@ -305,7 +305,7 @@ static diopiError_t tensorMatmulTensor(diopiContextHandle_t ctx, DiopiTensor out
         int64_t m = inputTensor.shape()[inputTensor.dim() - 1];
         int64_t p = otherTensor.shape()[otherTensor.dim() - 1];
         if (inputDim == 1) {
-            inputTensor.reshape({n, m});
+            inputTensor.view({n, m});
         }
 
         std::vector<int64_t> otherShape(otherTensor.shape());
@@ -358,8 +358,8 @@ static diopiError_t tensorMatmulTensor(diopiContextHandle_t ctx, DiopiTensor out
         DiopiTensor otherExpand = requiresTensor(ctx, tensor2ExpandSize, otherTensor.dtype());
         broadcast(ctx, inputExpand, inputTensor);
         broadcast(ctx, otherExpand, otherTensor);
-        inputExpand.reshape(tensor1BmmView);
-        otherExpand.reshape(tensor2BmmView);
+        inputExpand.view(tensor1BmmView);
+        otherExpand.view(tensor2BmmView);
 
         std::vector<int64_t> outputShape({expandBatchProduct});
         if (inputTensor.dim() > 1) {
@@ -368,7 +368,7 @@ static diopiError_t tensorMatmulTensor(diopiContextHandle_t ctx, DiopiTensor out
         if (otherTensor.dim() > 1) {
             outputShape.push_back(p);
         }
-        outTensor.reshape(outputShape);
+        outTensor.view(outputShape);
         DIOPI_CALL(batchMatmul(ctx, outTensor, inputExpand, otherExpand));
         return diopiSuccess;
     }

--- a/impl/camb/functions/slice.cpp
+++ b/impl/camb/functions/slice.cpp
@@ -122,7 +122,7 @@ diopiError_t diopiSelect(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     }
     std::vector<int64_t> shape(outTensor.shape());
     shape.insert(shape.begin() + dim, 1);
-    outTensor.reshape(shape);
+    outTensor.view(shape);
 
     CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc indexDesc(indexTensor, CNNL_LAYOUT_ARRAY);
@@ -154,7 +154,7 @@ diopiError_t diopiSelectBackward(diopiContextHandle_t ctx, diopiTensorHandle_t g
     DiopiTensor gradTensor(gradOutput);
     std::vector<int64_t> shape(gradTensor.shape());
     shape.insert(shape.begin() + dim, 1);
-    gradTensor.reshape(shape);
+    gradTensor.view(shape);
 
     if (gradInputTensor.dtype() == diopi_dtype_int64) {
         DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, diopi_dtype_int32));

--- a/impl/camb/functions/unique.cpp
+++ b/impl/camb/functions/unique.cpp
@@ -100,9 +100,9 @@ diopiError_t diopiUnique(diopiContextHandle_t ctx, diopiTensorHandle_t *out, dio
     }
 
     DiopiTensor slicedOutputTensor = requiresTensor(ctx, trueOutShape, outputTensor.dtype());
-    slicedOutputTensor.reshape({slicedOutputTensor.numel()});
+    slicedOutputTensor.view({slicedOutputTensor.numel()});
     CnnlTensorDesc slicedOutputDesc(slicedOutputTensor, CNNL_LAYOUT_ARRAY);
-    outputTensor.reshape({outputTensor.numel()});
+    outputTensor.view({outputTensor.numel()});
     CnnlTensorDesc newOutputDesc(outputTensor, CNNL_LAYOUT_ARRAY);
 
     int begin[] = {0};


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To align with the semantics of PyTorch functions. 
The original reshape() --> view()
The original defined() --> delete the judgment of whether the number of tensor elements is 0

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

