### PR TITLE
zzf/modify cmake file to adapt gcc 7.5

### DIFF
--- a/impl/ascend/test/CMakeLists.txt
+++ b/impl/ascend/test/CMakeLists.txt
@@ -39,7 +39,7 @@ set(FUNCTIONS_SRC
 )
 
 pybind11_add_module(${DIOPIFUNCTIONS} SHARED ${FUNCTIONS_SRC})
-target_link_libraries(${DIOPIFUNCTIONS} PRIVATE diopirt)
+target_link_libraries(${DIOPIFUNCTIONS} PRIVATE diopirt -Wl,--no-as-needed ${DEVICEIMPL} -Wl,--as-needed)
 add_dependencies(${DIOPIFUNCTIONS} functions_copy)
 if(${USE_ADAPTOR} STREQUAL "true")
     add_dependencies(${DIOPIFUNCTIONS} adaptor_code_gen)

--- a/impl/ascend/test/CMakeLists.txt
+++ b/impl/ascend/test/CMakeLists.txt
@@ -22,7 +22,7 @@ pybind11_add_module(${DIOPIRT} SHARED ${EXPORT_SRC})
 add_library(diopirt SHARED ${RUNTIME_SRC})
 
 target_link_libraries(${DIOPIRT} PRIVATE diopirt)
-target_link_libraries(diopirt ${DEVICEIMPL})
+target_link_libraries(diopirt ascendcl acl_op_compiler)
 
 set(FUNCTION_SAVE_PATH "${CMAKE_SOURCE_DIR}/../diopi_test/diopi_stub/csrc")
 

--- a/impl/camb/test/CMakeLists.txt
+++ b/impl/camb/test/CMakeLists.txt
@@ -40,7 +40,7 @@ add_custom_target(test_code_gen ALL
 set(FUNCTIONS_SRC ${GEN_FILES})
 
 pybind11_add_module(${DIOPI_FUNCTIONS} SHARED ${FUNCTIONS_SRC})
-target_link_libraries(${DIOPI_FUNCTIONS} PRIVATE diopirt ${DEVICEIMPL})
+target_link_libraries(${DIOPI_FUNCTIONS} PRIVATE diopirt -Wl,--no-as-needed ${DEVICEIMPL} -Wl,--as-needed)
 add_dependencies(${DIOPI_FUNCTIONS} test_code_gen)
 
 file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/../diopi_test/python)


### PR DESCRIPTION
## Motivation and Context
modify cmake file to adapt gcc 7.5


## Description
modify cmake file to adapt gcc 7.5


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

