### PR TITLE
wx/fix the bug of random op about data type out of bounds

### DIFF
--- a/impl/camb/cnnl_helper.hpp
+++ b/impl/camb/cnnl_helper.hpp
@@ -19,16 +19,13 @@
 
 #include "diopi_helper.hpp"
 
-namespace impl {
-namespace camb {
-
-#define DIOPI_CALLCNNL(Expr)                                                                                                        \
-    do {                                                                                                                            \
-        ::cnnlStatus_t ret = Expr;                                                                                                  \
-        if (ret != ::CNNL_STATUS_SUCCESS) {                                                                                         \
-            setLastErrorString("cnnl error %d: %s in %s at %s:%d\n", ret, ::cnnlGetErrorString(ret), __func__, __FILE__, __LINE__); \
-            return diopiErrorOccurred;                                                                                              \
-        }                                                                                                                           \
+#define DIOPI_CALLCNNL(Expr)                                                                                                                    \
+    do {                                                                                                                                        \
+        ::cnnlStatus_t ret = Expr;                                                                                                              \
+        if (ret != ::CNNL_STATUS_SUCCESS) {                                                                                                     \
+            impl::camb::setLastErrorString("cnnl error %d: %s in %s at %s:%d\n", ret, ::cnnlGetErrorString(ret), __func__, __FILE__, __LINE__); \
+            return diopiErrorOccurred;                                                                                                          \
+        }                                                                                                                                       \
     } while (false);
 
 #define DIOPI_CHECKCNNL(Expr)                                                                            \
@@ -39,6 +36,9 @@ namespace camb {
             std::abort();                                                                                \
         }                                                                                                \
     } while (false);
+
+namespace impl {
+namespace camb {
 
 class CnnlDataType final {
 public:

--- a/impl/camb/functions/random.cpp
+++ b/impl/camb/functions/random.cpp
@@ -26,7 +26,7 @@ extern "C" diopiError_t diopiRandomInp(diopiContextHandle_t ctx, diopiTensorHand
         float min = from;
         float max;
         if (to != nullptr) {
-            max = *to;
+            max = *to - 1;
         } else {
             max = CNNL_DTYPE_FLOAT ? FLT_MAX : std::numeric_limits<half_float::half>::max();
         }

--- a/impl/camb/functions/random.cpp
+++ b/impl/camb/functions/random.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "../cnnl_helper.hpp"
+#include "../common/float16.hpp"
 
 namespace impl {
 namespace camb {
@@ -25,9 +26,9 @@ extern "C" diopiError_t diopiRandomInp(diopiContextHandle_t ctx, diopiTensorHand
         float min = from;
         float max;
         if (to != nullptr) {
-            max = *to - 1;
+            max = *to;
         } else {
-            max = FLT_MAX;
+            max = CNNL_DTYPE_FLOAT ? FLT_MAX : std::numeric_limits<half_float::half>::max();
         }
         diopiTensorHandle_t stateHandle = nullptr;
         DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));

--- a/proto/include/diopi/diopirt.h
+++ b/proto/include/diopi/diopirt.h
@@ -52,6 +52,8 @@ typedef enum {
     diopi_device = 1,
 } diopiDevice_t;
 
+// In order to meet the requirements of common dtype inference in diopitest, all members in this enumeration should be assigned values in the order of
+// increasing dtype precision
 typedef enum {
     diopi_dtype_int8 = 0,
     diopi_dtype_uint8 = 1,

--- a/proto/include/diopi/diopirt.h
+++ b/proto/include/diopi/diopirt.h
@@ -52,7 +52,7 @@ typedef enum {
     diopi_device = 1,
 } diopiDevice_t;
 
-// In order to meet the requirements of common dtype inference in diopitest, all members in this enumeration should be assigned values in the order of
+// In order to meet the requirements of common dtype inference in diopi_test, all members in this enumeration should be assigned values in the order of
 // increasing dtype precision
 typedef enum {
     diopi_dtype_int8 = 0,


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Fix the bug of random op about data type out of bounds.

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

