### PR TITLE
wx/fix index and dtype bug 

### DIFF
--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -68,8 +68,23 @@ def get_dtype(input) -> Dtype:
         assert 0, "not supported type of input"
 
 
+def infer_tensor_scalar_common_dtype(input: Tensor, other) -> Dtype:
+    dtype1, dtype2 = get_dtype(input), get_dtype(other)
+    if dtype1 in float_types:
+        return dtype1
+    if dtype1 not in float_types and dtype2 in float_types:
+        return Dtype.float32
+    if dtype1 == Dtype.bool and dtype2 != Dtype.bool:
+        return Dtype.float32 if dtype2 in float_types else Dtype.int64
+    return dtype1
+
+
 def common_dtype(input, other) -> Dtype:
     dtype1, dtype2 = get_dtype(input), get_dtype(other)
+    if isinstance(input, Tensor) and (isinstance(other, int) or isinstance(other, float)):
+        return infer_tensor_scalar_common_dtype(input, other)
+    if isinstance(other, Tensor) and (isinstance(input, int) or isinstance(input, float)):
+        return infer_tensor_scalar_common_dtype(other, input)
     if dtype1 in float_types and dtype2 not in float_types:
         return dtype1
     if dtype1 not in float_types and dtype2 in float_types:

--- a/impl/camb/functions/index.cpp
+++ b/impl/camb/functions/index.cpp
@@ -34,6 +34,7 @@ static diopiError_t indexPreProcess(diopiContextHandle_t ctx, DiopiTensor inputT
                                     std::vector<DiopiTensor>& indicesTensorsCast) {
     // expand bool tensor or byte tensor into 1 or more int tensors
     bool boolTensorConvertToEmptyTensor = false;
+    bool containIntTensor = false;
     for (auto indexTensor : indicesTensors) {
         if (!indexTensor.defined()) {
             indicesTensorsCast.emplace_back();
@@ -70,13 +71,14 @@ static diopiError_t indexPreProcess(diopiContextHandle_t ctx, DiopiTensor inputT
             } else {
                 // int tensor
                 indicesTensorsCast.emplace_back(std::move(indexTensor));
+                containIntTensor = true;
             }
         }
     }
     indicesTensorsCast.resize(indicesTensors.size());
 
-    // handle the broadcast of special empty index tensor
-    if (boolTensorConvertToEmptyTensor) {
+    // handle the broadcast of special empty index tensor when containing int index tensor
+    if (boolTensorConvertToEmptyTensor && containIntTensor) {
         bool first = true;
         std::vector<int64_t> sizes;
         for (const auto& indexTensorCast : indicesTensorsCast) {


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* For index op, fix the bug about the broadcast of special empty index tensor when containing int index tensor.
* Add the inference of the common dtype between tensor and scalar.


## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

