### PR TITLE
zzf/fix bug of linear backward

### DIFF
--- a/impl/camb/functions/linear.cpp
+++ b/impl/camb/functions/linear.cpp
@@ -162,13 +162,18 @@ diopiError_t diopiLinearBackward(diopiContextHandle_t ctx, diopiTensorHandle_t g
     }
     DiopiTensor biasTensor((diopiTensorHandle_t) nullptr);
 
-    DIOPI_CALL(matmul(ctx, gradOutputTensor, inputTensor, biasTensor, gradWeightTemp, true, false));
-    if (gradWeightTemp.dtype() != gradWeightTensor.dtype()) {
-        DIOPI_CALL(dataTypeCast(ctx, gradWeightTensor, gradWeightTemp));
+    if (gradWeight != nullptr) {
+        DIOPI_CALL(matmul(ctx, gradOutputTensor, inputTensor, biasTensor, gradWeightTemp, true, false));
+        if (gradWeightTemp.dtype() != gradWeightTensor.dtype()) {
+            DIOPI_CALL(dataTypeCast(ctx, gradWeightTensor, gradWeightTemp));
+        }
     }
-    DIOPI_CALL(matmul(ctx, gradOutputTensor, weightTensor, biasTensor, gradInputTemp, false, false));
-    if (gradInputTemp.dtype() != gradInputTensor.dtype()) {
-        DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputTemp));
+
+    if (gradInput != nullptr) {
+        DIOPI_CALL(matmul(ctx, gradOutputTensor, weightTensor, biasTensor, gradInputTemp, false, false));
+        if (gradInputTemp.dtype() != gradInputTensor.dtype()) {
+            DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputTemp));
+        }
     }
 
     if (gradBias != nullptr) {


### PR DESCRIPTION
## Motivation and Context
fix bug of DiopiLinearBackward when grad of input and grad of weight is nullptr.


## Description
modify linear.cpp file.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

