### PR TITLE
Wx/delete CnnlDescBase and some static functions in CnnlDataType

### DIFF
--- a/impl/camb/cnnl_helper.cpp
+++ b/impl/camb/cnnl_helper.cpp
@@ -149,10 +149,10 @@ diopiError_t cnnlTranspose(diopiContextHandle_t& ctx, cnnlHandle_t& handle, Diop
     CnnlTensorDesc outDesc(out, layoutOut);
     CnnlTransposeDescriptor transDesc(order.size(), order.data());
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetTransposeWorkspaceSize(handle, inDesc.get(), transDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetTransposeWorkspaceSize(handle, inDesc.get(), transDesc.get(), &workspaceSize));
 
     void* workspacePtr = workspaceSize == 0 ? requiresBuffer(ctx, workspaceSize).data() : nullptr;
-    DIOPI_CALLCNNL(cnnlTranspose_v2(handle, transDesc.get(), inDesc.get(), in.data(), outDesc.get(), out.data(), workspacePtr, workspaceSize));
+    DIOPI_CALL_CNNL(cnnlTranspose_v2(handle, transDesc.get(), inDesc.get(), in.data(), outDesc.get(), out.data(), workspacePtr, workspaceSize));
     return diopiSuccess;
 }
 

--- a/impl/camb/cnnl_helper.cpp
+++ b/impl/camb/cnnl_helper.cpp
@@ -60,15 +60,6 @@ diopiError_t CnnlDataType::convertToCnnlType(cnnlDataType_t* cnnlType, diopiDtyp
     }
     return diopiSuccess;
 }
-bool CnnlDataType::isFloatPoint(cnnlDataType_t cnnlDT) {
-    return cnnlDT == CNNL_DTYPE_HALF || cnnlDT == CNNL_DTYPE_FLOAT || cnnlDT == CNNL_DTYPE_DOUBLE || cnnlDT == CNNL_DTYPE_COMPLEX_HALF ||
-           cnnlDT == CNNL_DTYPE_COMPLEX_FLOAT;
-}
-bool CnnlDataType::isInteger(cnnlDataType_t cnnlDT) {
-    return cnnlDT == CNNL_DTYPE_INT8 || cnnlDT == CNNL_DTYPE_INT16 || cnnlDT == CNNL_DTYPE_INT31 || cnnlDT == CNNL_DTYPE_INT32 || cnnlDT == CNNL_DTYPE_INT64 ||
-           cnnlDT == CNNL_DTYPE_UINT8 || cnnlDT == CNNL_DTYPE_UINT16 || cnnlDT == CNNL_DTYPE_UINT32 || cnnlDT == CNNL_DTYPE_UINT64;
-}
-bool CnnlDataType::isBool(cnnlDataType_t cnnlDT) { return cnnlDT == CNNL_DTYPE_BOOL; }
 
 const std::unordered_map<std::vector<diopiDtype_t>, cnnlCastDataType_t, HashCnnlCastDType> gCnnlCastDataTypeMapping{
     {{diopi_dtype_bool, diopi_dtype_int32}, CNNL_CAST_BOOL_TO_INT32},

--- a/impl/camb/cnnl_helper.hpp
+++ b/impl/camb/cnnl_helper.hpp
@@ -43,13 +43,10 @@ namespace camb {
 class CnnlDataType final {
 public:
     static diopiError_t convertToCnnlType(cnnlDataType_t* cnnlType, diopiDtype_t type);
-    static bool isFloatPoint(cnnlDataType_t cnnlDT);
-    static bool isInteger(cnnlDataType_t cnnlDT);
-    static bool isBool(cnnlDataType_t cnnlDT);
 };
 
 template <typename T, ::cnnlStatus_t (*fnCreate)(T*), ::cnnlStatus_t (*fnDestroy)(T)>
-class CnnlResourceGuard final {
+class CnnlResourceGuard {
 public:
     CnnlResourceGuard() { DIOPI_CHECKCNNL(fnCreate(&resource_)); }
 
@@ -61,20 +58,7 @@ protected:
     T resource_{0};
 };
 
-template <typename T, ::cnnlStatus_t (*fnCreate)(T*), ::cnnlStatus_t (*fnDestroy)(T)>
-class CnnlDescBase {
-public:
-    CnnlDescBase() { DIOPI_CHECKCNNL(fnCreate(&resource_)); }
-
-    virtual ~CnnlDescBase() { DIOPI_CHECKCNNL(fnDestroy(resource_)); }
-
-    T& get() { return resource_; }
-
-protected:
-    T resource_{0};
-};
-
-class CnnlTensorDesc : public CnnlDescBase<cnnlTensorDescriptor_t, cnnlCreateTensorDescriptor, cnnlDestroyTensorDescriptor> {
+class CnnlTensorDesc : public CnnlResourceGuard<cnnlTensorDescriptor_t, cnnlCreateTensorDescriptor, cnnlDestroyTensorDescriptor> {
 public:
     CnnlTensorDesc() = default;
 
@@ -182,7 +166,7 @@ private:
     std::mutex mutex_;
 };
 
-class CnnlTransposeDescriptor final : public CnnlDescBase<cnnlTransposeDescriptor_t, cnnlCreateTransposeDescriptor, cnnlDestroyTransposeDescriptor> {
+class CnnlTransposeDescriptor final : public CnnlResourceGuard<cnnlTransposeDescriptor_t, cnnlCreateTransposeDescriptor, cnnlDestroyTransposeDescriptor> {
 public:
     CnnlTransposeDescriptor() = default;
 
@@ -194,7 +178,7 @@ public:
     }
 };
 
-class CnnlReduceDescriptor final : public CnnlDescBase<cnnlReduceDescriptor_t, cnnlCreateReduceDescriptor, cnnlDestroyReduceDescriptor> {
+class CnnlReduceDescriptor final : public CnnlResourceGuard<cnnlReduceDescriptor_t, cnnlCreateReduceDescriptor, cnnlDestroyReduceDescriptor> {
 public:
     CnnlReduceDescriptor() = default;
 
@@ -210,7 +194,7 @@ public:
     }
 };
 
-class CnnlInterpDescriptor final : public CnnlDescBase<cnnlInterpDescriptor_t, cnnlCreateInterpDescriptor, cnnlDestroyInterpDescriptor> {
+class CnnlInterpDescriptor final : public CnnlResourceGuard<cnnlInterpDescriptor_t, cnnlCreateInterpDescriptor, cnnlDestroyInterpDescriptor> {
 public:
     CnnlInterpDescriptor() = default;
 

--- a/impl/camb/cnnl_helper.hpp
+++ b/impl/camb/cnnl_helper.hpp
@@ -19,7 +19,7 @@
 
 #include "diopi_helper.hpp"
 
-#define DIOPI_CALLCNNL(Expr)                                                                                                                    \
+#define DIOPI_CALL_CNNL(Expr)                                                                                                                   \
     do {                                                                                                                                        \
         ::cnnlStatus_t ret = Expr;                                                                                                              \
         if (ret != ::CNNL_STATUS_SUCCESS) {                                                                                                     \
@@ -28,7 +28,7 @@
         }                                                                                                                                       \
     } while (false);
 
-#define DIOPI_CHECKCNNL(Expr)                                                                            \
+#define DIOPI_CHECK_CNNL(Expr)                                                                           \
     do {                                                                                                 \
         ::cnnlStatus_t ret = Expr;                                                                       \
         if (ret != ::CNNL_STATUS_SUCCESS) {                                                              \
@@ -48,9 +48,9 @@ public:
 template <typename T, ::cnnlStatus_t (*fnCreate)(T*), ::cnnlStatus_t (*fnDestroy)(T)>
 class CnnlResourceGuard {
 public:
-    CnnlResourceGuard() { DIOPI_CHECKCNNL(fnCreate(&resource_)); }
+    CnnlResourceGuard() { DIOPI_CHECK_CNNL(fnCreate(&resource_)); }
 
-    ~CnnlResourceGuard() { DIOPI_CHECKCNNL(fnDestroy(resource_)); }
+    ~CnnlResourceGuard() { DIOPI_CHECK_CNNL(fnDestroy(resource_)); }
 
     T& get() { return resource_; }
 
@@ -76,7 +76,7 @@ public:
         std::vector<int32_t> strideTmp(dim);
         if (!dim) {
             std::vector<int> dimArray(1, 1);
-            DIOPI_CALLCNNL(cnnlSetTensorDescriptorEx(get(), CNNL_LAYOUT_ARRAY, dtype, 1, dimArray.data(), dimArray.data()));
+            DIOPI_CALL_CNNL(cnnlSetTensorDescriptorEx(get(), CNNL_LAYOUT_ARRAY, dtype, 1, dimArray.data(), dimArray.data()));
             return diopiSuccess;
         }
         if (layout == CNNL_LAYOUT_NHWC || layout == CNNL_LAYOUT_NDHWC || layout == CNNL_LAYOUT_NLC) {
@@ -102,7 +102,7 @@ public:
             shapeTmp = shape;
             strideTmp = stride;
         }
-        DIOPI_CALLCNNL(cnnlSetTensorDescriptorEx(get(), layout, dtype, shapeTmp.size(), shapeTmp.data(), strideTmp.data()));
+        DIOPI_CALL_CNNL(cnnlSetTensorDescriptorEx(get(), layout, dtype, shapeTmp.size(), shapeTmp.data(), strideTmp.data()));
         return diopiSuccess;
     }
     template <typename T>
@@ -129,7 +129,7 @@ public:
     diopiError_t set(T& t, cnnlTensorLayout_t layout, std::vector<int> dims) {
         cnnlDataType_t dtype;
         DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, t.dtype()));
-        DIOPI_CALLCNNL(cnnlSetTensorDescriptor(get(), layout, dtype, dims.size(), dims.data()));
+        DIOPI_CALL_CNNL(cnnlSetTensorDescriptor(get(), layout, dtype, dims.size(), dims.data()));
         return diopiSuccess;
     }
 };
@@ -173,7 +173,7 @@ public:
     CnnlTransposeDescriptor(const int dim, const int* permute) { set(dim, permute); }
 
     diopiError_t set(const int dim, const int* permute) {
-        DIOPI_CALLCNNL(cnnlSetTransposeDescriptor(get(), dim, permute));
+        DIOPI_CALL_CNNL(cnnlSetTransposeDescriptor(get(), dim, permute));
         return diopiSuccess;
     }
 };
@@ -189,7 +189,7 @@ public:
         for (int i = 0; i < axisNum; i++) {
             axisList[i] = static_cast<int>(axis[i]);
         }
-        DIOPI_CALLCNNL(cnnlSetReduceDescriptor(get(), axisList.data(), axisNum, reduceOp, tensorType, CNNL_NOT_PROPAGATE_NAN, isIndices, indicesType));
+        DIOPI_CALL_CNNL(cnnlSetReduceDescriptor(get(), axisList.data(), axisNum, reduceOp, tensorType, CNNL_NOT_PROPAGATE_NAN, isIndices, indicesType));
         return diopiSuccess;
     }
 };
@@ -200,9 +200,9 @@ public:
 
     diopiError_t set(cnnlTensorDescriptor_t inputDesc, const cnnlInterpMode_t mode, const cnnlInterpCoordinateTransformationMode_t coordinateTransMode,
                      float* scales) {
-        DIOPI_CALLCNNL(cnnlSetInterpDescriptor(this->get(), mode, coordinateTransMode));
+        DIOPI_CALL_CNNL(cnnlSetInterpDescriptor(this->get(), mode, coordinateTransMode));
         cnnlInterpRoundMode_t roundMode = CNNL_INTERP_FLOOR;
-        DIOPI_CALLCNNL(cnnlSetInterpDescriptorEx(this->get(), inputDesc, roundMode, scales, nullptr, -0.75, false));
+        DIOPI_CALL_CNNL(cnnlSetInterpDescriptorEx(this->get(), inputDesc, roundMode, scales, nullptr, -0.75, false));
         return diopiSuccess;
     }
 };

--- a/impl/camb/common/basic_op.cpp
+++ b/impl/camb/common/basic_op.cpp
@@ -20,7 +20,7 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor input, DiopiTens
 
     CnnlResourceGuard<cnnlOpTensorDescriptor_t, cnnlCreateOpTensorDescriptor, cnnlDestroyOpTensorDescriptor> opDesc;
 
-    DIOPI_CALLCNNL(cnnlSetOpTensorDescriptor(opDesc.get(), opType, compType, CNNL_NOT_PROPAGATE_NAN));
+    DIOPI_CALL_CNNL(cnnlSetOpTensorDescriptor(opDesc.get(), opType, compType, CNNL_NOT_PROPAGATE_NAN));
 
     std::shared_ptr<void> alpha1Value = nullptr;
     std::shared_ptr<void> alpha2Value = nullptr;
@@ -43,26 +43,26 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor input, DiopiTens
     CnnlTensorDesc outputDesc(outputCasted, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetOpTensorWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetOpTensorWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outputDesc.get(), &workspaceSize));
 
     void* workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlOpTensor(handle,
-                                opDesc.get(),
-                                alpha1Value.get(),
-                                inputDesc.get(),
-                                inputCasted.data(),
-                                alpha2Value.get(),
-                                otherDesc.get(),
-                                otherCasted.data(),
-                                workspace,
-                                workspaceSize,
-                                betaValue.get(),
-                                outputDesc.get(),
-                                outputCasted.data()));
+    DIOPI_CALL_CNNL(cnnlOpTensor(handle,
+                                 opDesc.get(),
+                                 alpha1Value.get(),
+                                 inputDesc.get(),
+                                 inputCasted.data(),
+                                 alpha2Value.get(),
+                                 otherDesc.get(),
+                                 otherCasted.data(),
+                                 workspace,
+                                 workspaceSize,
+                                 betaValue.get(),
+                                 outputDesc.get(),
+                                 outputCasted.data()));
 
     DIOPI_CALL(dataTypeCast(ctx, out, outputCasted));
     return diopiSuccess;

--- a/impl/camb/common/broadcast.cpp
+++ b/impl/camb/common/broadcast.cpp
@@ -26,7 +26,7 @@ diopiError_t broadcast(diopiContextHandle_t ctx, DiopiTensor& out, const DiopiTe
     }
     CnnlTensorDesc inputDesc(input, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(out, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlExpand(handle, inputDesc.get(), const_cast<DiopiTensor&>(input).data(), outDesc.get(), out.data()));
+    DIOPI_CALL_CNNL(cnnlExpand(handle, inputDesc.get(), const_cast<DiopiTensor&>(input).data(), outDesc.get(), out.data()));
     return diopiSuccess;
 }
 

--- a/impl/camb/common/clone.cpp
+++ b/impl/camb/common/clone.cpp
@@ -22,7 +22,7 @@ diopiError_t clone(diopiContextHandle_t ctx, const DiopiTensor& inTensor, DiopiT
     }
     CnnlTensorDesc inTensorDesc(inTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outTensorDesc(outTensor, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlCopy(handle, inTensorDesc.get(), inTensor.data(), outTensorDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlCopy(handle, inTensorDesc.get(), inTensor.data(), outTensorDesc.get(), outTensor.data()));
     return diopiSuccess;
 }
 

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -20,9 +20,9 @@ static diopiError_t transpose(diopiContextHandle_t& ctx, DiopiTensor& in, DiopiT
     CnnlTensorDesc outDesc(out, layoutOut);
     CnnlTransposeDescriptor transDesc(order.size(), order.data());
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetTransposeWorkspaceSize(handle, inDesc.get(), transDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetTransposeWorkspaceSize(handle, inDesc.get(), transDesc.get(), &workspaceSize));
     void* workspacePtr = workspaceSize == 0 ? requiresBuffer(ctx, workspaceSize).data() : nullptr;
-    DIOPI_CALLCNNL(cnnlTranspose_v2(handle, transDesc.get(), inDesc.get(), in.data(), outDesc.get(), out.data(), workspacePtr, workspaceSize));
+    DIOPI_CALL_CNNL(cnnlTranspose_v2(handle, transDesc.get(), inDesc.get(), in.data(), outDesc.get(), out.data(), workspacePtr, workspaceSize));
     return diopiSuccess;
 }
 

--- a/impl/camb/common/dtype_cast.cpp
+++ b/impl/camb/common/dtype_cast.cpp
@@ -116,7 +116,7 @@ diopiError_t dataTypeCast(diopiContextHandle_t ctx, DiopiTensor& dest, const Dio
         CnnlTensorDesc srcTmpDesc(srcTmp, CNNL_LAYOUT_ARRAY);
         CnnlTensorDesc destTmpDesc(destTmp, CNNL_LAYOUT_ARRAY);
         cnnlCastDataType_t castType = it->second;
-        DIOPI_CALLCNNL(cnnlCastDataType(handle, srcTmpDesc.get(), srcTmp.data(), castType, destTmpDesc.get(), destTmp.data()));
+        DIOPI_CALL_CNNL(cnnlCastDataType(handle, srcTmpDesc.get(), srcTmp.data(), castType, destTmpDesc.get(), destTmp.data()));
     } else {
         DIOPI_CALL(dataTypeCastTwice(ctx, dest, src));
     }

--- a/impl/camb/common/scalar.cpp
+++ b/impl/camb/common/scalar.cpp
@@ -17,13 +17,13 @@ diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t*
         int32_t val = static_cast<int32_t>(scalar->ival);
         out = requiresTensor(ctx, sSize, diopi_dtype_int32);
         CnnlTensorDesc descOut(out, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, &val, descOut.get(), out.data()));
+        DIOPI_CALL_CNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, &val, descOut.get(), out.data()));
         return diopiSuccess;
     } else if (scalar->stype == diopi_dtype_float64) {
         float val = static_cast<float>(scalar->fval);
         out = requiresTensor(ctx, sSize, diopi_dtype_float32);
         CnnlTensorDesc descOut(out, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, &val, descOut.get(), out.data()));
+        DIOPI_CALL_CNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, &val, descOut.get(), out.data()));
         return diopiSuccess;
     } else {
         setLastErrorString("%s", "salar dtype is not float64 or int64");

--- a/impl/camb/common/transpose.cpp
+++ b/impl/camb/common/transpose.cpp
@@ -56,14 +56,14 @@ diopiError_t transpose(diopiContextHandle_t ctx, DiopiTensor outTensor, DiopiTen
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
-    DIOPI_CALLCNNL(cnnlTranspose_v2(handle, transposeDesc, inputDesc.get(), input.data(), outDesc.get(), outTensor.data(), workspace, workspaceSize));
+    DIOPI_CALL_CNNL(cnnlTranspose_v2(handle, transposeDesc, inputDesc.get(), input.data(), outDesc.get(), outTensor.data(), workspace, workspaceSize));
     return diopiSuccess;
 }
 
 diopiError_t transpose(diopiContextHandle_t ctx, const DiopiTensor& inputTensor, DiopiTensor& outTensor, std::vector<int32_t> perms) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
     CnnlResourceGuard<cnnlTransposeDescriptor_t, cnnlCreateTransposeDescriptor, cnnlDestroyTransposeDescriptor> cnnlTransposeDesc;
-    DIOPI_CALLCNNL(cnnlSetTransposeDescriptor(cnnlTransposeDesc.get(), perms.size(), perms.data()));
+    DIOPI_CALL_CNNL(cnnlSetTransposeDescriptor(cnnlTransposeDesc.get(), perms.size(), perms.data()));
     if (!outTensor.defined()) {
         std::vector<int64_t> trShape(perms.size());
         for (size_t i = 0; i < perms.size(); ++i) {
@@ -79,7 +79,7 @@ diopiError_t transpose(diopiContextHandle_t ctx, const DiopiTensor& inputTensor,
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
-    DIOPI_CALLCNNL(
+    DIOPI_CALL_CNNL(
         cnnlTranspose_v2(handle, cnnlTransposeDesc.get(), inDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data(), workspace, workspaceSize));
     return diopiSuccess;
 }

--- a/impl/camb/functions/abs.cpp
+++ b/impl/camb/functions/abs.cpp
@@ -21,7 +21,7 @@ static diopiError_t abs(diopiContextHandle_t ctx, DiopiTensor input, DiopiTensor
     }
     CnnlTensorDesc inputDesc(input, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outputTmpDesc(outputTmp, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlAbs(handle, inputDesc.get(), input.data(), outputTmpDesc.get(), outputTmp.data()));
+    DIOPI_CALL_CNNL(cnnlAbs(handle, inputDesc.get(), input.data(), outputTmpDesc.get(), outputTmp.data()));
     if (outputTmp.dtype() != output.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, output, outputTmp));
     }

--- a/impl/camb/functions/activation.cpp
+++ b/impl/camb/functions/activation.cpp
@@ -70,7 +70,7 @@ diopiError_t cnnlActivationInternal(diopiContextHandle_t ctx, DiopiTensor input,
     void* beta = attr.get("beta", nullptr);
 
     CnnlResourceGuard<cnnlActivationDescriptor_t, cnnlCreateActivationDescriptor, cnnlDestroyActivationDescriptor> activationDesc;
-    DIOPI_CALLCNNL(cnnlSetActivationDescriptor_v6(activationDesc.get(), mode, perf, nanProp, coef, slicedDim, gamma, scale, isResult, approximate));
+    DIOPI_CALL_CNNL(cnnlSetActivationDescriptor_v6(activationDesc.get(), mode, perf, nanProp, coef, slicedDim, gamma, scale, isResult, approximate));
 
     std::vector<DiopiTensor*> inputs{&input};
     DIOPI_CALL(autoCastTensorType(ctx, inputs, {diopi_dtype_float16, diopi_dtype_float32}));
@@ -80,7 +80,7 @@ diopiError_t cnnlActivationInternal(diopiContextHandle_t ctx, DiopiTensor input,
     CnnlTensorDesc inputDesc(input, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outputDesc(tempOutput, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlActivationForward(handle, activationDesc.get(), alpha, inputDesc.get(), input.data(), beta, outputDesc.get(), tempOutput.data()));
+    DIOPI_CALL_CNNL(cnnlActivationForward(handle, activationDesc.get(), alpha, inputDesc.get(), input.data(), beta, outputDesc.get(), tempOutput.data()));
     DIOPI_CALL(dataTypeCast(ctx, out, tempOutput));
 
     return diopiSuccess;
@@ -103,7 +103,7 @@ diopiError_t cnnlActivationBackwardInternal(diopiContextHandle_t ctx, DiopiTenso
     void* beta = attr.get("beta", nullptr);
 
     CnnlResourceGuard<cnnlActivationDescriptor_t, cnnlCreateActivationDescriptor, cnnlDestroyActivationDescriptor> activationDesc;
-    DIOPI_CALLCNNL(cnnlSetActivationDescriptor_v6(activationDesc.get(), mode, perf, nanProp, coef, slicedDim, gamma, scale, isResult, approximate));
+    DIOPI_CALL_CNNL(cnnlSetActivationDescriptor_v6(activationDesc.get(), mode, perf, nanProp, coef, slicedDim, gamma, scale, isResult, approximate));
     std::vector<DiopiTensor*> inputs{&gradOutput};
     if (input.defined()) {
         inputs.push_back(&input);
@@ -128,18 +128,18 @@ diopiError_t cnnlActivationBackwardInternal(diopiContextHandle_t ctx, DiopiTenso
         DIOPI_CALL(outputDesc.set(output, CNNL_LAYOUT_ARRAY));
     }
 
-    DIOPI_CALLCNNL(cnnlActivationBackward(handle,
-                                          activationDesc.get(),
-                                          alpha,
-                                          outputDesc.get(),
-                                          output.defined() ? output.data() : nullptr,
-                                          gradOutputDesc.get(),
-                                          gradOutput.data(),
-                                          inputDesc.get(),
-                                          input.defined() ? input.data() : nullptr,
-                                          beta,
-                                          gradInputDesc.get(),
-                                          tempGradInput.data()));
+    DIOPI_CALL_CNNL(cnnlActivationBackward(handle,
+                                           activationDesc.get(),
+                                           alpha,
+                                           outputDesc.get(),
+                                           output.defined() ? output.data() : nullptr,
+                                           gradOutputDesc.get(),
+                                           gradOutput.data(),
+                                           inputDesc.get(),
+                                           input.defined() ? input.data() : nullptr,
+                                           beta,
+                                           gradInputDesc.get(),
+                                           tempGradInput.data()));
     DIOPI_CALL(dataTypeCast(ctx, gradInput, tempGradInput));
     return diopiSuccess;
 }

--- a/impl/camb/functions/adadelta.cpp
+++ b/impl/camb/functions/adadelta.cpp
@@ -44,18 +44,18 @@ diopiError_t diopiAdadelta(diopiContextHandle_t ctx, diopiTensorHandle_t input, 
     DIOPI_CALL(dataTypeCast(ctx, rhoTensor, inputCasted.dtype()));
     DIOPI_CALL(dataTypeCast(ctx, epsTensor, inputCasted.dtype()));
 
-    DIOPI_CALLCNNL(cnnlApplyAdadelta(handle,
-                                     inputDesc.get(),
-                                     inputCasted.data(),
-                                     squareAvgDesc.get(),
-                                     squareAvgCasted.data(),
-                                     accDeltaDesc.get(),
-                                     accDeltaCasted.data(),
-                                     gradDesc.get(),
-                                     gradCasted.data(),
-                                     lrTensor.data(),
-                                     rhoTensor.data(),
-                                     epsTensor.data()));
+    DIOPI_CALL_CNNL(cnnlApplyAdadelta(handle,
+                                      inputDesc.get(),
+                                      inputCasted.data(),
+                                      squareAvgDesc.get(),
+                                      squareAvgCasted.data(),
+                                      accDeltaDesc.get(),
+                                      accDeltaCasted.data(),
+                                      gradDesc.get(),
+                                      gradCasted.data(),
+                                      lrTensor.data(),
+                                      rhoTensor.data(),
+                                      epsTensor.data()));
 
     DIOPI_CALL(dataTypeCast(ctx, inputTensor, inputCasted));
     DIOPI_CALL(dataTypeCast(ctx, squareAvgTensor, squareAvgCasted));

--- a/impl/camb/functions/adaptive_pooling.cpp
+++ b/impl/camb/functions/adaptive_pooling.cpp
@@ -46,15 +46,15 @@ diopiError_t diopiAdaptiveAvgPool2d(diopiContextHandle_t ctx, diopiTensorHandle_
 // version should be greater than 1.15.2
 #if (CNNL_MAJOR * 10000 + CNNL_MINOR * 100 + CNNL_PATCHLEVEL >= 11502)
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetAdaptivePoolingForwardWorkspaceSize(handle, inputDesc.get(), mode, outputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetAdaptivePoolingForwardWorkspaceSize(handle, inputDesc.get(), mode, outputDesc.get(), &workspaceSize));
 
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
     /* call adaptive pooling */
-    DIOPI_CALLCNNL(cnnlAdaptivePoolingForward_v2(
+    DIOPI_CALL_CNNL(cnnlAdaptivePoolingForward_v2(
         handle, inputDesc.get(), inputTr.data(), mode, workspacePtr, workspaceSize, outputDesc.get(), outputChannelLast.data(), nullptr, nullptr));
 #else
-    DIOPI_CALLCNNL(cnnlAdaptivePoolingForward(handle, inputDesc.get(), inputTr.data(), mode, outputDesc.get(), outputChannelLast.data(), nullptr, nullptr));
+    DIOPI_CALL_CNNL(cnnlAdaptivePoolingForward(handle, inputDesc.get(), inputTr.data(), mode, outputDesc.get(), outputChannelLast.data(), nullptr, nullptr));
 #endif
     // NHWC -> NCHW
     DIOPI_CALL(impl::camb::contiguous(ctx, outputChannelLast, diopiMemoryFormat_t::Contiguous));
@@ -98,14 +98,14 @@ diopiError_t diopiAdaptiveAvgPool2dBackward(diopiContextHandle_t ctx, diopiTenso
     CnnlTensorDesc gradInputDesc(gradInputChannelLast, layout);
 
     /* call adaptive pooling */
-    DIOPI_CALLCNNL(cnnlAdaptivePoolingBackward(handle,
-                                               gradOutputDesc.get(),
-                                               gradOutputTr.data(),
-                                               nullptr,
-                                               nullptr,
-                                               CNNL_POOLING_AVERAGE_COUNT_INCLUDE_PADDING,
-                                               gradInputDesc.get(),
-                                               gradInputChannelLast.data()));
+    DIOPI_CALL_CNNL(cnnlAdaptivePoolingBackward(handle,
+                                                gradOutputDesc.get(),
+                                                gradOutputTr.data(),
+                                                nullptr,
+                                                nullptr,
+                                                CNNL_POOLING_AVERAGE_COUNT_INCLUDE_PADDING,
+                                                gradInputDesc.get(),
+                                                gradInputChannelLast.data()));
 
     // NHWC -> NCHW
     DIOPI_CALL(impl::camb::contiguous(ctx, gradInputChannelLast, diopiMemoryFormat_t::Contiguous));

--- a/impl/camb/functions/addcdiv.cpp
+++ b/impl/camb/functions/addcdiv.cpp
@@ -27,7 +27,7 @@ diopiError_t diopiAddcdiv(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     CnnlTensorDesc outTensorDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetAddcdivWorkspaceSize(handle, inputTensorDesc.get(), otherTensor1Desc.get(), otherTensor2Desc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetAddcdivWorkspaceSize(handle, inputTensorDesc.get(), otherTensor1Desc.get(), otherTensor2Desc.get(), &workspaceSize));
     void* workspace = nullptr;
     float scalarValue;
     if (DiopiDataType::isInteger(value->stype)) {
@@ -37,18 +37,18 @@ diopiError_t diopiAddcdiv(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     }
 
     workspace = requiresBuffer(ctx, workspaceSize).data();
-    DIOPI_CALLCNNL(cnnlAddcdiv(handle,
-                               inputTensorDesc.get(),
-                               inputTensor.data(),
-                               &(scalarValue),
-                               otherTensor1Desc.get(),
-                               otherTensor1.data(),
-                               otherTensor2Desc.get(),
-                               otherTensor2.data(),
-                               workspace,
-                               workspaceSize,
-                               outTensorDesc.get(),
-                               outTensorTemp.data()))
+    DIOPI_CALL_CNNL(cnnlAddcdiv(handle,
+                                inputTensorDesc.get(),
+                                inputTensor.data(),
+                                &(scalarValue),
+                                otherTensor1Desc.get(),
+                                otherTensor1.data(),
+                                otherTensor2Desc.get(),
+                                otherTensor2.data(),
+                                workspace,
+                                workspaceSize,
+                                outTensorDesc.get(),
+                                outTensorTemp.data()))
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));
     }

--- a/impl/camb/functions/addcmul.cpp
+++ b/impl/camb/functions/addcmul.cpp
@@ -27,7 +27,7 @@ diopiError_t diopiAddcmul(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     CnnlTensorDesc outTensorDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetAddcmulWorkspaceSize(handle, inputTensorDesc.get(), otherTensor1Desc.get(), otherTensor2Desc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetAddcmulWorkspaceSize(handle, inputTensorDesc.get(), otherTensor1Desc.get(), otherTensor2Desc.get(), &workspaceSize));
     void* workspace = nullptr;
     float scalarValue;
     if (DiopiDataType::isInteger(value->stype)) {
@@ -37,18 +37,18 @@ diopiError_t diopiAddcmul(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     }
 
     workspace = requiresBuffer(ctx, workspaceSize).data();
-    DIOPI_CALLCNNL(cnnlAddcmul(handle,
-                               inputTensorDesc.get(),
-                               inputTensor.data(),
-                               &(scalarValue),
-                               otherTensor1Desc.get(),
-                               otherTensor1.data(),
-                               otherTensor2Desc.get(),
-                               otherTensor2.data(),
-                               workspace,
-                               workspaceSize,
-                               outTensorDesc.get(),
-                               outTensorTemp.data()))
+    DIOPI_CALL_CNNL(cnnlAddcmul(handle,
+                                inputTensorDesc.get(),
+                                inputTensor.data(),
+                                &(scalarValue),
+                                otherTensor1Desc.get(),
+                                otherTensor1.data(),
+                                otherTensor2Desc.get(),
+                                otherTensor2.data(),
+                                workspace,
+                                workspaceSize,
+                                outTensorDesc.get(),
+                                outTensorTemp.data()))
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));
     }

--- a/impl/camb/functions/addmm.cpp
+++ b/impl/camb/functions/addmm.cpp
@@ -46,9 +46,9 @@ diopiError_t diopiAddmm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
     int32_t isTransa = 0;
     int32_t isTransb = 0;
     int32_t allowTf32I32 = 1;
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_TRANSA, &(isTransa), sizeof(int32_t)));
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_TRANSB, &(isTransb), sizeof(int32_t)));
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_ALLOW_TF32, &(allowTf32I32), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_TRANSA, &(isTransa), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_TRANSB, &(isTransb), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_ALLOW_TF32, &(allowTf32I32), sizeof(int32_t)));
 
     size_t workspaceSize = 0;
     int requestedAlgoCount = 1;
@@ -58,17 +58,17 @@ diopiError_t diopiAddmm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
     CnnlResourceGuard<cnnlMatMulAlgo_t, cnnlMatMulAlgoCreate, cnnlMatMulAlgoDestroy> cnnlMatMulAlgo;
     cnnlMatMulAlgo_t matmulAlgo = cnnlMatMulAlgo.get();
 
-    DIOPI_CALLCNNL(cnnlGetMatMulAlgoHeuristic(handle,
-                                              matmulDesc,
-                                              mat1Desc.get(),
-                                              mat2Desc.get(),
-                                              mmResultDesc.get(),
-                                              mmResultDesc.get(),
-                                              nullptr,
-                                              requestedAlgoCount,
-                                              &heuristicResult,
-                                              &returnAlgoCount));
-    DIOPI_CALLCNNL(cnnlGetMatMulHeuristicResult(heuristicResult, matmulAlgo, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetMatMulAlgoHeuristic(handle,
+                                               matmulDesc,
+                                               mat1Desc.get(),
+                                               mat2Desc.get(),
+                                               mmResultDesc.get(),
+                                               mmResultDesc.get(),
+                                               nullptr,
+                                               requestedAlgoCount,
+                                               &heuristicResult,
+                                               &returnAlgoCount));
+    DIOPI_CALL_CNNL(cnnlGetMatMulHeuristicResult(heuristicResult, matmulAlgo, &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -91,44 +91,44 @@ diopiError_t diopiAddmm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
     float alphaDefault = 1;
     float betaDefault = 0;
 
-    DIOPI_CALLCNNL(cnnlMatMul_v2(handle,
-                                 matmulDesc,
-                                 matmulAlgo,
-                                 &alphaDefault,
-                                 mat1Desc.get(),
-                                 mat1TensorTmp.data(),
-                                 mat2Desc.get(),
-                                 mat2TensorTmp.data(),
-                                 &betaDefault,
-                                 mmResultDesc.get(),
-                                 mmResultTensor.data(),
-                                 workspace,
-                                 workspaceSize,
-                                 mmResultDesc.get(),
-                                 mmResultTensor.data()));
+    DIOPI_CALL_CNNL(cnnlMatMul_v2(handle,
+                                  matmulDesc,
+                                  matmulAlgo,
+                                  &alphaDefault,
+                                  mat1Desc.get(),
+                                  mat1TensorTmp.data(),
+                                  mat2Desc.get(),
+                                  mat2TensorTmp.data(),
+                                  &betaDefault,
+                                  mmResultDesc.get(),
+                                  mmResultTensor.data(),
+                                  workspace,
+                                  workspaceSize,
+                                  mmResultDesc.get(),
+                                  mmResultTensor.data()));
 
     CnnlResourceGuard<cnnlOpTensorDescriptor_t, cnnlCreateOpTensorDescriptor, cnnlDestroyOpTensorDescriptor> cnnlOpTensorDesc;
     cnnlOpTensorDescriptor_t optensorDesc = cnnlOpTensorDesc.get();
     workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetOpTensorWorkspaceSize(handle, mmResultDesc.get(), inputDesc.get(), outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetOpTensorWorkspaceSize(handle, mmResultDesc.get(), inputDesc.get(), outDesc.get(), &workspaceSize));
     workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlOpTensor(handle,
-                                optensorDesc,
-                                &alphaTmp,
-                                mmResultDesc.get(),
-                                mmResultTensor.data(),
-                                &betaTmp,
-                                inputDesc.get(),
-                                inputTensorTmp.data(),
-                                workspace,
-                                workspaceSize,
-                                &betaDefault,
-                                outDesc.get(),
-                                outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlOpTensor(handle,
+                                 optensorDesc,
+                                 &alphaTmp,
+                                 mmResultDesc.get(),
+                                 mmResultTensor.data(),
+                                 &betaTmp,
+                                 inputDesc.get(),
+                                 inputTensorTmp.data(),
+                                 workspace,
+                                 workspaceSize,
+                                 &betaDefault,
+                                 outDesc.get(),
+                                 outTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
 
     return diopiSuccess;

--- a/impl/camb/functions/amax.cpp
+++ b/impl/camb/functions/amax.cpp
@@ -42,31 +42,31 @@ diopiError_t diopiAmax(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
     cnnlDataType_t tensorType;
     CnnlDataType::convertToCnnlType(&tensorType, inputTensorTmp.dtype());
     CnnlResourceGuard<cnnlReduceDescriptor_t, cnnlCreateReduceDescriptor, cnnlDestroyReduceDescriptor> reduceDesc;
-    DIOPI_CALLCNNL(cnnlSetReduceDescriptor_v2(
+    DIOPI_CALL_CNNL(cnnlSetReduceDescriptor_v2(
         reduceDesc.get(), axis.data(), axis.size(), CNNL_REDUCE_MAX, tensorType, CNNL_NOT_PROPAGATE_NAN, CNNL_REDUCE_NO_INDICES, CNNL_32BIT_INDICES, 0.0));
 
     CnnlTensorDesc inputDesc(inputTensorTmp, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetReduceOpWorkspaceSize(handle, inputDesc.get(), outDesc.get(), reduceDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetReduceOpWorkspaceSize(handle, inputDesc.get(), outDesc.get(), reduceDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlReduce(handle,
-                              reduceDesc.get(),
-                              workspace,
-                              workspaceSize,
-                              nullptr,
-                              inputDesc.get(),
-                              inputTensorTmp.data(),
-                              0,
-                              nullptr,
-                              nullptr,
-                              outDesc.get(),
-                              outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlReduce(handle,
+                               reduceDesc.get(),
+                               workspace,
+                               workspaceSize,
+                               nullptr,
+                               inputDesc.get(),
+                               inputTensorTmp.data(),
+                               0,
+                               nullptr,
+                               nullptr,
+                               outDesc.get(),
+                               outTensorTmp.data()));
     if (outTensorTmp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     }

--- a/impl/camb/functions/arange.cpp
+++ b/impl/camb/functions/arange.cpp
@@ -21,14 +21,14 @@ diopiError_t diopiArange(diopiContextHandle_t ctx, diopiTensorHandle_t out, cons
     CnnlTensorDesc outDesc(out32Tensor, CNNL_LAYOUT_ARRAY);
 
     if (DiopiDataType::isInteger(out32Tensor.dtype())) {
-        DIOPI_CALLCNNL(cnnlArange_v2(handle, CNNL_COMPUTATION_ULTRAHIGH_PRECISION, &(start->ival), &(step->ival), outDesc.get(), out32Tensor.data()));
+        DIOPI_CALL_CNNL(cnnlArange_v2(handle, CNNL_COMPUTATION_ULTRAHIGH_PRECISION, &(start->ival), &(step->ival), outDesc.get(), out32Tensor.data()));
         if (out32Tensor.dtype() != outTensor.dtype()) {
             DIOPI_CALL(dataTypeCast(ctx, outTensor, out32Tensor));
         }
     } else if (DiopiDataType::isFloatPoint(out32Tensor.dtype())) {
         float startVal = DiopiDataType::isInteger(start->stype) ? start->ival : start->fval;
         float stepVal = DiopiDataType::isInteger(step->stype) ? step->ival : step->fval;
-        DIOPI_CALLCNNL(cnnlArange_v2(handle, CNNL_COMPUTATION_ULTRAHIGH_PRECISION, &(startVal), &(stepVal), outDesc.get(), out32Tensor.data()));
+        DIOPI_CALL_CNNL(cnnlArange_v2(handle, CNNL_COMPUTATION_ULTRAHIGH_PRECISION, &(startVal), &(stepVal), outDesc.get(), out32Tensor.data()));
     }
 
     return diopiSuccess;

--- a/impl/camb/functions/arange.cpp
+++ b/impl/camb/functions/arange.cpp
@@ -20,14 +20,12 @@ diopiError_t diopiArange(diopiContextHandle_t ctx, diopiTensorHandle_t out, cons
     }
     CnnlTensorDesc outDesc(out32Tensor, CNNL_LAYOUT_ARRAY);
 
-    cnnlDataType_t dtype;
-    CnnlDataType::convertToCnnlType(&dtype, out32Tensor.dtype());
-    if (CnnlDataType::isInteger(dtype)) {
+    if (DiopiDataType::isInteger(out32Tensor.dtype())) {
         DIOPI_CALLCNNL(cnnlArange_v2(handle, CNNL_COMPUTATION_ULTRAHIGH_PRECISION, &(start->ival), &(step->ival), outDesc.get(), out32Tensor.data()));
         if (out32Tensor.dtype() != outTensor.dtype()) {
             DIOPI_CALL(dataTypeCast(ctx, outTensor, out32Tensor));
         }
-    } else if (CnnlDataType::isFloatPoint(dtype)) {
+    } else if (DiopiDataType::isFloatPoint(out32Tensor.dtype())) {
         float startVal = DiopiDataType::isInteger(start->stype) ? start->ival : start->fval;
         float stepVal = DiopiDataType::isInteger(step->stype) ? step->ival : step->fval;
         DIOPI_CALLCNNL(cnnlArange_v2(handle, CNNL_COMPUTATION_ULTRAHIGH_PRECISION, &(startVal), &(stepVal), outDesc.get(), out32Tensor.data()));

--- a/impl/camb/functions/argmax.cpp
+++ b/impl/camb/functions/argmax.cpp
@@ -63,28 +63,28 @@ diopiError_t diopiArgmax(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     CnnlDataType::convertToCnnlType(&tensorType, inputCasted.dtype());
     CnnlResourceGuard<cnnlReduceDescriptor_t, cnnlCreateReduceDescriptor, cnnlDestroyReduceDescriptor> reduceDesc;
 
-    DIOPI_CALLCNNL(cnnlSetReduceDescriptor_v2(
+    DIOPI_CALL_CNNL(cnnlSetReduceDescriptor_v2(
         reduceDesc.get(), axis.data(), axis.size(), CNNL_REDUCE_MAX, tensorType, CNNL_NOT_PROPAGATE_NAN, CNNL_REDUCE_ONLY_INDICES, CNNL_32BIT_INDICES, 0.0));
 
     void* workspace = nullptr;
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetReduceOpWorkspaceSize(handle, inputDesc.get(), outDesc.get(), reduceDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetReduceOpWorkspaceSize(handle, inputDesc.get(), outDesc.get(), reduceDesc.get(), &workspaceSize));
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlReduce(handle,
-                              reduceDesc.get(),
-                              workspace,
-                              workspaceSize,
-                              nullptr,
-                              inputDesc.get(),
-                              inputCasted.data(),
-                              indicesCasted.elemsize() * indicesCasted.numel(),
-                              indicesCasted.data(),
-                              nullptr,
-                              outDesc.get(),
-                              outCasted.data()));
+    DIOPI_CALL_CNNL(cnnlReduce(handle,
+                               reduceDesc.get(),
+                               workspace,
+                               workspaceSize,
+                               nullptr,
+                               inputDesc.get(),
+                               inputCasted.data(),
+                               indicesCasted.elemsize() * indicesCasted.numel(),
+                               indicesCasted.data(),
+                               nullptr,
+                               outDesc.get(),
+                               outCasted.data()));
 
     DIOPI_CALL(dataTypeCast(ctx, indicesTensor, indicesCasted));
     return diopiSuccess;

--- a/impl/camb/functions/atan.cpp
+++ b/impl/camb/functions/atan.cpp
@@ -28,22 +28,22 @@ static diopiError_t atan(diopiContextHandle_t ctx, DiopiTensor output, DiopiTens
     CnnlTensorDesc outputDesc(outputTmp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetAtan2WorkspaceSize(handle, input1Desc.get(), input2Desc.get(), outputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetAtan2WorkspaceSize(handle, input1Desc.get(), input2Desc.get(), outputDesc.get(), &workspaceSize));
     void *workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlAtan2(handle,
-                             CNNL_COMPUTATION_HIGH_PRECISION,
-                             input1Desc.get(),
-                             input1.data(),
-                             input2Desc.get(),
-                             input2.data(),
-                             workspace,
-                             workspaceSize,
-                             outputDesc.get(),
-                             outputTmp.data()));
+    DIOPI_CALL_CNNL(cnnlAtan2(handle,
+                              CNNL_COMPUTATION_HIGH_PRECISION,
+                              input1Desc.get(),
+                              input1.data(),
+                              input2Desc.get(),
+                              input2.data(),
+                              workspace,
+                              workspaceSize,
+                              outputDesc.get(),
+                              outputTmp.data()));
     if (outputTmp.dtype() != output.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, output, outputTmp));
     }

--- a/impl/camb/functions/avg_pool2d.cpp
+++ b/impl/camb/functions/avg_pool2d.cpp
@@ -81,11 +81,11 @@ diopiError_t diopiAvgPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     CnnlResourceGuard<cnnlPoolingDescriptor_t, cnnlCreatePoolingDescriptor, cnnlDestroyPoolingDescriptor> cnnlPoolDesc;
     cnnlPoolingDescriptor_t poolDesc = cnnlPoolDesc.get();
     cnnlPoolingMode_t mode = countIncludePad ? CNNL_POOLING_AVERAGE_COUNT_INCLUDE_PADDING : CNNL_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING;
-    DIOPI_CALLCNNL(
+    DIOPI_CALL_CNNL(
         cnnlSetPooling2dDescriptor_v2(poolDesc, mode, CNNL_PROPAGATE_NAN, kernelH, kernelW, pu, pd, pl, pr, strideH, strideW, dilation0, dilation1, ceilMode));
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetPoolingWorkspaceSize(handle, mode, outTensor.shape()[3], inputTensor.shape()[2], &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetPoolingWorkspaceSize(handle, mode, outTensor.shape()[3], inputTensor.shape()[2], &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -93,7 +93,7 @@ diopiError_t diopiAvgPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     const void* alpha = nullptr;
     const void* beta = nullptr;
-    DIOPI_CALLCNNL(cnnlPoolingForward(
+    DIOPI_CALL_CNNL(cnnlPoolingForward(
         handle, poolDesc, alpha, inputDesc.get(), inputTensorTmp.data(), beta, outDesc.get(), outTensorTmp.data(), workspace, workspaceSize));
 
     if (divisorOverride != nullptr) {
@@ -210,24 +210,24 @@ diopiError_t diopiAvgPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
     CnnlResourceGuard<cnnlPoolingDescriptor_t, cnnlCreatePoolingDescriptor, cnnlDestroyPoolingDescriptor> cnnlPoolDesc;
     cnnlPoolingDescriptor_t poolDesc = cnnlPoolDesc.get();
     cnnlPoolingMode_t mode = countIncludePad ? CNNL_POOLING_AVERAGE_COUNT_INCLUDE_PADDING : CNNL_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING;
-    DIOPI_CALLCNNL(
+    DIOPI_CALL_CNNL(
         cnnlSetPooling2dDescriptor_v2(poolDesc, mode, CNNL_PROPAGATE_NAN, kernelH, kernelW, pu, pd, pl, pr, strideH, strideW, dilation0, dilation1, ceilMode));
 
     const void* alpha = nullptr;
     const void* beta = nullptr;
 
-    DIOPI_CALLCNNL(cnnlPoolingBackward(handle,
-                                       poolDesc,
-                                       alpha,
-                                       nullptr,
-                                       nullptr,
-                                       gradOutputDesc.get(),
-                                       gradOutputTensorT.data(),
-                                       inputDesc.get(),
-                                       inputTensorT.data(),
-                                       beta,
-                                       gradInputDesc.get(),
-                                       gradInputTensorT.data()));
+    DIOPI_CALL_CNNL(cnnlPoolingBackward(handle,
+                                        poolDesc,
+                                        alpha,
+                                        nullptr,
+                                        nullptr,
+                                        gradOutputDesc.get(),
+                                        gradOutputTensorT.data(),
+                                        inputDesc.get(),
+                                        inputTensorT.data(),
+                                        beta,
+                                        gradInputDesc.get(),
+                                        gradInputTensorT.data()));
 
     if (gradInputTensorT.shape().size() == 4) {
         std::vector<int64_t> permNhwc2nchw{0, 3, 1, 2};

--- a/impl/camb/functions/baddbmm.cpp
+++ b/impl/camb/functions/baddbmm.cpp
@@ -42,11 +42,11 @@ static diopiError_t batchAddBatchMatmul(diopiContextHandle_t ctx, DiopiTensor in
     int32_t isTransb = 0;
     int32_t isBetaUse = 1;
     int32_t isTF32Allow = 1;
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_COMPUTE_TYPE, &dataType, sizeof(int32_t)));
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_TRANSA, &isTransa, sizeof(int32_t)));
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_TRANSB, &isTransb, sizeof(int32_t)));
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_USE_BETA, &isBetaUse, sizeof(int32_t)));
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_ALLOW_TF32, &isTF32Allow, sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_COMPUTE_TYPE, &dataType, sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_TRANSA, &isTransa, sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_DESC_TRANSB, &isTransb, sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_USE_BETA, &isBetaUse, sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_ALLOW_TF32, &isTF32Allow, sizeof(int32_t)));
 
     CnnlResourceGuard<cnnlMatMulHeuristicResult_t, cnnlCreateMatMulHeuristicResult, cnnlDestroyMatMulHeuristicResult> matmulHrObj;
     cnnlMatMulHeuristicResult_t matmulHr = matmulHrObj.get();
@@ -57,16 +57,16 @@ static diopiError_t batchAddBatchMatmul(diopiContextHandle_t ctx, DiopiTensor in
     size_t workspaceSize = 0;
     int requestAlgoCount = 1;
     int returnAlgoCount = 0;
-    DIOPI_CALLCNNL(cnnlGetBatchMatMulAlgoHeuristic(handle,
-                                                   matmulDesc,
-                                                   batch1Desc.get(),
-                                                   batch2Desc.get(),
-                                                   inputDesc.get(),
-                                                   nullptr,  // preference not supported.
-                                                   requestAlgoCount,
-                                                   &matmulHr,
-                                                   &returnAlgoCount));
-    DIOPI_CALLCNNL(cnnlGetBatchMatMulHeuristicResult(matmulHr, matmulAlgo, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetBatchMatMulAlgoHeuristic(handle,
+                                                    matmulDesc,
+                                                    batch1Desc.get(),
+                                                    batch2Desc.get(),
+                                                    inputDesc.get(),
+                                                    nullptr,  // preference not supported.
+                                                    requestAlgoCount,
+                                                    &matmulHr,
+                                                    &returnAlgoCount));
+    DIOPI_CALL_CNNL(cnnlGetBatchMatMulHeuristicResult(matmulHr, matmulAlgo, &workspaceSize));
 
     void *workspace = nullptr;
     if (workspaceSize != 0) {
@@ -74,19 +74,19 @@ static diopiError_t batchAddBatchMatmul(diopiContextHandle_t ctx, DiopiTensor in
         DIOPI_CHECK(workspace != nullptr, "[diopiBaddbmm] require buffers: size = %d, for workspace failed.", workspaceSize);
     }
 
-    DIOPI_CALLCNNL(cnnlBatchMatMulBCast_v2(handle,
-                                           matmulDesc,
-                                           matmulAlgo,
-                                           &alpha,
-                                           batch1Desc.get(),
-                                           batch1.data(),
-                                           batch2Desc.get(),
-                                           batch2.data(),
-                                           &beta,
-                                           inputDesc.get(),
-                                           input.data(),
-                                           workspace,
-                                           workspaceSize));
+    DIOPI_CALL_CNNL(cnnlBatchMatMulBCast_v2(handle,
+                                            matmulDesc,
+                                            matmulAlgo,
+                                            &alpha,
+                                            batch1Desc.get(),
+                                            batch1.data(),
+                                            batch2Desc.get(),
+                                            batch2.data(),
+                                            &beta,
+                                            inputDesc.get(),
+                                            input.data(),
+                                            workspace,
+                                            workspaceSize));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/batch_norm.cpp
+++ b/impl/camb/functions/batch_norm.cpp
@@ -80,54 +80,54 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     if (training) {
         size_t workspaceSize = 0;
-        DIOPI_CALLCNNL(cnnlGetBatchNormForwardWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
+        DIOPI_CALL_CNNL(cnnlGetBatchNormForwardWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
 
         void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
         // set activition part to default
         cnnlActivationMode_t activeMode = CNNL_ACTIVATION_IDENTITY;
         cnnlActivationDescriptor_t activationDesc = nullptr;
-        DIOPI_CALLCNNL(cnnlCreateActivationDescriptor(&activationDesc));
+        DIOPI_CALL_CNNL(cnnlCreateActivationDescriptor(&activationDesc));
         cnnlSetActivationDescriptor_v5(activationDesc, activeMode, CNNL_ACTIVATION_HIGH_PRECISION, CNNL_NOT_PROPAGATE_NAN, 1.0, -1, 1.0, 1.0, false);
-        DIOPI_CALLCNNL(cnnlBatchNormForwardTraining_v2(handle,
-                                                       activationDesc,
-                                                       CNNL_BATCHNORM_SPATIAL,
-                                                       CNNL_BATCHNORM_OPS_BN,
-                                                       nullptr,
-                                                       nullptr,
-                                                       inputDesc.get(),
-                                                       inputTr.data(),
-                                                       nullptr,
-                                                       nullptr,
-                                                       weightBiasMeanVarDesc.get(),
-                                                       weightTr.data(),
-                                                       biasTr.data(),
-                                                       runningMeanTr.defined() ? runningMeanTr.data() : nullptr,
-                                                       runningVarTr.defined() ? runningVarTr.data() : nullptr,
-                                                       static_cast<float>(eps),
-                                                       static_cast<float>(momentum),
-                                                       outputDesc.get(),
-                                                       outputTmpTr.data(),
-                                                       saveMeanTr.data(),
-                                                       saveInvstdTr.data(),
-                                                       workspacePtr,
-                                                       workspaceSize,
-                                                       nullptr,
-                                                       0));
+        DIOPI_CALL_CNNL(cnnlBatchNormForwardTraining_v2(handle,
+                                                        activationDesc,
+                                                        CNNL_BATCHNORM_SPATIAL,
+                                                        CNNL_BATCHNORM_OPS_BN,
+                                                        nullptr,
+                                                        nullptr,
+                                                        inputDesc.get(),
+                                                        inputTr.data(),
+                                                        nullptr,
+                                                        nullptr,
+                                                        weightBiasMeanVarDesc.get(),
+                                                        weightTr.data(),
+                                                        biasTr.data(),
+                                                        runningMeanTr.defined() ? runningMeanTr.data() : nullptr,
+                                                        runningVarTr.defined() ? runningVarTr.data() : nullptr,
+                                                        static_cast<float>(eps),
+                                                        static_cast<float>(momentum),
+                                                        outputDesc.get(),
+                                                        outputTmpTr.data(),
+                                                        saveMeanTr.data(),
+                                                        saveInvstdTr.data(),
+                                                        workspacePtr,
+                                                        workspaceSize,
+                                                        nullptr,
+                                                        0));
     } else {
-        DIOPI_CALLCNNL(cnnlBatchNormForwardInference(handle,
-                                                     nullptr,
-                                                     nullptr,
-                                                     inputDesc.get(),
-                                                     inputTr.data(),
-                                                     weightBiasMeanVarDesc.get(),
-                                                     weightTr.data(),
-                                                     biasTr.data(),
-                                                     runningMeanTr.defined() ? runningMeanTr.data() : nullptr,
-                                                     runningVarTr.defined() ? runningVarTr.data() : nullptr,
-                                                     static_cast<float>(eps),
-                                                     outputDesc.get(),
-                                                     outputTmpTr.data()));
+        DIOPI_CALL_CNNL(cnnlBatchNormForwardInference(handle,
+                                                      nullptr,
+                                                      nullptr,
+                                                      inputDesc.get(),
+                                                      inputTr.data(),
+                                                      weightBiasMeanVarDesc.get(),
+                                                      weightTr.data(),
+                                                      biasTr.data(),
+                                                      runningMeanTr.defined() ? runningMeanTr.data() : nullptr,
+                                                      runningVarTr.defined() ? runningVarTr.data() : nullptr,
+                                                      static_cast<float>(eps),
+                                                      outputDesc.get(),
+                                                      outputTmpTr.data()));
     }
 
     // channels last -> contiguous
@@ -215,76 +215,76 @@ diopiError_t diopiBatchNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_
     cnnlActivationMode_t activeMode = CNNL_ACTIVATION_IDENTITY;
 
     cnnlActivationDescriptor_t activationDesc = nullptr;
-    DIOPI_CALLCNNL(cnnlCreateActivationDescriptor(&activationDesc));
+    DIOPI_CALL_CNNL(cnnlCreateActivationDescriptor(&activationDesc));
     cnnlSetActivationDescriptor_v5(activationDesc, activeMode, CNNL_ACTIVATION_HIGH_PRECISION, CNNL_NOT_PROPAGATE_NAN, 1.0, -1, 1.0, 1.0, false);
 
     if (training) {
         // get workspace
         size_t workspaceSize = 0;
-        DIOPI_CALLCNNL(cnnlGetBatchNormBackwardWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
+        DIOPI_CALL_CNNL(cnnlGetBatchNormBackwardWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
 
         void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-        DIOPI_CALLCNNL(cnnlBatchNormBackward_v2(handle,
-                                                activationDesc,
-                                                mode,
-                                                bnOps,
-                                                nullptr,
-                                                nullptr,
-                                                nullptr,
-                                                nullptr,
-                                                inputDesc.get(),
-                                                inputTr.data(),
-                                                nullptr,
-                                                nullptr,
-                                                gradOutputDesc.get(),
-                                                gradOutputTr.data(),
-                                                weightBiasMeanVarDesc.get(),
-                                                weightTr.data(),
-                                                nullptr,
-                                                saveMeanTr.defined() ? saveMeanTr.data() : nullptr,
-                                                saveInvstdTr.defined() ? saveInvstdTr.data() : nullptr,
-                                                static_cast<float>(eps),
-                                                nullptr,
-                                                nullptr,
-                                                gradInputDesc.get(),
-                                                gradInputTmpTr.data(),
-                                                gradWeightTmpTr.data(),
-                                                gradBiasTmpTr.data(),
-                                                workspacePtr,
-                                                workspaceSize,
-                                                nullptr,
-                                                0));
+        DIOPI_CALL_CNNL(cnnlBatchNormBackward_v2(handle,
+                                                 activationDesc,
+                                                 mode,
+                                                 bnOps,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 inputDesc.get(),
+                                                 inputTr.data(),
+                                                 nullptr,
+                                                 nullptr,
+                                                 gradOutputDesc.get(),
+                                                 gradOutputTr.data(),
+                                                 weightBiasMeanVarDesc.get(),
+                                                 weightTr.data(),
+                                                 nullptr,
+                                                 saveMeanTr.defined() ? saveMeanTr.data() : nullptr,
+                                                 saveInvstdTr.defined() ? saveInvstdTr.data() : nullptr,
+                                                 static_cast<float>(eps),
+                                                 nullptr,
+                                                 nullptr,
+                                                 gradInputDesc.get(),
+                                                 gradInputTmpTr.data(),
+                                                 gradWeightTmpTr.data(),
+                                                 gradBiasTmpTr.data(),
+                                                 workspacePtr,
+                                                 workspaceSize,
+                                                 nullptr,
+                                                 0));
     } else {
         size_t workspaceSize = 0;
-        DIOPI_CALLCNNL(cnnlGetFrozenBatchNormBackwardWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
+        DIOPI_CALL_CNNL(cnnlGetFrozenBatchNormBackwardWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
 
         void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-        DIOPI_CALLCNNL(cnnlFrozenBatchNormBackward_v2(handle,
-                                                      activationDesc,
-                                                      mode,
-                                                      bnOps,
-                                                      inputDesc.get(),
-                                                      inputTr.data(),
-                                                      nullptr,
-                                                      nullptr,
-                                                      gradOutputDesc.get(),
-                                                      gradOutputTr.data(),
-                                                      weightBiasMeanVarDesc.get(),
-                                                      weightTr.data(),
-                                                      nullptr,
-                                                      runningMeanTr.defined() ? runningMeanTr.data() : nullptr,
-                                                      runningVarTr.defined() ? runningVarTr.data() : nullptr,
-                                                      static_cast<float>(eps),
-                                                      workspacePtr,
-                                                      workspaceSize,
-                                                      nullptr,
-                                                      nullptr,
-                                                      gradInputDesc.get(),
-                                                      gradInputTmpTr.data(),
-                                                      gradWeightTmpTr.data(),
-                                                      gradBiasTmpTr.data()));
+        DIOPI_CALL_CNNL(cnnlFrozenBatchNormBackward_v2(handle,
+                                                       activationDesc,
+                                                       mode,
+                                                       bnOps,
+                                                       inputDesc.get(),
+                                                       inputTr.data(),
+                                                       nullptr,
+                                                       nullptr,
+                                                       gradOutputDesc.get(),
+                                                       gradOutputTr.data(),
+                                                       weightBiasMeanVarDesc.get(),
+                                                       weightTr.data(),
+                                                       nullptr,
+                                                       runningMeanTr.defined() ? runningMeanTr.data() : nullptr,
+                                                       runningVarTr.defined() ? runningVarTr.data() : nullptr,
+                                                       static_cast<float>(eps),
+                                                       workspacePtr,
+                                                       workspaceSize,
+                                                       nullptr,
+                                                       nullptr,
+                                                       gradInputDesc.get(),
+                                                       gradInputTmpTr.data(),
+                                                       gradWeightTmpTr.data(),
+                                                       gradBiasTmpTr.data()));
     }
 
     // Channels last -> contiguous

--- a/impl/camb/functions/bce_loss.cpp
+++ b/impl/camb/functions/bce_loss.cpp
@@ -72,7 +72,7 @@ DIOPI_API diopiError_t diopiBCELoss(diopiContextHandle_t ctx, diopiTensorHandle_
 
     size_t workspaceSize = 0;
     void *workspace = nullptr;
-    DIOPI_CALLCNNL(cnnlGetBceLossWorkspaceSize(handle, inputDesc.get(), weightDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetBceLossWorkspaceSize(handle, inputDesc.get(), weightDesc.get(), &workspaceSize));
     if (workspaceSize > 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
@@ -80,18 +80,18 @@ DIOPI_API diopiError_t diopiBCELoss(diopiContextHandle_t ctx, diopiTensorHandle_
     cnnlBceLossReduction_t bceReduction;
     convertBCEReduction(&bceReduction, reduction);
 
-    DIOPI_CALLCNNL(cnnlBceLoss(handle,
-                               inputDesc.get(),
-                               inputTensor.data(),
-                               targetDesc.get(),
-                               targetTensor.data(),
-                               weightDesc.get(),
-                               weightTensor.data(),
-                               bceReduction,
-                               workspace,
-                               workspaceSize,
-                               outCastedDesc.get(),
-                               outCastedTensor.data()));
+    DIOPI_CALL_CNNL(cnnlBceLoss(handle,
+                                inputDesc.get(),
+                                inputTensor.data(),
+                                targetDesc.get(),
+                                targetTensor.data(),
+                                weightDesc.get(),
+                                weightTensor.data(),
+                                bceReduction,
+                                workspace,
+                                workspaceSize,
+                                outCastedDesc.get(),
+                                outCastedTensor.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outCastedTensor));
     return diopiSuccess;
 }
@@ -129,7 +129,7 @@ DIOPI_API diopiError_t diopiBCELossBackward(diopiContextHandle_t ctx, diopiTenso
 
     size_t workspaceSize = 0;
     void *workspace = nullptr;
-    DIOPI_CALLCNNL(cnnlGetBceLossBackwardWorkspaceSize(handle, targetDesc.get(), weightDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetBceLossBackwardWorkspaceSize(handle, targetDesc.get(), weightDesc.get(), &workspaceSize));
     if (workspaceSize > 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
@@ -137,20 +137,20 @@ DIOPI_API diopiError_t diopiBCELossBackward(diopiContextHandle_t ctx, diopiTenso
     cnnlBceLossReduction_t bceReduction;
     convertBCEReduction(&bceReduction, reduction);
 
-    DIOPI_CALLCNNL(cnnlBceLossBackward(handle,
-                                       gradOutputDesc.get(),
-                                       gradOutputTensor.data(),
-                                       inputDesc.get(),
-                                       inputTensor.data(),
-                                       targetDesc.get(),
-                                       targetTensor.data(),
-                                       weightDesc.get(),
-                                       weightTensor.data(),
-                                       bceReduction,
-                                       workspace,
-                                       workspaceSize,
-                                       gradInputDesc.get(),
-                                       gradInputCastedTensor.data()));
+    DIOPI_CALL_CNNL(cnnlBceLossBackward(handle,
+                                        gradOutputDesc.get(),
+                                        gradOutputTensor.data(),
+                                        inputDesc.get(),
+                                        inputTensor.data(),
+                                        targetDesc.get(),
+                                        targetTensor.data(),
+                                        weightDesc.get(),
+                                        weightTensor.data(),
+                                        bceReduction,
+                                        workspace,
+                                        workspaceSize,
+                                        gradInputDesc.get(),
+                                        gradInputCastedTensor.data()));
     DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputCastedTensor));
     return diopiSuccess;
 }

--- a/impl/camb/functions/bce_with_logits.cpp
+++ b/impl/camb/functions/bce_with_logits.cpp
@@ -79,7 +79,7 @@ DIOPI_API diopiError_t diopiBCEWithLogits(diopiContextHandle_t ctx, diopiTensorH
     }
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetBceWithLogitsWorkspaceSize(
+    DIOPI_CALL_CNNL(cnnlGetBceWithLogitsWorkspaceSize(
         handle, inputDesc.get(), weightFlag ? weightDesc.get() : nullptr, posWeightFlag ? posWeightDesc.get() : nullptr, &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
@@ -87,21 +87,21 @@ DIOPI_API diopiError_t diopiBCEWithLogits(diopiContextHandle_t ctx, diopiTensorH
     }
 
     cnnlComputationPreference_t mode = CNNL_COMPUTATION_FAST;
-    DIOPI_CALLCNNL(cnnlBceWithLogits_v2(handle,
-                                        mode,
-                                        inputDesc.get(),
-                                        inputTensorTmp.data(),
-                                        targetDesc.get(),
-                                        targetTensorTmp.data(),
-                                        weightFlag ? weightDesc.get() : nullptr,
-                                        weightFlag ? weightTensorTmp.data() : nullptr,
-                                        posWeightFlag ? posWeightDesc.get() : nullptr,
-                                        posWeightFlag ? posWeightTensorTmp.data() : nullptr,
-                                        reductionMode,
-                                        workspace,
-                                        workspaceSize,
-                                        outDesc.get(),
-                                        outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlBceWithLogits_v2(handle,
+                                         mode,
+                                         inputDesc.get(),
+                                         inputTensorTmp.data(),
+                                         targetDesc.get(),
+                                         targetTensorTmp.data(),
+                                         weightFlag ? weightDesc.get() : nullptr,
+                                         weightFlag ? weightTensorTmp.data() : nullptr,
+                                         posWeightFlag ? posWeightDesc.get() : nullptr,
+                                         posWeightFlag ? posWeightTensorTmp.data() : nullptr,
+                                         reductionMode,
+                                         workspace,
+                                         workspaceSize,
+                                         outDesc.get(),
+                                         outTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
 
     return diopiSuccess;
@@ -177,29 +177,29 @@ DIOPI_API diopiError_t diopiBCEWithLogitsBackward(diopiContextHandle_t ctx, diop
     }
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetBceWithLogitsBackwardWorkspaceSize(
+    DIOPI_CALL_CNNL(cnnlGetBceWithLogitsBackwardWorkspaceSize(
         handle, targetDesc.get(), weightFlag ? weightDesc.get() : nullptr, posWeightFlag ? posWeightDesc.get() : nullptr, &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlBceWithLogitsBackward(handle,
-                                             gradOutputDesc.get(),
-                                             gradOutputTensorTmp.data(),
-                                             inputDesc.get(),
-                                             inputTensorTmp.data(),
-                                             targetDesc.get(),
-                                             targetTensorTmp.data(),
-                                             weightFlag ? weightDesc.get() : nullptr,
-                                             weightFlag ? weightTensorTmp.data() : nullptr,
-                                             posWeightFlag ? posWeightDesc.get() : nullptr,
-                                             posWeightFlag ? posWeightTensorTmp.data() : nullptr,
-                                             reductionMode,
-                                             workspace,
-                                             workspaceSize,
-                                             gradInputDesc.get(),
-                                             gradInputTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlBceWithLogitsBackward(handle,
+                                              gradOutputDesc.get(),
+                                              gradOutputTensorTmp.data(),
+                                              inputDesc.get(),
+                                              inputTensorTmp.data(),
+                                              targetDesc.get(),
+                                              targetTensorTmp.data(),
+                                              weightFlag ? weightDesc.get() : nullptr,
+                                              weightFlag ? weightTensorTmp.data() : nullptr,
+                                              posWeightFlag ? posWeightDesc.get() : nullptr,
+                                              posWeightFlag ? posWeightTensorTmp.data() : nullptr,
+                                              reductionMode,
+                                              workspace,
+                                              workspaceSize,
+                                              gradInputDesc.get(),
+                                              gradInputTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputTensorTmp));
 
     return diopiSuccess;

--- a/impl/camb/functions/bernoulli.cpp
+++ b/impl/camb/functions/bernoulli.cpp
@@ -19,7 +19,7 @@ DIOPI_API diopiError_t diopiBernoulli(diopiContextHandle_t ctx, diopiTensorHandl
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, inputTensor.dtype()));
 
     cnnlRandGenerator_t cnnlGenerator = nullptr;
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
+    DIOPI_CALL_CNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
 
     diopiTensorHandle_t stateHandle = nullptr;
     DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));
@@ -28,17 +28,17 @@ DIOPI_API diopiError_t diopiBernoulli(diopiContextHandle_t ctx, diopiTensorHandl
 
     if (outputTensor.dtype() != inputTensor.dtype()) {
         DiopiTensor outTemp = requiresTensor(ctx, inputTensor.shape(), inputTensor.dtype());
-        DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, inputTensor.numel(), 0, 1, outTemp.data()));
+        DIOPI_CALL_CNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, inputTensor.numel(), 0, 1, outTemp.data()));
         DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
         DIOPI_CALL(diopiLtInp(ctx, diopiTensorHandle_t(outTemp), input));
         DIOPI_CALL(dataTypeCast(ctx, outputTensor, outTemp));
     } else {
-        DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, inputTensor.numel(), 0, 1, outputTensor.data()));
+        DIOPI_CALL_CNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, inputTensor.numel(), 0, 1, outputTensor.data()));
         DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
         DIOPI_CALL(diopiLtInp(ctx, out, input));
     }
 
-    DIOPI_CALLCNNL(cnnlRandDestroyGenerator(cnnlGenerator));
+    DIOPI_CALL_CNNL(cnnlRandDestroyGenerator(cnnlGenerator));
     return diopiSuccess;
 }
 
@@ -51,17 +51,17 @@ DIOPI_API diopiError_t diopiBernoulliInp(diopiContextHandle_t ctx, diopiTensorHa
     DiopiTensor outTemp = requiresTensor(ctx, inputTensor.shape(), inputTensor.dtype());
 
     cnnlRandGenerator_t cnnlGenerator = nullptr;
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
+    DIOPI_CALL_CNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
 
     diopiTensorHandle_t stateHandle = nullptr;
     DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));
     void* statePtr = nullptr;
     DIOPI_CALL(diopiGetTensorData(stateHandle, &statePtr));
-    DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, inputTensor.numel(), 0, 1, outTemp.data()));
+    DIOPI_CALL_CNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, inputTensor.numel(), 0, 1, outTemp.data()));
     DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
     DIOPI_CALL(diopiLt(ctx, inout, diopiTensorHandle_t(outTemp), inout));
 
-    DIOPI_CALLCNNL(cnnlRandDestroyGenerator(cnnlGenerator));
+    DIOPI_CALL_CNNL(cnnlRandDestroyGenerator(cnnlGenerator));
     return diopiSuccess;
 }
 
@@ -73,19 +73,19 @@ DIOPI_API diopiError_t diopiBernoulliScalar(diopiContextHandle_t ctx, diopiTenso
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, outTensor.dtype()));
 
     cnnlRandGenerator_t cnnlGenerator = nullptr;
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
+    DIOPI_CALL_CNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
 
     diopiTensorHandle_t stateHandle = nullptr;
     DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));
     void* statePtr = nullptr;
     DIOPI_CALL(diopiGetTensorData(stateHandle, &statePtr));
-    DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, outTensor.numel(), 0, 1, outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, outTensor.numel(), 0, 1, outTensor.data()));
     DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
 
     diopiScalar_t scalar = constructDiopiScalarT(outTensor.dtype(), p);
     DIOPI_CALL(diopiLtInpScalar(ctx, out, &scalar));
 
-    DIOPI_CALLCNNL(cnnlRandDestroyGenerator(cnnlGenerator));
+    DIOPI_CALL_CNNL(cnnlRandDestroyGenerator(cnnlGenerator));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/bitwise.cpp
+++ b/impl/camb/functions/bitwise.cpp
@@ -42,13 +42,13 @@ diopiError_t bitwiseCommon(diopiContextHandle_t ctx, diopiTensorHandle_t out, di
     }
 
     size_t workspaceSize(0);
-    DIOPI_CALLCNNL(cnnlGetBitComputeWorkspaceSize(handle, input1Desc.get(), input2DescTmp, outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetBitComputeWorkspaceSize(handle, input1Desc.get(), input2DescTmp, outDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlBitCompute_v2(
+    DIOPI_CALL_CNNL(cnnlBitCompute_v2(
         handle, optype, input1Desc.get(), input1Tensor.data(), input2DescTmp, input2Ptr, outDesc.get(), out32Tensor.data(), workspace, workspaceSize));
     if (outTensor.dtype() != out32Tensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, out32Tensor));

--- a/impl/camb/functions/bmm.cpp
+++ b/impl/camb/functions/bmm.cpp
@@ -31,7 +31,7 @@ diopiError_t diopiBmm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
     CnnlTensorDesc mat2Desc(mat2Casted, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outputCasted, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(
+    DIOPI_CALL_CNNL(
         cnnlBatchMatMul(handle, false, false, mat1Desc.get(), mat1Casted.data(), mat2Desc.get(), mat2Casted.data(), outDesc.get(), outputCasted.data()));
     DIOPI_CALL(dataTypeCast(ctx, outputTensor, outputCasted));
     return diopiSuccess;

--- a/impl/camb/functions/cat.cpp
+++ b/impl/camb/functions/cat.cpp
@@ -23,7 +23,7 @@ diopiError_t diopiCat(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
     }
 
     size_t workspaceSize(0);
-    DIOPI_CALLCNNL(cnnlGetConcatWorkspaceSize(handle, numInputs, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetConcatWorkspaceSize(handle, numInputs, &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -31,7 +31,7 @@ diopiError_t diopiCat(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
 
     DiopiTensor outTensor(out);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlConcat(handle, numInputs, dim, inputsDescTmp.data(), inputs.data(), workspace, workspaceSize, outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlConcat(handle, numInputs, dim, inputsDescTmp.data(), inputs.data(), workspace, workspaceSize, outDesc.get(), outTensor.data()));
 
     return diopiSuccess;
 }

--- a/impl/camb/functions/cdist.cpp
+++ b/impl/camb/functions/cdist.cpp
@@ -40,7 +40,7 @@ static diopiError_t expand(diopiContextHandle_t ctx, DiopiTensor inputTensor, Di
     CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlExpand(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlExpand(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensorTmp.data()));
     if (outTensor.dtype() != outTensorTmp.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     }
@@ -107,7 +107,7 @@ diopiError_t diopiCdist(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
     CnnlTensorDesc input1Desc(input1TensorExpand, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc input2Desc(input2TensorExpand, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlCdistForward(
+    DIOPI_CALL_CNNL(cnnlCdistForward(
         handle, input1Desc.get(), input1TensorExpand.data(), input2Desc.get(), input2TensorExpand.data(), p, outDesc.get(), outTensorTmp.data()));
     outTensorTmp.view(outputShape);
     if (outTensor.dtype() != outTensorTmp.dtype()) {
@@ -185,18 +185,18 @@ diopiError_t diopiCdistBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gr
     CnnlTensorDesc input2Desc(input2TensorExpand, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc cdistDesc(cdistTensor, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlCdistBackward(handle,
-                                     input1Desc.get(),
-                                     input1TensorExpand.data(),
-                                     input2Desc.get(),
-                                     input2TensorExpand.data(),
-                                     cdistDesc.get(),
-                                     cdistTensor.data(),
-                                     gradOutputDesc.get(),
-                                     gradOutputTensor.data(),
-                                     p,
-                                     gradInputDesc.get(),
-                                     gradInputTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlCdistBackward(handle,
+                                      input1Desc.get(),
+                                      input1TensorExpand.data(),
+                                      input2Desc.get(),
+                                      input2TensorExpand.data(),
+                                      cdistDesc.get(),
+                                      cdistTensor.data(),
+                                      gradOutputDesc.get(),
+                                      gradOutputTensor.data(),
+                                      p,
+                                      gradInputDesc.get(),
+                                      gradInputTensorTmp.data()));
     if (gradInputTensor.dtype() != gradInputTensorTmp.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputTensorTmp));
     }

--- a/impl/camb/functions/clamp.cpp
+++ b/impl/camb/functions/clamp.cpp
@@ -74,7 +74,7 @@ diopiError_t clampCommon(diopiContextHandle_t ctx, diopiConstTensorHandle_t inpu
     DIOPI_CALL(getClampBoundPtr(ctx, min, inputTensor.dtype(), &minPtr));
     DIOPI_CALL(getClampBoundPtr(ctx, max, inputTensor.dtype(), &maxPtr));
 
-    DIOPI_CALLCNNL(
+    DIOPI_CALL_CNNL(
         cnnlClip_v2(handle, CNNL_POINTER_MODE_DEVICE, inputDesc.get(), inputTensor.data(), minPtr, maxPtr, output32Desc.get(), output32Tensor.data()));
     if (outputTensor.dtype() != output32Tensor.dtype()) {
         if (outputTensor.dtype() != diopi_dtype_uint8) {

--- a/impl/camb/functions/col2im.cpp
+++ b/impl/camb/functions/col2im.cpp
@@ -35,19 +35,19 @@ static diopiError_t transposeInternal(diopiContextHandle_t ctx, DiopiTensor outT
     CnnlResourceGuard<cnnlTransposeDescriptor_t, cnnlCreateTransposeDescriptor, cnnlDestroyTransposeDescriptor> cnnlTransposeDesc;
     cnnlTransposeDescriptor_t transposeDesc = cnnlTransposeDesc.get();
     std::vector<int> perms = getPerm(input, dim0, dim1);
-    DIOPI_CALLCNNL(cnnlSetTransposeDescriptor(transposeDesc, perms.size(), perms.data()));
+    DIOPI_CALL_CNNL(cnnlSetTransposeDescriptor(transposeDesc, perms.size(), perms.data()));
 
     CnnlTensorDesc inputDesc(input, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetTransposeWorkspaceSize(handle, inputDesc.get(), transposeDesc, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetTransposeWorkspaceSize(handle, inputDesc.get(), transposeDesc, &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlTranspose_v2(handle, transposeDesc, inputDesc.get(), input.data(), outDesc.get(), outTensor.data(), workspace, workspaceSize));
+    DIOPI_CALL_CNNL(cnnlTranspose_v2(handle, transposeDesc, inputDesc.get(), input.data(), outDesc.get(), outTensor.data(), workspace, workspaceSize));
     return diopiSuccess;
 }
 
@@ -89,20 +89,20 @@ diopiError_t diopiCol2Im(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     cnnlTensorDescriptor_t wDesc = weightDesc.get();
     std::vector<int> weightSizes = {1, 1, kernelSizeHeight, kernelSizeWidth};
     std::vector<int> weightStrides = {1, 1, 1, 1};
-    DIOPI_CALLCNNL(cnnlSetTensorDescriptorEx(wDesc, CNNL_LAYOUT_NCHW, dtype, weightSizes.size(), weightSizes.data(), weightStrides.data()));
+    DIOPI_CALL_CNNL(cnnlSetTensorDescriptorEx(wDesc, CNNL_LAYOUT_NCHW, dtype, weightSizes.size(), weightSizes.data(), weightStrides.data()));
 
     CnnlResourceGuard<cnnlConvolutionDescriptor_t, cnnlCreateConvolutionDescriptor, cnnlDestroyConvolutionDescriptor> cnnlConvDesc;
     cnnlConvolutionDescriptor_t convDesc = cnnlConvDesc.get();
-    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc, 4, vPadding.data(), vStride.data(), vDilation.data(), 1, dtype));
+    DIOPI_CALL_CNNL(cnnlSetConvolutionDescriptor(convDesc, 4, vPadding.data(), vStride.data(), vDilation.data(), 1, dtype));
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetCol2ImWorkspaceSize(handle, inputColDesc.get(), wDesc, outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetCol2ImWorkspaceSize(handle, inputColDesc.get(), wDesc, outDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlCol2Im(handle, inputColDesc.get(), inputCol.data(), wDesc, convDesc, workspace, workspaceSize, outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlCol2Im(handle, inputColDesc.get(), inputCol.data(), wDesc, convDesc, workspace, workspaceSize, outDesc.get(), outTensor.data()));
 
     return diopiSuccess;
 }

--- a/impl/camb/functions/conv_2d.cpp
+++ b/impl/camb/functions/conv_2d.cpp
@@ -44,38 +44,38 @@ diopiError_t convForward(diopiContextHandle_t ctx, DiopiTensor input, DiopiTenso
 
     cnnlDataType_t computeType;
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, input.dtype()));
-    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
+    DIOPI_CALL_CNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
     size_t workspaceSize;
-    DIOPI_CALLCNNL(cnnlGetConvolutionForwardWorkspaceSize(handle,
-                                                          inputDesc.get(),
-                                                          weightDesc.get(),
-                                                          outputDesc.get(),
-                                                          bias.defined() ? biasDesc.get() : nullptr,
-                                                          convDesc.get(),
-                                                          CNNL_CONVOLUTION_FWD_ALGO_DIRECT,
-                                                          &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetConvolutionForwardWorkspaceSize(handle,
+                                                           inputDesc.get(),
+                                                           weightDesc.get(),
+                                                           outputDesc.get(),
+                                                           bias.defined() ? biasDesc.get() : nullptr,
+                                                           convDesc.get(),
+                                                           CNNL_CONVOLUTION_FWD_ALGO_DIRECT,
+                                                           &workspaceSize));
 
     void *workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlConvolutionForward(handle,
-                                          convDesc.get(),
-                                          CNNL_CONVOLUTION_FWD_ALGO_DIRECT,
-                                          nullptr,
-                                          inputDesc.get(),
-                                          input.data(),
-                                          weightDesc.get(),
-                                          weight.data(),
-                                          bias.defined() ? biasDesc.get() : nullptr,
-                                          bias.defined() ? bias.data() : nullptr,
-                                          workspace,
-                                          workspaceSize,
-                                          nullptr,
-                                          outputDesc.get(),
-                                          output.data()));
+    DIOPI_CALL_CNNL(cnnlConvolutionForward(handle,
+                                           convDesc.get(),
+                                           CNNL_CONVOLUTION_FWD_ALGO_DIRECT,
+                                           nullptr,
+                                           inputDesc.get(),
+                                           input.data(),
+                                           weightDesc.get(),
+                                           weight.data(),
+                                           bias.defined() ? biasDesc.get() : nullptr,
+                                           bias.defined() ? bias.data() : nullptr,
+                                           workspace,
+                                           workspaceSize,
+                                           nullptr,
+                                           outputDesc.get(),
+                                           output.data()));
     return diopiSuccess;
 }
 
@@ -99,29 +99,29 @@ diopiError_t convBackwardData(diopiContextHandle_t ctx, DiopiTensor gradOutput, 
 
     cnnlDataType_t computeType;
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, gradInput.dtype()));
-    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
+    DIOPI_CALL_CNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetConvolutionBackwardDataWorkspaceSize(
+    DIOPI_CALL_CNNL(cnnlGetConvolutionBackwardDataWorkspaceSize(
         handle, weightDesc.get(), gradOutputDesc.get(), convDesc.get(), gradInputDesc.get(), CNNL_CONVOLUTION_BWD_DATA_ALGO_DIRECT, &workspaceSize));
 
     void *workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
-    DIOPI_CALLCNNL(cnnlConvolutionBackwardData(handle,
-                                               nullptr,
-                                               weightDesc.get(),
-                                               weight.data(),
-                                               gradOutputDesc.get(),
-                                               gradOutput.data(),
-                                               convDesc.get(),
-                                               CNNL_CONVOLUTION_BWD_DATA_ALGO_DIRECT,
-                                               workspace,
-                                               workspaceSize,
-                                               nullptr,
-                                               gradInputDesc.get(),
-                                               gradInput.data()));
+    DIOPI_CALL_CNNL(cnnlConvolutionBackwardData(handle,
+                                                nullptr,
+                                                weightDesc.get(),
+                                                weight.data(),
+                                                gradOutputDesc.get(),
+                                                gradOutput.data(),
+                                                convDesc.get(),
+                                                CNNL_CONVOLUTION_BWD_DATA_ALGO_DIRECT,
+                                                workspace,
+                                                workspaceSize,
+                                                nullptr,
+                                                gradInputDesc.get(),
+                                                gradInput.data()));
 
     return diopiSuccess;
 }
@@ -145,10 +145,10 @@ diopiError_t convBackwardFilter(diopiContextHandle_t ctx, DiopiTensor gradOutput
 
     cnnlDataType_t computeType;
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, gradOutput.dtype()));
-    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
+    DIOPI_CALL_CNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetConvolutionBackwardFilterWorkspaceSize(
+    DIOPI_CALL_CNNL(cnnlGetConvolutionBackwardFilterWorkspaceSize(
         handle, inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), convDesc.get(), CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT, &workspaceSize));
 
     void *workspace = nullptr;
@@ -156,19 +156,19 @@ diopiError_t convBackwardFilter(diopiContextHandle_t ctx, DiopiTensor gradOutput
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlConvolutionBackwardFilter(handle,
-                                                 nullptr,
-                                                 inputDesc.get(),
-                                                 input.data(),
-                                                 gradOutputDesc.get(),
-                                                 gradOutput.data(),
-                                                 convDesc.get(),
-                                                 CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT,
-                                                 workspace,
-                                                 workspaceSize,
-                                                 nullptr,
-                                                 gradWeightDesc.get(),
-                                                 gradWeight.data()));
+    DIOPI_CALL_CNNL(cnnlConvolutionBackwardFilter(handle,
+                                                  nullptr,
+                                                  inputDesc.get(),
+                                                  input.data(),
+                                                  gradOutputDesc.get(),
+                                                  gradOutput.data(),
+                                                  convDesc.get(),
+                                                  CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT,
+                                                  workspace,
+                                                  workspaceSize,
+                                                  nullptr,
+                                                  gradWeightDesc.get(),
+                                                  gradWeight.data()));
     return diopiSuccess;
 }
 
@@ -180,12 +180,12 @@ diopiError_t convBackwardBias(diopiContextHandle_t ctx, DiopiTensor gradOutput, 
     size_t workspaceSizeBias;
     int channelAxis = 3;
 
-    DIOPI_CALLCNNL(cnnlGetBiasAddBackwardWorkspaceSize(handle, gradOutputDesc.get(), biasGradDesc.get(), channelAxis, &workspaceSizeBias))
+    DIOPI_CALL_CNNL(cnnlGetBiasAddBackwardWorkspaceSize(handle, gradOutputDesc.get(), biasGradDesc.get(), channelAxis, &workspaceSizeBias))
     void *workspaceBias = nullptr;
     if (0 != workspaceSizeBias) {
         workspaceBias = requiresBuffer(ctx, workspaceSizeBias).data();
     }
-    DIOPI_CALLCNNL(cnnlBiasAddBackward_v2(
+    DIOPI_CALL_CNNL(cnnlBiasAddBackward_v2(
         handle, gradOutputDesc.get(), gradOutput.data(), channelAxis, biasGradDesc.get(), gradBias.data(), workspaceBias, workspaceSizeBias));
     return diopiSuccess;
 }
@@ -285,7 +285,7 @@ diopiError_t diopiConvTranspose2d(diopiContextHandle_t ctx, diopiTensorHandle_t 
         CnnlTensorDesc biasDesc(biasTensor, CNNL_LAYOUT_NHWC);
         CnnlTensorDesc outputDesc(outputTensorTmp, CNNL_LAYOUT_NHWC);
         size_t workspaceSizeBias;
-        DIOPI_CALLCNNL(cnnlGetBiasAddWorkspaceSize(handle, biasDesc.get(), outputDesc.get(), &workspaceSizeBias));
+        DIOPI_CALL_CNNL(cnnlGetBiasAddWorkspaceSize(handle, biasDesc.get(), outputDesc.get(), &workspaceSizeBias));
 
         void *workspaceBias = nullptr;
         if (workspaceSizeBias != 0) {
@@ -293,7 +293,7 @@ diopiError_t diopiConvTranspose2d(diopiContextHandle_t ctx, diopiTensorHandle_t 
         }
         float alpha = 1.0;
         float beta = 1.0;
-        DIOPI_CALLCNNL(
+        DIOPI_CALL_CNNL(
             cnnlBiasAdd(handle, &alpha, biasDesc.get(), biasTensor.data(), workspaceBias, workspaceSizeBias, &beta, outputDesc.get(), outputTensorTmp.data()));
     }
 

--- a/impl/camb/functions/copy.cpp
+++ b/impl/camb/functions/copy.cpp
@@ -28,7 +28,7 @@ diopiError_t diopiCopyInp(diopiContextHandle_t ctx, diopiConstTensorHandle_t src
     CnnlTensorDesc inputDesc(destTr, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc srcDesc(srcTr, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlCopy(handle, srcDesc.get(), srcTr.data(), inputDesc.get(), destTr.data()));
+    DIOPI_CALL_CNNL(cnnlCopy(handle, srcDesc.get(), srcTr.data(), inputDesc.get(), destTr.data()));
 
     return diopiSuccess;
 }

--- a/impl/camb/functions/cos.cpp
+++ b/impl/camb/functions/cos.cpp
@@ -24,7 +24,7 @@ static diopiError_t cos(diopiContextHandle_t ctx, DiopiTensor input, DiopiTensor
     }
     CnnlTensorDesc inputDesc(input, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outputTmpDesc(outputTmp, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlCos_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, inputDesc.get(), input.data(), outputTmpDesc.get(), outputTmp.data()));
+    DIOPI_CALL_CNNL(cnnlCos_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, inputDesc.get(), input.data(), outputTmpDesc.get(), outputTmp.data()));
     if (outputTmp.dtype() != output.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, output, outputTmp));
     }

--- a/impl/camb/functions/ctc_loss.cpp
+++ b/impl/camb/functions/ctc_loss.cpp
@@ -59,29 +59,29 @@ static diopiError_t ctcLoss(diopiContextHandle_t ctx, DiopiTensor lossTensor, Di
     CnnlTensorDesc targetLengthsDesc(targetLengths, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetCTCLossWorkspaceSize(handle, ctcLossDesc, logProbsTensorDesc.get(), backward, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetCTCLossWorkspaceSize(handle, ctcLossDesc, logProbsTensorDesc.get(), backward, &workspaceSize));
     void *workspace = nullptr;
     if (workspaceSize > 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
         DIOPI_CHECK(workspace != nullptr, "[diopiCTCLoss] require buffers: size = %d, for workspace failed.", workspaceSize);
     }
 
-    DIOPI_CALLCNNL(cnnlCTCLoss(handle,
-                               ctcLossDesc,
-                               logProbsTensorDesc.get(),
-                               logProbsTensor.data(),
-                               targetTensorDesc.get(),
-                               targetTensor.data(),
-                               inputLengthsDesc.get(),
-                               inputLengths.data(),
-                               targetLengthsDesc.get(),
-                               targetLengths.data(),
-                               workspace,
-                               workspaceSize,
-                               lossTensorDesc.get(),
-                               lossTensor.data(),
-                               backward ? gradTensorDesc.get() : nullptr,
-                               backward ? gradTensor.data() : nullptr));
+    DIOPI_CALL_CNNL(cnnlCTCLoss(handle,
+                                ctcLossDesc,
+                                logProbsTensorDesc.get(),
+                                logProbsTensor.data(),
+                                targetTensorDesc.get(),
+                                targetTensor.data(),
+                                inputLengthsDesc.get(),
+                                inputLengths.data(),
+                                targetLengthsDesc.get(),
+                                targetLengths.data(),
+                                workspace,
+                                workspaceSize,
+                                lossTensorDesc.get(),
+                                lossTensor.data(),
+                                backward ? gradTensorDesc.get() : nullptr,
+                                backward ? gradTensor.data() : nullptr));
     return diopiSuccess;
 }
 
@@ -124,7 +124,7 @@ diopiError_t diopiCTCLoss(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     DIOPI_CALL(convertCTCLossReduction(&ctcLossReduceMode, reduction));
     cnnlCTCLossZeroInfinityMode_t ctcLossZeroInfMode = zeroInfinity ? CNNL_ZERO_INFINITY : CNNL_NONE_ZERO_INFINITY;
 
-    DIOPI_CALLCNNL(cnnlSetCTCLossDescriptor(ctcLossDesc, ctcLossNormMode, ctcLossReduceMode, ctcLossZeroInfMode, blank, maxInputLength, maxTargetLen));
+    DIOPI_CALL_CNNL(cnnlSetCTCLossDescriptor(ctcLossDesc, ctcLossNormMode, ctcLossReduceMode, ctcLossZeroInfMode, blank, maxInputLength, maxTargetLen));
 
     DiopiTensor gradTensor = requiresTensor(ctx, logProbsTensor.shape(), logProbsTensor.dtype());
     DIOPI_CALL(ctcLoss(ctx, outTensorTemp, gradTensor, logProbsTensor, targetTensor, inputLengthsTensor, targetLengthTensor, ctcLossDesc, false));
@@ -176,7 +176,7 @@ diopiError_t diopiCTCLossBackward(diopiContextHandle_t ctx, diopiTensorHandle_t 
     DIOPI_CALL(convertCTCLossReduction(&ctcLossReduceMode, reduction));
     cnnlCTCLossZeroInfinityMode_t ctcLossZeroInfMode = zeroInfinity ? CNNL_ZERO_INFINITY : CNNL_NONE_ZERO_INFINITY;
 
-    DIOPI_CALLCNNL(cnnlSetCTCLossDescriptor(ctcLossDesc, ctcLossNormMode, ctcLossReduceMode, ctcLossZeroInfMode, blank, maxInputLength, maxTargetLen));
+    DIOPI_CALL_CNNL(cnnlSetCTCLossDescriptor(ctcLossDesc, ctcLossNormMode, ctcLossReduceMode, ctcLossZeroInfMode, blank, maxInputLength, maxTargetLen));
 
     DiopiTensor lossTensor;
     if (ctcLossReduceMode == CNNL_REDUCE_MODE_NONE) {

--- a/impl/camb/functions/cumsum.cpp
+++ b/impl/camb/functions/cumsum.cpp
@@ -30,11 +30,11 @@ diopiError_t diopiCumsum(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     int axis = getDim(inputTensor, dim);
 
     if (inputTensor.dtype() == outTensor.dtype()) {
-        DIOPI_CALLCNNL(cnnlCumsum(handle, inputDesc.get(), inputTensor.data(), axis, false, false, CNNL_PROPAGATE_NAN, outDesc.get(), outTensor.data()));
+        DIOPI_CALL_CNNL(cnnlCumsum(handle, inputDesc.get(), inputTensor.data(), axis, false, false, CNNL_PROPAGATE_NAN, outDesc.get(), outTensor.data()));
     } else {
         DiopiTensor outTemp = requiresTensor(ctx, outTensor.shape(), inputTensor.dtype());
         CnnlTensorDesc outTempDesc(outTemp, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlCumsum(handle, inputDesc.get(), inputTensor.data(), axis, false, false, CNNL_PROPAGATE_NAN, outTempDesc.get(), outTemp.data()));
+        DIOPI_CALL_CNNL(cnnlCumsum(handle, inputDesc.get(), inputTensor.data(), axis, false, false, CNNL_PROPAGATE_NAN, outTempDesc.get(), outTemp.data()));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTemp));
     }
 

--- a/impl/camb/functions/div.cpp
+++ b/impl/camb/functions/div.cpp
@@ -32,46 +32,46 @@ DIOPI_API diopiError_t diopiDiv(diopiContextHandle_t ctx, diopiTensorHandle_t ou
 
     switch (roundingMode) {
         case RoundModeFloor:
-            DIOPI_CALLCNNL(cnnlGetFloorDivWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
+            DIOPI_CALL_CNNL(cnnlGetFloorDivWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
             workspace = requiresBuffer(ctx, workspaceSize).data();
-            DIOPI_CALLCNNL(cnnlFloorDiv_v2(handle,
-                                           preferFloor,
-                                           inputDesc.get(),
-                                           inputTensor.data(),
-                                           otherDesc.get(),
-                                           otherTensor.data(),
-                                           outDesc.get(),
-                                           outTensorTemp.data(),
-                                           workspace,
-                                           workspaceSize));
+            DIOPI_CALL_CNNL(cnnlFloorDiv_v2(handle,
+                                            preferFloor,
+                                            inputDesc.get(),
+                                            inputTensor.data(),
+                                            otherDesc.get(),
+                                            otherTensor.data(),
+                                            outDesc.get(),
+                                            outTensorTemp.data(),
+                                            workspace,
+                                            workspaceSize));
             break;
         case RoundModeTrunc:
-            DIOPI_CALLCNNL(cnnlGetFloorDivTruncWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
+            DIOPI_CALL_CNNL(cnnlGetFloorDivTruncWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
             workspace = requiresBuffer(ctx, workspaceSize).data();
-            DIOPI_CALLCNNL(cnnlFloorDivTrunc(handle,
-                                             prefer,
-                                             inputDesc.get(),
-                                             inputTensor.data(),
-                                             otherDesc.get(),
-                                             otherTensor.data(),
-                                             outDesc.get(),
-                                             outTensorTemp.data(),
-                                             workspace,
-                                             workspaceSize));
+            DIOPI_CALL_CNNL(cnnlFloorDivTrunc(handle,
+                                              prefer,
+                                              inputDesc.get(),
+                                              inputTensor.data(),
+                                              otherDesc.get(),
+                                              otherTensor.data(),
+                                              outDesc.get(),
+                                              outTensorTemp.data(),
+                                              workspace,
+                                              workspaceSize));
             break;
         case RoundModeNone:
-            DIOPI_CALLCNNL(cnnlGetDivWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
+            DIOPI_CALL_CNNL(cnnlGetDivWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
             workspace = requiresBuffer(ctx, workspaceSize).data();
-            DIOPI_CALLCNNL(cnnlDiv_v2(handle,
-                                      prefer,
-                                      inputDesc.get(),
-                                      inputTensor.data(),
-                                      otherDesc.get(),
-                                      otherTensor.data(),
-                                      workspace,
-                                      workspaceSize,
-                                      outDesc.get(),
-                                      outTensorTemp.data()));
+            DIOPI_CALL_CNNL(cnnlDiv_v2(handle,
+                                       prefer,
+                                       inputDesc.get(),
+                                       inputTensor.data(),
+                                       otherDesc.get(),
+                                       otherTensor.data(),
+                                       workspace,
+                                       workspaceSize,
+                                       outDesc.get(),
+                                       outTensorTemp.data()));
 
             break;
         default:

--- a/impl/camb/functions/dropout.cpp
+++ b/impl/camb/functions/dropout.cpp
@@ -39,7 +39,7 @@ diopiError_t diopiDropout(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
         // create and set the rand_generator
         cnnlRandGenerator_t generator;
         // MTGP32 algorithm performs better on MLU300 series than MLU200 series
-        DIOPI_CALLCNNL(cnnlRandCreateGenerator(&generator, CNNL_RAND_RNG_MTGP32));
+        DIOPI_CALL_CNNL(cnnlRandCreateGenerator(&generator, CNNL_RAND_RNG_MTGP32));
         diopiTensorHandle_t stateHandle = nullptr;
         DIOPI_CALL(diopiGeneratorGetState(ctx, gen, &stateHandle));
         void* statePtr = nullptr;
@@ -50,7 +50,7 @@ diopiError_t diopiDropout(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
             DiopiTensor tempTensor = ones(ctx, maskTensor.shape(), diopi_dtype_float32);
             CnnlTensorDesc tempDesc(tempTensor, CNNL_LAYOUT_ARRAY);
 
-            DIOPI_CALLCNNL(cnnlFusedDropout_v2(
+            DIOPI_CALL_CNNL(cnnlFusedDropout_v2(
                 handle, generator, tempDesc.get(), tempTensor.data(), p, statePtr, maskDesc.get(), maskTensor.data(), tempDesc.get(), tempTensor.data()));
 
             DiopiTensor bcastTempTensor;
@@ -60,25 +60,25 @@ diopiError_t diopiDropout(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
 
             cnnlTensorDescriptor_t inputDescs[] = {inputDesc.get(), bcastTempDesc.get()};
             const void* inputs[] = {inputTensor.data(), bcastTempTensor.data()};
-            DIOPI_CALLCNNL(cnnlMulN(handle, inputDescs, inputs, 2, outputDesc.get(), outputTensorTemp.data()))
+            DIOPI_CALL_CNNL(cnnlMulN(handle, inputDescs, inputs, 2, outputDesc.get(), outputTensorTemp.data()))
         } else {
             // cases for dropout
-            DIOPI_CALLCNNL(cnnlFusedDropout_v2(handle,
-                                               generator,
-                                               inputDesc.get(),
-                                               inputTensor.data(),
-                                               p,
-                                               statePtr,
-                                               maskDesc.get(),
-                                               maskTensor.data(),
-                                               outputDesc.get(),
-                                               outputTensorTemp.data()));
+            DIOPI_CALL_CNNL(cnnlFusedDropout_v2(handle,
+                                                generator,
+                                                inputDesc.get(),
+                                                inputTensor.data(),
+                                                p,
+                                                statePtr,
+                                                maskDesc.get(),
+                                                maskTensor.data(),
+                                                outputDesc.get(),
+                                                outputTensorTemp.data()));
         }
         if (outputTensorTemp.dtype() != outputTensor.dtype()) {
             DIOPI_CALL(dataTypeCast(ctx, outputTensor, outputTensorTemp));
         }
         DIOPI_CALL(diopiGeneratorSetState(gen, stateHandle));
-        DIOPI_CALLCNNL(cnnlRandDestroyGenerator(generator));
+        DIOPI_CALL_CNNL(cnnlRandDestroyGenerator(generator));
 
     } else {  // if in test_mode
         DIOPI_CALL(diopiCopyInp(ctx, input, out));

--- a/impl/camb/functions/embedding.cpp
+++ b/impl/camb/functions/embedding.cpp
@@ -41,16 +41,16 @@ diopiError_t diopiEmbedding(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     CnnlTensorDesc weightDesc(weightTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc indicesDesc(indicesTensor, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlEmbeddingForward_v2(handle,
-                                           weightDesc.get(),
-                                           weightTensor.data(),
-                                           indicesDesc.get(),
-                                           static_cast<const int *>(indicesTensor.data()),
-                                           paddingIdxCasted,
-                                           nullptr,
-                                           nullptr,
-                                           outDesc.get(),
-                                           outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlEmbeddingForward_v2(handle,
+                                            weightDesc.get(),
+                                            weightTensor.data(),
+                                            indicesDesc.get(),
+                                            static_cast<const int *>(indicesTensor.data()),
+                                            paddingIdxCasted,
+                                            nullptr,
+                                            nullptr,
+                                            outDesc.get(),
+                                            outTensorTmp.data()));
     if (outTensorTmp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     }
@@ -97,24 +97,24 @@ diopiError_t diopiEmbeddingBackward(diopiContextHandle_t ctx, diopiTensorHandle_
 
     size_t workspaceSize = 0;
 
-    DIOPI_CALLCNNL(cnnlGetEmbeddingBackwardWorkspaceSize(handle, gradDesc.get(), outDesc.get(), scaleGradByfreq, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetEmbeddingBackwardWorkspaceSize(handle, gradDesc.get(), outDesc.get(), scaleGradByfreq, &workspaceSize));
 
     void *workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlEmbeddingBackward(handle,
-                                         paddingIdxCasted,
-                                         scaleGradByfreq,
-                                         indicesDesc.get(),
-                                         indicesTensor.data(),
-                                         gradDesc.get(),
-                                         gradTensor.data(),
-                                         workspace,
-                                         workspaceSize,
-                                         outDesc.get(),
-                                         outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlEmbeddingBackward(handle,
+                                          paddingIdxCasted,
+                                          scaleGradByfreq,
+                                          indicesDesc.get(),
+                                          indicesTensor.data(),
+                                          gradDesc.get(),
+                                          gradTensor.data(),
+                                          workspace,
+                                          workspaceSize,
+                                          outDesc.get(),
+                                          outTensorTmp.data()));
     if (outTensorTmp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     }

--- a/impl/camb/functions/erf.cpp
+++ b/impl/camb/functions/erf.cpp
@@ -28,7 +28,7 @@ diopiError_t diopiErf(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
     CnnlTensorDesc outDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
 
     cnnlComputationPreference_t prefer = CNNL_COMPUTATION_HIGH_PRECISION;
-    DIOPI_CALLCNNL(cnnlErf_v2(handle, prefer, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlErf_v2(handle, prefer, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensorTemp.data()));
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));
     }

--- a/impl/camb/functions/erfinv.cpp
+++ b/impl/camb/functions/erfinv.cpp
@@ -35,7 +35,7 @@ DIOPI_API diopiError_t diopiErfinv(diopiContextHandle_t ctx, diopiTensorHandle_t
     CnnlTensorDesc outDesc(outCastedTensor, CNNL_LAYOUT_ARRAY);
 
     cnnlComputationPreference_t computePrefer = CNNL_COMPUTATION_HIGH_PRECISION;
-    DIOPI_CALLCNNL(cnnlErfinv(handle, computePrefer, inputDesc.get(), inputCastedTensor.data(), outDesc.get(), outCastedTensor.data()));
+    DIOPI_CALL_CNNL(cnnlErfinv(handle, computePrefer, inputDesc.get(), inputCastedTensor.data(), outDesc.get(), outCastedTensor.data()));
     if (outCastedTensor.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outCastedTensor));
     }

--- a/impl/camb/functions/exp.cpp
+++ b/impl/camb/functions/exp.cpp
@@ -23,7 +23,7 @@ static diopiError_t exp(diopiContextHandle_t ctx, DiopiTensor input, DiopiTensor
         outputTmp = requiresTensor(ctx, output.shape(), input.dtype());
     }
     CnnlTensorDesc desc(input, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlExp_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, desc.get(), input.data(), desc.get(), outputTmp.data()));
+    DIOPI_CALL_CNNL(cnnlExp_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, desc.get(), input.data(), desc.get(), outputTmp.data()));
     if (output.dtype() != outputTmp.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, output, outputTmp));
     }

--- a/impl/camb/functions/expand.cpp
+++ b/impl/camb/functions/expand.cpp
@@ -41,7 +41,7 @@ diopiError_t diopiExpand(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
         descOut.set(trOutTmp, CNNL_LAYOUT_ARRAY);
     }
 
-    DIOPI_CALLCNNL(cnnlExpand(handle, descInput.get(), trInput.data(), descOut.get(), trOutTmp.data()));
+    DIOPI_CALL_CNNL(cnnlExpand(handle, descInput.get(), trInput.data(), descOut.get(), trOutTmp.data()));
     if (trOutTmp.dtype() != trOut.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, trOut, trOutTmp));
     }

--- a/impl/camb/functions/fill.cpp
+++ b/impl/camb/functions/fill.cpp
@@ -100,7 +100,7 @@ diopiError_t diopiFill(diopiContextHandle_t ctx, diopiTensorHandle_t input, cons
         }
     }
 
-    DIOPI_CALLCNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, valuePtr, inputTensorDesc.get(), inputTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, valuePtr, inputTensorDesc.get(), inputTensorTemp.data()));
 
     if (inputTensorTemp.dtype() != inputTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, inputTensor, inputTensorTemp));

--- a/impl/camb/functions/flip.cpp
+++ b/impl/camb/functions/flip.cpp
@@ -26,11 +26,11 @@ diopiError_t diopiFlip(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
     }
 
     if (outTensor.dtype() == inputTensor.dtype()) {
-        DIOPI_CALLCNNL(cnnlFlip(handle, dimension.data(), dims.len, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
+        DIOPI_CALL_CNNL(cnnlFlip(handle, dimension.data(), dims.len, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
     } else {
         DiopiTensor outTemp = requiresTensor(ctx, outTensor.shape(), inputTensor.dtype());
         CnnlTensorDesc outTempDesc(outTemp, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlFlip(handle, dimension.data(), dims.len, inputDesc.get(), inputTensor.data(), outTempDesc.get(), outTemp.data()));
+        DIOPI_CALL_CNNL(cnnlFlip(handle, dimension.data(), dims.len, inputDesc.get(), inputTensor.data(), outTempDesc.get(), outTemp.data()));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTemp));
     }
     return diopiSuccess;

--- a/impl/camb/functions/floor.cpp
+++ b/impl/camb/functions/floor.cpp
@@ -42,7 +42,7 @@ diopiError_t diopiFloor(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
         descOut.set(trOutTmp, CNNL_LAYOUT_ARRAY);
     }
 
-    DIOPI_CALLCNNL(cnnlFloor(handle, descInput.get(), trInput.data(), descOut.get(), trOutTmp.data()));
+    DIOPI_CALL_CNNL(cnnlFloor(handle, descInput.get(), trInput.data(), descOut.get(), trOutTmp.data()));
     if (trOutTmp.dtype() != trOut.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, trOut, trOutTmp));
     }

--- a/impl/camb/functions/gather.cpp
+++ b/impl/camb/functions/gather.cpp
@@ -31,12 +31,12 @@ DIOPI_API diopiError_t diopiGather(diopiContextHandle_t ctx, diopiTensorHandle_t
     }
 
     if (outTensor.dtype() == inputTensor.dtype()) {
-        DIOPI_CALLCNNL(cnnlGather(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outDesc.get(), outTensor.data()));
+        DIOPI_CALL_CNNL(cnnlGather(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outDesc.get(), outTensor.data()));
     } else {
         DiopiTensor outTemp = outTensor;
         DIOPI_CALL(dataTypeCast(ctx, outTemp, inputTensor.dtype()));
         CnnlTensorDesc outTempDesc(outTemp, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlGather(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outTempDesc.get(), outTemp.data()));
+        DIOPI_CALL_CNNL(cnnlGather(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outTempDesc.get(), outTemp.data()));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTemp));
     }
 
@@ -70,17 +70,17 @@ DIOPI_API diopiError_t diopiGatherBackward(diopiContextHandle_t ctx, diopiTensor
     CnnlTensorDesc outTempDesc(outTemp, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc gradOutputDesc(gradOutputTensor, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlScatter(handle,
-                               dim,
-                               outTempDesc.get(),
-                               outTemp.data(),
-                               indexDesc.get(),
-                               indexTensor.data(),
-                               gradOutputDesc.get(),
-                               gradOutputTensor.data(),
-                               outTempDesc.get(),
-                               outTemp.data(),
-                               CNNL_SCATTER_ADD));
+    DIOPI_CALL_CNNL(cnnlScatter(handle,
+                                dim,
+                                outTempDesc.get(),
+                                outTemp.data(),
+                                indexDesc.get(),
+                                indexTensor.data(),
+                                gradOutputDesc.get(),
+                                gradOutputTensor.data(),
+                                outTempDesc.get(),
+                                outTemp.data(),
+                                CNNL_SCATTER_ADD));
     DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, outTemp));
 
     return diopiSuccess;

--- a/impl/camb/functions/groupnorm.cpp
+++ b/impl/camb/functions/groupnorm.cpp
@@ -47,7 +47,7 @@ DIOPI_API diopiError_t diopiGroupNorm(diopiContextHandle_t ctx, diopiTensorHandl
     CnnlTensorDesc saveMeanDesc(saveMeanTensor, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetGroupNormForwardWorkspaceSize(handle, numGroups, inputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetGroupNormForwardWorkspaceSize(handle, numGroups, inputDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -56,21 +56,21 @@ DIOPI_API diopiError_t diopiGroupNorm(diopiContextHandle_t ctx, diopiTensorHandl
     if (eps < 0) {
         eps = 1e-5;
     }
-    DIOPI_CALLCNNL(cnnlGroupNormForward_v3(handle,
-                                           eps,
-                                           numGroups,
-                                           inputDesc.get(),
-                                           inputTensor.data(),
-                                           weightDesc.get(),
-                                           weightTensor.data(),
-                                           biasTensor.data(),
-                                           workspace,
-                                           workspaceSize,
-                                           outDesc.get(),
-                                           outTensor.data(),
-                                           saveMeanDesc.get(),
-                                           saveMeanTensor.data(),
-                                           saveInvstdTensor.data()));
+    DIOPI_CALL_CNNL(cnnlGroupNormForward_v3(handle,
+                                            eps,
+                                            numGroups,
+                                            inputDesc.get(),
+                                            inputTensor.data(),
+                                            weightDesc.get(),
+                                            weightTensor.data(),
+                                            biasTensor.data(),
+                                            workspace,
+                                            workspaceSize,
+                                            outDesc.get(),
+                                            outTensor.data(),
+                                            saveMeanDesc.get(),
+                                            saveMeanTensor.data(),
+                                            saveInvstdTensor.data()));
     return diopiSuccess;
 }
 
@@ -135,32 +135,32 @@ DIOPI_API diopiError_t diopiGroupNormBackward(diopiContextHandle_t ctx, diopiTen
     CnnlTensorDesc gradOutputDesc(gradOutputTensor, CNNL_LAYOUT_NCHW);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetGroupNormBackwardWorkspaceSize(handle, inputTensor.shape()[0] * inputTensor.shape()[1], &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetGroupNormBackwardWorkspaceSize(handle, inputTensor.shape()[0] * inputTensor.shape()[1], &workspaceSize));
     void* workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlGroupNormBackward(handle,
-                                         inputDesc.get(),
-                                         inputTensor.data(),
-                                         gradOutputDesc.get(),
-                                         gradOutputTensor.data(),
-                                         weightDesc.get(),
-                                         weightTensor.data(),
-                                         meanDesc.get(),
-                                         meanTensor.data(),
-                                         rstdDesc.get(),
-                                         rstdTensor.data(),
-                                         numGroups,
-                                         gradInputDesc.get(),
-                                         gradInputTensor.data(),
-                                         gradWeightDesc.get(),
-                                         gradWeightTensor.data(),
-                                         gradBiasDesc.get(),
-                                         gradBiasTensor.data(),
-                                         workspace,
-                                         workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGroupNormBackward(handle,
+                                          inputDesc.get(),
+                                          inputTensor.data(),
+                                          gradOutputDesc.get(),
+                                          gradOutputTensor.data(),
+                                          weightDesc.get(),
+                                          weightTensor.data(),
+                                          meanDesc.get(),
+                                          meanTensor.data(),
+                                          rstdDesc.get(),
+                                          rstdTensor.data(),
+                                          numGroups,
+                                          gradInputDesc.get(),
+                                          gradInputTensor.data(),
+                                          gradWeightDesc.get(),
+                                          gradWeightTensor.data(),
+                                          gradBiasDesc.get(),
+                                          gradBiasTensor.data(),
+                                          workspace,
+                                          workspaceSize));
 
     return diopiSuccess;
 }

--- a/impl/camb/functions/hardtanh.cpp
+++ b/impl/camb/functions/hardtanh.cpp
@@ -29,7 +29,7 @@ diopiError_t diopiHardtanh(diopiContextHandle_t ctx, diopiTensorHandle_t out, di
     min = min > max ? max : min;
     // DIOPI_CHECK(max > min, "assert max.val > min.val");
 
-    DIOPI_CALLCNNL(cnnlHardtanh(handle, inputDesc.get(), inputTensor.data(), max, min, outDesc.get(), outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlHardtanh(handle, inputDesc.get(), inputTensor.data(), max, min, outDesc.get(), outTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
 
     return diopiSuccess;
@@ -61,7 +61,7 @@ diopiError_t diopiHardtanhBackward(diopiContextHandle_t ctx, diopiTensorHandle_t
     min = min > max ? max : min;
     // DIOPI_CHECK(max > min, "assert max.val > min.val");
 
-    DIOPI_CALLCNNL(cnnlHardtanhBackward(
+    DIOPI_CALL_CNNL(cnnlHardtanhBackward(
         handle, inputDesc.get(), inputTensor.data(), gradOutDesc.get(), gradOutTensor.data(), max, min, gradInDesc.get(), gradInputTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputTensorTmp));
     return diopiSuccess;

--- a/impl/camb/functions/im2col.cpp
+++ b/impl/camb/functions/im2col.cpp
@@ -91,17 +91,17 @@ diopiError_t im2colOutInternal(diopiContextHandle_t ctx, DiopiTensor& output, co
     cnnlDataType_t computeType;
     std::vector<int32_t> paddingTmp{padding[0], padding[0], padding[1], padding[1]};
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, outputTr.dtype()));
-    DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), inputTr.dim(), paddingTmp.data(), stride.data(), dilation.data(), groups, computeType));
+    DIOPI_CALL_CNNL(cnnlSetConvolutionDescriptor(convDesc.get(), inputTr.dim(), paddingTmp.data(), stride.data(), dilation.data(), groups, computeType));
 
     auto inputPtr = inputTr.data();
     auto outputPtr = outputTr.data();
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetIm2ColWorkspaceSize(handle, descInput.get(), descWeight.get(), convDesc.get(), descOutput.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetIm2ColWorkspaceSize(handle, descInput.get(), descWeight.get(), convDesc.get(), descOutput.get(), &workspaceSize));
     void* workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
-    DIOPI_CALLCNNL(cnnlIm2Col(
+    DIOPI_CALL_CNNL(cnnlIm2Col(
         handle, descInput.get(), inputPtr, descWeight.get(), convDesc.get(), nullptr, nullptr, nullptr, workspace, workspaceSize, descOutput.get(), outputPtr));
     return diopiSuccess;
 }

--- a/impl/camb/functions/index.cpp
+++ b/impl/camb/functions/index.cpp
@@ -180,27 +180,27 @@ static diopiError_t indexPut(diopiContextHandle_t ctx, diopiTensorHandle_t out, 
     CnnlTensorDesc outputDesc(outputTensor, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(
+    DIOPI_CALL_CNNL(
         cnnlGetIndexPutWorkspaceSize(handle, inputDesc.get(), indicesDescT.data(), indicesDescT.size(), valuesDesc.get(), accumulate, &workspaceSize));
     void* workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlIndexPut(handle,
-                                inputDesc.get(),
-                                inputTensor.data(),
-                                indicesDescT.data(),
-                                indicesPtrList.data(),
-                                indicesDescT.size(),
-                                valuesDesc.get(),
-                                valuesTensor.data(),
-                                workspace,
-                                workspaceSize,
-                                accumulate,
-                                true,
-                                outputDesc.get(),
-                                outputTensor.data()));
+    DIOPI_CALL_CNNL(cnnlIndexPut(handle,
+                                 inputDesc.get(),
+                                 inputTensor.data(),
+                                 indicesDescT.data(),
+                                 indicesPtrList.data(),
+                                 indicesDescT.size(),
+                                 valuesDesc.get(),
+                                 valuesTensor.data(),
+                                 workspace,
+                                 workspaceSize,
+                                 accumulate,
+                                 true,
+                                 outputDesc.get(),
+                                 outputTensor.data()));
     return diopiSuccess;
 }
 
@@ -243,7 +243,7 @@ diopiError_t diopiIndex(diopiContextHandle_t ctx, diopiTensorHandle_t* out, diop
 
     int32_t outputDescDim = 0;
     std::vector<int32_t> outputDescDims(arraySize);
-    DIOPI_CALLCNNL(cnnlGetAdvancedIndexOutputDim(handle, inputDesc.get(), indicesDescT.data(), &outputDescDim, outputDescDims.data()));
+    DIOPI_CALL_CNNL(cnnlGetAdvancedIndexOutputDim(handle, inputDesc.get(), indicesDescT.data(), &outputDescDim, outputDescDims.data()));
     outputDescDims.resize(outputDescDim);
 
     std::vector<int64_t> outTensorShape(outputDescDims.begin(), outputDescDims.end());
@@ -255,23 +255,23 @@ diopiError_t diopiIndex(diopiContextHandle_t ctx, diopiTensorHandle_t* out, diop
     cnrtMemcpy(outputDim.data(), &outputDescDim, sizeof(int32_t), cnrtMemcpyHostToDev);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetAdvancedIndexWorkspaceSize(handle, inputDesc.get(), indicesDescT.data(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetAdvancedIndexWorkspaceSize(handle, inputDesc.get(), indicesDescT.data(), &workspaceSize));
     void* workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlAdvancedIndex(handle,
-                                     inputDesc.get(),
-                                     inputTensorTmp.data(),
-                                     indicesDescT.data(),
-                                     indicesPtrList.data(),
-                                     workspace,
-                                     workspaceSize,
-                                     outDesc.get(),
-                                     outTensor.data(),
-                                     outputDims.data(),
-                                     outputDim.data()));
+    DIOPI_CALL_CNNL(cnnlAdvancedIndex(handle,
+                                      inputDesc.get(),
+                                      inputTensorTmp.data(),
+                                      indicesDescT.data(),
+                                      indicesPtrList.data(),
+                                      workspace,
+                                      workspaceSize,
+                                      outDesc.get(),
+                                      outTensor.data(),
+                                      outputDims.data(),
+                                      outputDim.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, inputTensor.dtype()));
     *out = diopiTensorHandle_t(outTensor);
     return diopiSuccess;

--- a/impl/camb/functions/index_put.cpp
+++ b/impl/camb/functions/index_put.cpp
@@ -90,25 +90,25 @@ diopiError_t diopiIndexPut(diopiContextHandle_t ctx, diopiTensorHandle_t out, di
     }
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(
+    DIOPI_CALL_CNNL(
         cnnlGetIndexPutWorkspaceSize(handle, inputDesc.get(), indicesDescs.data(), indicesDescs.size(), valuesDesc.get(), accumulate, &workspaceSize));
 
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlIndexPut(handle,
-                                inputDesc.get(),
-                                inputTensor.data(),
-                                indicesDescs.data(),
-                                indicesPtrList.data(),
-                                indicesDescs.size(),
-                                valuesDesc.get(),
-                                valuesTensor.data(),
-                                workspacePtr,
-                                workspaceSize,
-                                accumulate,
-                                true,
-                                outputDesc.get(),
-                                outputTensor.data()));
+    DIOPI_CALL_CNNL(cnnlIndexPut(handle,
+                                 inputDesc.get(),
+                                 inputTensor.data(),
+                                 indicesDescs.data(),
+                                 indicesPtrList.data(),
+                                 indicesDescs.size(),
+                                 valuesDesc.get(),
+                                 valuesTensor.data(),
+                                 workspacePtr,
+                                 workspaceSize,
+                                 accumulate,
+                                 true,
+                                 outputDesc.get(),
+                                 outputTensor.data()));
 
     return diopiSuccess;
 }

--- a/impl/camb/functions/isnan.cpp
+++ b/impl/camb/functions/isnan.cpp
@@ -23,7 +23,7 @@ diopiError_t diopiIsNan(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
 
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc inputDesc(inputTensorTmp, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlIsNan(handle, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlIsNan(handle, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensor.data()));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/layernorm.cpp
+++ b/impl/camb/functions/layernorm.cpp
@@ -29,7 +29,7 @@ diopiError_t diopiLayerNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     CnnlTensorDesc saveMeanDesc(saveMeanTensor, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize(0);
-    DIOPI_CALLCNNL(cnnlGetLayerNormOpWorkspaceSize(handle, normalizedShape.len, inputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetLayerNormOpWorkspaceSize(handle, normalizedShape.len, inputDesc.get(), &workspaceSize));
     void *workspace = nullptr;
     if (workspaceSize > 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -53,21 +53,21 @@ diopiError_t diopiLayerNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     }
 
     int axis = inputTensor.dim() - normalizedShape.len;
-    DIOPI_CALLCNNL(cnnlLayerNormForward(handle,
-                                        inputDesc.get(),
-                                        inputTensor.data(),
-                                        axis,
-                                        weightBiasDescTmp,
-                                        weightPtr,
-                                        biasPtr,
-                                        eps,
-                                        workspace,
-                                        workspaceSize,
-                                        outDesc.get(),
-                                        outTensor.data(),
-                                        saveMeanDesc.get(),
-                                        saveMeanTensor.data(),
-                                        saveInvstdTensor.data()));
+    DIOPI_CALL_CNNL(cnnlLayerNormForward(handle,
+                                         inputDesc.get(),
+                                         inputTensor.data(),
+                                         axis,
+                                         weightBiasDescTmp,
+                                         weightPtr,
+                                         biasPtr,
+                                         eps,
+                                         workspace,
+                                         workspaceSize,
+                                         outDesc.get(),
+                                         outTensor.data(),
+                                         saveMeanDesc.get(),
+                                         saveMeanTensor.data(),
+                                         saveInvstdTensor.data()));
 
     if (outDtype != diopi_dtype_float32 && outDtype != diopi_dtype_float16) {
         DiopiTensor outTensorTmp(out);
@@ -145,29 +145,29 @@ diopiError_t diopiLayerNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_
     int axis = inputTensor.dim() - normalizedShape.len;
 
     size_t workspaceSize(0);
-    DIOPI_CALLCNNL(cnnlGetLayerNormBackwardWorkspaceSize(handle, inputDesc.get(), axis, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetLayerNormBackwardWorkspaceSize(handle, inputDesc.get(), axis, &workspaceSize));
     void *workspace = nullptr;
     if (workspaceSize > 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlLayerNormBackward_v2(handle,
-                                            inputDesc.get(),
-                                            inputTensor.data(),
-                                            axis,
-                                            gradOutputDesc.get(),
-                                            gradOutputTensor.data(),
-                                            weightBiasDescTmp,
-                                            weightPtr,
-                                            meanDesc.get(),
-                                            meanTensor.data(),
-                                            rstdTensor.data(),
-                                            workspace,
-                                            workspaceSize,
-                                            gradInputDesc.get(),
-                                            gradInputTensor.data(),
-                                            gradWeightPtr,
-                                            gradBiasPtr));
+    DIOPI_CALL_CNNL(cnnlLayerNormBackward_v2(handle,
+                                             inputDesc.get(),
+                                             inputTensor.data(),
+                                             axis,
+                                             gradOutputDesc.get(),
+                                             gradOutputTensor.data(),
+                                             weightBiasDescTmp,
+                                             weightPtr,
+                                             meanDesc.get(),
+                                             meanTensor.data(),
+                                             rstdTensor.data(),
+                                             workspace,
+                                             workspaceSize,
+                                             gradInputDesc.get(),
+                                             gradInputTensor.data(),
+                                             gradWeightPtr,
+                                             gradBiasPtr));
     if (outDtype != diopi_dtype_float16 && outDtype != diopi_dtype_float32) {
         DiopiTensor gradInputTensorTmp(gradInput);
         DIOPI_CALL(dataTypeCast(ctx, gradInputTensorTmp, gradInputTensor));

--- a/impl/camb/functions/lerp.cpp
+++ b/impl/camb/functions/lerp.cpp
@@ -38,23 +38,23 @@ diopiError_t diopiLerpTensor(diopiContextHandle_t ctx, diopiTensorHandle_t out, 
     CnnlTensorDesc weightDesc(weightTensorTmp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetLerpWorkspaceSize(handle, inputDesc.get(), endDesc.get(), weightDesc.get(), outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetLerpWorkspaceSize(handle, inputDesc.get(), endDesc.get(), weightDesc.get(), outDesc.get(), &workspaceSize));
     void *workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlLerp(handle,
-                            inputDesc.get(),
-                            inputTensorTmp.data(),
-                            endDesc.get(),
-                            endTensorTmp.data(),
-                            weightDesc.get(),
-                            weightTensorTmp.data(),
-                            workspace,
-                            workspaceSize,
-                            outDesc.get(),
-                            outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlLerp(handle,
+                             inputDesc.get(),
+                             inputTensorTmp.data(),
+                             endDesc.get(),
+                             endTensorTmp.data(),
+                             weightDesc.get(),
+                             weightTensorTmp.data(),
+                             workspace,
+                             workspaceSize,
+                             outDesc.get(),
+                             outTensorTmp.data()));
     if (outTensor.dtype() != outTensorTmp.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     }

--- a/impl/camb/functions/linalg_qr.cpp
+++ b/impl/camb/functions/linalg_qr.cpp
@@ -47,22 +47,22 @@ diopiError_t diopiLinalgQR(diopiContextHandle_t ctx, diopiConstTensorHandle_t a,
     CnnlTensorDesc output2Desc(output2TensorTmp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetQRWorkspaceSize(handle, inputDesc.get(), reduced, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetQRWorkspaceSize(handle, inputDesc.get(), reduced, &workspaceSize));
     void *workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlQR(handle,
-                          inputDesc.get(),
-                          inputTensor.data(),
-                          output1Desc.get(),
-                          output1TensorTmp.data(),
-                          output2Desc.get(),
-                          output2TensorTmp.data(),
-                          workspace,
-                          workspaceSize,
-                          reduced));
+    DIOPI_CALL_CNNL(cnnlQR(handle,
+                           inputDesc.get(),
+                           inputTensor.data(),
+                           output1Desc.get(),
+                           output1TensorTmp.data(),
+                           output2Desc.get(),
+                           output2TensorTmp.data(),
+                           workspace,
+                           workspaceSize,
+                           reduced));
     if (output1TensorTmp.dtype() != output1Tensor.dtype() || output2TensorTmp.dtype() != output2Tensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, output1Tensor, output1TensorTmp));
         DIOPI_CALL(dataTypeCast(ctx, output2Tensor, output2TensorTmp));

--- a/impl/camb/functions/linear.cpp
+++ b/impl/camb/functions/linear.cpp
@@ -49,22 +49,22 @@ diopiError_t matmul(diopiContextHandle_t ctx, DiopiTensor inputA, DiopiTensor in
         setLastErrorString("%s", "matmul on support float or half.");
         return diopiDtypeNotSupported;
     }
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_COMPUTE_TYPE, &(compType), sizeof(cnnlDataType_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_COMPUTE_TYPE, &(compType), sizeof(cnnlDataType_t)));
 
     int32_t isTransa = 0;
     if (transA) {
         isTransa = 1;
     }
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_TRANSA, &(isTransa), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_TRANSA, &(isTransa), sizeof(int32_t)));
 
     int32_t isTransb = 0;
     if (transB) {
         isTransb = 1;
     }
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_TRANSB, &(isTransb), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_TRANSB, &(isTransb), sizeof(int32_t)));
 
     int32_t allowTf32I32 = 0;
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_ALLOW_TF32, &(allowTf32I32), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_ALLOW_TF32, &(allowTf32I32), sizeof(int32_t)));
 
     int32_t useBeta = 0;
     float beta = 0.0;
@@ -72,26 +72,26 @@ diopiError_t matmul(diopiContextHandle_t ctx, DiopiTensor inputA, DiopiTensor in
         useBeta = 1;
         beta = 1.0;
         DIOPI_CALL(biasDesc.set(inputBias, CNNL_LAYOUT_ARRAY));
-        DIOPI_CALLCNNL(cnnlExpand(handle, biasDesc.get(), inputBias.data(), outputDesc.get(), output.data()));
+        DIOPI_CALL_CNNL(cnnlExpand(handle, biasDesc.get(), inputBias.data(), outputDesc.get(), output.data()));
     }
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_USE_BETA, &(useBeta), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_USE_BETA, &(useBeta), sizeof(int32_t)));
 
     size_t workspaceSize = 0;
     int requestedAlgoCount = 1;
     int returnAlgoCount = 0;
     CnnlResourceGuard<cnnlMatMulHeuristicResult_t, cnnlCreateMatMulHeuristicResult, cnnlDestroyMatMulHeuristicResult> heuristicResult;
     CnnlResourceGuard<cnnlMatMulAlgo_t, cnnlMatMulAlgoCreate, cnnlMatMulAlgoDestroy> algo;
-    DIOPI_CALLCNNL(cnnlGetMatMulAlgoHeuristic(handle,
-                                              matmulDesc.get(),
-                                              aDesc.get(),
-                                              bDesc.get(),
-                                              outputDesc.get(),
-                                              outputDesc.get(),
-                                              nullptr,
-                                              requestedAlgoCount,
-                                              &heuristicResult.get(),
-                                              &returnAlgoCount));
-    DIOPI_CALLCNNL(cnnlGetMatMulHeuristicResult(heuristicResult.get(), algo.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetMatMulAlgoHeuristic(handle,
+                                               matmulDesc.get(),
+                                               aDesc.get(),
+                                               bDesc.get(),
+                                               outputDesc.get(),
+                                               outputDesc.get(),
+                                               nullptr,
+                                               requestedAlgoCount,
+                                               &heuristicResult.get(),
+                                               &returnAlgoCount));
+    DIOPI_CALL_CNNL(cnnlGetMatMulHeuristicResult(heuristicResult.get(), algo.get(), &workspaceSize));
 
     void* workspace = nullptr;
     if (0 != workspaceSize) {
@@ -100,21 +100,21 @@ diopiError_t matmul(diopiContextHandle_t ctx, DiopiTensor inputA, DiopiTensor in
 
     float alphaDefault = 1.0;
 
-    DIOPI_CALLCNNL(cnnlMatMul_v2(handle,
-                                 matmulDesc.get(),
-                                 algo.get(),
-                                 &alphaDefault,
-                                 aDesc.get(),
-                                 inputA.data(),
-                                 bDesc.get(),
-                                 inputB.data(),
-                                 &beta,
-                                 outputDesc.get(),
-                                 output.data(),
-                                 workspace,
-                                 workspaceSize,
-                                 outputDesc.get(),
-                                 output.data()));
+    DIOPI_CALL_CNNL(cnnlMatMul_v2(handle,
+                                  matmulDesc.get(),
+                                  algo.get(),
+                                  &alphaDefault,
+                                  aDesc.get(),
+                                  inputA.data(),
+                                  bDesc.get(),
+                                  inputB.data(),
+                                  &beta,
+                                  outputDesc.get(),
+                                  output.data(),
+                                  workspace,
+                                  workspaceSize,
+                                  outputDesc.get(),
+                                  output.data()));
 
     return diopiSuccess;
 }
@@ -192,13 +192,13 @@ diopiError_t diopiLinearBackward(diopiContextHandle_t ctx, diopiTensorHandle_t g
 
         int channelAxis = 1;
         size_t workspaceSizeBias;
-        DIOPI_CALLCNNL(cnnlGetBiasAddBackwardWorkspaceSize(handle, gradOutputDesc.get(), biasGradDesc.get(), channelAxis, &workspaceSizeBias))
+        DIOPI_CALL_CNNL(cnnlGetBiasAddBackwardWorkspaceSize(handle, gradOutputDesc.get(), biasGradDesc.get(), channelAxis, &workspaceSizeBias))
 
         void* workspaceBias = nullptr;
         if (0 != workspaceSizeBias) {
             workspaceBias = requiresBuffer(ctx, workspaceSizeBias).data();
         }
-        DIOPI_CALLCNNL(cnnlBiasAddBackward_v2(
+        DIOPI_CALL_CNNL(cnnlBiasAddBackward_v2(
             handle, gradOutputDesc.get(), gradOutputTensor.data(), channelAxis, biasGradDesc.get(), biasGradTemp.data(), workspaceBias, workspaceSizeBias));
         if (biasGradTensor.dtype() != biasGradTemp.dtype()) {
             DIOPI_CALL(dataTypeCast(ctx, biasGradTensor, biasGradTemp));

--- a/impl/camb/functions/linspace.cpp
+++ b/impl/camb/functions/linspace.cpp
@@ -9,21 +9,19 @@ diopiError_t diopiLinspace(diopiContextHandle_t ctx, diopiTensorHandle_t out, co
 
     float startValue, endValue;
 
-    cnnlDataType_t startType, endType;
-    DIOPI_CALL(CnnlDataType::convertToCnnlType(&startType, start->stype));
-    DIOPI_CALL(CnnlDataType::convertToCnnlType(&endType, end->stype));
-
-    if (CnnlDataType::isFloatPoint(startType)) {
+    diopiDtype_t startType = start->stype;
+    diopiDtype_t endType = end->stype;
+    if (DiopiDataType::isFloatPoint(startType)) {
         startValue = start->fval;
-    } else if (CnnlDataType::isInteger(startType)) {
+    } else if (DiopiDataType::isInteger(startType)) {
         startValue = start->ival;
     } else {
         return diopiDtypeNotSupported;
     }
 
-    if (CnnlDataType::isFloatPoint(endType)) {
+    if (DiopiDataType::isFloatPoint(endType)) {
         endValue = end->fval;
-    } else if (CnnlDataType::isInteger(startType)) {
+    } else if (DiopiDataType::isInteger(startType)) {
         endValue = end->ival;
     } else {
         return diopiDtypeNotSupported;

--- a/impl/camb/functions/linspace.cpp
+++ b/impl/camb/functions/linspace.cpp
@@ -28,7 +28,7 @@ diopiError_t diopiLinspace(diopiContextHandle_t ctx, diopiTensorHandle_t out, co
     }
 
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlLinspace(handle, startValue, endValue, outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlLinspace(handle, startValue, endValue, outDesc.get(), outTensor.data()));
     return diopiSuccess;
 }
 }  // namespace camb

--- a/impl/camb/functions/log.cpp
+++ b/impl/camb/functions/log.cpp
@@ -24,7 +24,7 @@ diopiError_t logInternal(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     CnnlTensorDesc inputDesc(inputTensorTmp, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlLog(handle, logBase, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlLog(handle, logBase, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     return diopiSuccess;
 }

--- a/impl/camb/functions/logic.cpp
+++ b/impl/camb/functions/logic.cpp
@@ -33,21 +33,21 @@ diopiError_t logic(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConst
     CnnlTensorDesc outDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetLogicOpWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetLogicOpWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
-    DIOPI_CALLCNNL(cnnlLogicOp(handle,
-                               logicOp,
-                               inputDesc.get(),
-                               inputTensor.data(),
-                               otherDesc.get(),
-                               otherTensor.data(),
-                               workspace,
-                               workspaceSize,
-                               outDesc.get(),
-                               outTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlLogicOp(handle,
+                                logicOp,
+                                inputDesc.get(),
+                                inputTensor.data(),
+                                otherDesc.get(),
+                                otherTensor.data(),
+                                workspace,
+                                workspaceSize,
+                                outDesc.get(),
+                                outTensorTemp.data()));
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));
     }
@@ -85,22 +85,22 @@ diopiError_t logicScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     CnnlTensorDesc outDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetLogicOpWorkspaceSize(handle, inputDesc.get(), otherTDesc.get(), outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetLogicOpWorkspaceSize(handle, inputDesc.get(), otherTDesc.get(), outDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlLogicOp(handle,
-                               logicOp,
-                               inputDesc.get(),
-                               inputTensor.data(),
-                               otherTDesc.get(),
-                               otherTTensor.data(),
-                               workspace,
-                               workspaceSize,
-                               outDesc.get(),
-                               outTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlLogicOp(handle,
+                                logicOp,
+                                inputDesc.get(),
+                                inputTensor.data(),
+                                otherTDesc.get(),
+                                otherTTensor.data(),
+                                workspace,
+                                workspaceSize,
+                                outDesc.get(),
+                                outTensorTemp.data()));
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));
     }

--- a/impl/camb/functions/loss.cpp
+++ b/impl/camb/functions/loss.cpp
@@ -103,24 +103,24 @@ diopiError_t diopiNLLLoss(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     targetDesc.set(targetTensor, CNNL_LAYOUT_ARRAY, {n});
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetNlllossWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetNlllossWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlNlllossForward(handle,
-                                      reductionMode,
-                                      workspacePtr,
-                                      workspaceSize,
-                                      inputDesc.get(),
-                                      inputTensor.data(),
-                                      targetDesc.get(),
-                                      targetTensor.data(),
-                                      static_cast<int>(ignoreIndex),
-                                      weightDesc.get(),
-                                      weightTensor.data(),
-                                      twDesc.get(),
-                                      totalWeightTensor.data(),
-                                      outputDesc.get(),
-                                      outTmpTensor.data()));
+    DIOPI_CALL_CNNL(cnnlNlllossForward(handle,
+                                       reductionMode,
+                                       workspacePtr,
+                                       workspaceSize,
+                                       inputDesc.get(),
+                                       inputTensor.data(),
+                                       targetDesc.get(),
+                                       targetTensor.data(),
+                                       static_cast<int>(ignoreIndex),
+                                       weightDesc.get(),
+                                       weightTensor.data(),
+                                       twDesc.get(),
+                                       totalWeightTensor.data(),
+                                       outputDesc.get(),
+                                       outTmpTensor.data()));
 
     if (outTmpTensor.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTmpTensor));
@@ -212,19 +212,19 @@ diopiError_t diopiNLLLossBackward(diopiContextHandle_t ctx, diopiTensorHandle_t 
     targetDesc.set(targetTensor, CNNL_LAYOUT_ARRAY, {n});
     reduction == 0 ? gradOutputDesc.set(gradOutputTensor, CNNL_LAYOUT_ARRAY, {n}) : gradOutputDesc.set(gradOutputTensor, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlNlllossBackward(handle,
-                                       reductionMode,
-                                       gradOutputDesc.get(),
-                                       gradOutputTensor.data(),
-                                       targetDesc.get(),
-                                       targetTensor.data(),
-                                       static_cast<int>(ignoreIndex),
-                                       weightDesc.get(),
-                                       weightTensor.data(),
-                                       twDesc.get(),
-                                       totalWeightTensor.data(),
-                                       gradInputDesc.get(),
-                                       gradInputRealTensor.data()));
+    DIOPI_CALL_CNNL(cnnlNlllossBackward(handle,
+                                        reductionMode,
+                                        gradOutputDesc.get(),
+                                        gradOutputTensor.data(),
+                                        targetDesc.get(),
+                                        targetTensor.data(),
+                                        static_cast<int>(ignoreIndex),
+                                        weightDesc.get(),
+                                        weightTensor.data(),
+                                        twDesc.get(),
+                                        totalWeightTensor.data(),
+                                        gradInputDesc.get(),
+                                        gradInputRealTensor.data()));
     if (dim > 2) {
         // NHWC -> NCHW and dealing with data type
         gradInputRealTensor.view(inputTensor.shape());
@@ -320,7 +320,7 @@ diopiError_t diopiMSELoss(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
         descOut.set(trOutTmp, CNNL_LAYOUT_ARRAY);
     }
 
-    DIOPI_CALLCNNL(cnnlMSELoss(handle, cnnlReduction, descInput.get(), trInput.data(), descTarget.get(), trTarget.data(), descOut.get(), trOutTmp.data()));
+    DIOPI_CALL_CNNL(cnnlMSELoss(handle, cnnlReduction, descInput.get(), trInput.data(), descTarget.get(), trTarget.data(), descOut.get(), trOutTmp.data()));
     if (trOutTmp.dtype() != trOut.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, trOut, trOutTmp));
     }
@@ -369,16 +369,16 @@ diopiError_t diopiMSELossBackward(diopiContextHandle_t ctx, diopiTensorHandle_t 
         descGradInput.set(trGradInputTmp, CNNL_LAYOUT_ARRAY);
     }
 
-    DIOPI_CALLCNNL(cnnlMSELossBackward(handle,
-                                       cnnlReduction,
-                                       descInput.get(),
-                                       trInput.data(),
-                                       descTarget.get(),
-                                       trTarget.data(),
-                                       descGradOutput.get(),
-                                       trGradOutput.data(),
-                                       descGradInput.get(),
-                                       trGradInputTmp.data()));
+    DIOPI_CALL_CNNL(cnnlMSELossBackward(handle,
+                                        cnnlReduction,
+                                        descInput.get(),
+                                        trInput.data(),
+                                        descTarget.get(),
+                                        trTarget.data(),
+                                        descGradOutput.get(),
+                                        trGradOutput.data(),
+                                        descGradInput.get(),
+                                        trGradInputTmp.data()));
     if (trGradInputTmp.dtype() != trGradInput.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, trGradInput, trGradInputTmp));
     }
@@ -423,20 +423,20 @@ diopiError_t diopiSmoothL1Loss(diopiContextHandle_t ctx, diopiTensorHandle_t out
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetSmoothL1LossForwardWorkspaceSize(handle, inputDesc.get(), reductionMode, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetSmoothL1LossForwardWorkspaceSize(handle, inputDesc.get(), reductionMode, &workspaceSize));
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlSmoothL1LossForward_v2(handle,
-                                              inputDesc.get(),
-                                              inputTensor.data(),
-                                              targetDesc.get(),
-                                              targetTensor.data(),
-                                              beta,
-                                              reductionMode,
-                                              workspacePtr,
-                                              workspaceSize,
-                                              outDesc.get(),
-                                              outTmpTensor.data()));
+    DIOPI_CALL_CNNL(cnnlSmoothL1LossForward_v2(handle,
+                                               inputDesc.get(),
+                                               inputTensor.data(),
+                                               targetDesc.get(),
+                                               targetTensor.data(),
+                                               beta,
+                                               reductionMode,
+                                               workspacePtr,
+                                               workspaceSize,
+                                               outDesc.get(),
+                                               outTmpTensor.data()));
 
     if (outTmpTensor.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTmpTensor));
@@ -485,22 +485,22 @@ diopiError_t diopiSmoothL1LossBackward(diopiContextHandle_t ctx, diopiTensorHand
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetSmoothL1LossBackwardWorkspaceSize(handle, inputDesc.get(), reductionMode, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetSmoothL1LossBackwardWorkspaceSize(handle, inputDesc.get(), reductionMode, &workspaceSize));
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlSmoothL1LossBackward_v2(handle,
-                                               inputDesc.get(),
-                                               inputTensor.data(),
-                                               targetDesc.get(),
-                                               targetTensor.data(),
-                                               gradOutputDesc.get(),
-                                               gradOutputTensor.data(),
-                                               beta,
-                                               reductionMode,
-                                               workspacePtr,
-                                               workspaceSize,
-                                               gradInputDesc.get(),
-                                               gradInputTmpTensor.data()));
+    DIOPI_CALL_CNNL(cnnlSmoothL1LossBackward_v2(handle,
+                                                inputDesc.get(),
+                                                inputTensor.data(),
+                                                targetDesc.get(),
+                                                targetTensor.data(),
+                                                gradOutputDesc.get(),
+                                                gradOutputTensor.data(),
+                                                beta,
+                                                reductionMode,
+                                                workspacePtr,
+                                                workspaceSize,
+                                                gradInputDesc.get(),
+                                                gradInputTmpTensor.data()));
 
     if (gradInputTmpTensor.dtype() != gradInputTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputTmpTensor));

--- a/impl/camb/functions/masked_fill.cpp
+++ b/impl/camb/functions/masked_fill.cpp
@@ -57,26 +57,26 @@ diopiError_t diopiMaskedFill(diopiContextHandle_t ctx, diopiTensorHandle_t out, 
     }
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetMaskedWorkspaceSize(
+    DIOPI_CALL_CNNL(cnnlGetMaskedWorkspaceSize(
         handle, CNNL_MASKED_FILL, inputDesc.get(), maskDesc.get(), valueCast ? valueCastDesc.get() : valueDesc.get(), outDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlMasked_v3(handle,
-                                 CNNL_MASKED_FILL,
-                                 inputDesc.get(),
-                                 inputTensorTmp.data(),
-                                 maskDesc.get(),
-                                 maskTensorTmp.data(),
-                                 valueCast ? valueCastDesc.get() : valueDesc.get(),
-                                 valueCast ? valueCastTensor.data() : valueTensorTmp.data(),
-                                 workspace,
-                                 workspaceSize,
-                                 outDesc.get(),
-                                 outTensorTmp.data(),
-                                 nullptr));
+    DIOPI_CALL_CNNL(cnnlMasked_v3(handle,
+                                  CNNL_MASKED_FILL,
+                                  inputDesc.get(),
+                                  inputTensorTmp.data(),
+                                  maskDesc.get(),
+                                  maskTensorTmp.data(),
+                                  valueCast ? valueCastDesc.get() : valueDesc.get(),
+                                  valueCast ? valueCastTensor.data() : valueTensorTmp.data(),
+                                  workspace,
+                                  workspaceSize,
+                                  outDesc.get(),
+                                  outTensorTmp.data(),
+                                  nullptr));
 
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     return diopiSuccess;

--- a/impl/camb/functions/masked_select.cpp
+++ b/impl/camb/functions/masked_select.cpp
@@ -31,7 +31,7 @@ diopiError_t diopiMaskedSelect(diopiContextHandle_t ctx, diopiTensorHandle_t *ou
     cnnlMaskedOp_t maskMode = CNNL_MASKED_SELECT;
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetMaskedWorkspaceSize(handle, maskMode, inputDesc.get(), maskDesc.get(), nullptr, outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetMaskedWorkspaceSize(handle, maskMode, inputDesc.get(), maskDesc.get(), nullptr, outDesc.get(), &workspaceSize));
     void *workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -42,34 +42,34 @@ diopiError_t diopiMaskedSelect(diopiContextHandle_t ctx, diopiTensorHandle_t *ou
 
 // version should be greater than 1.15.2
 #if (CNNL_MAJOR * 10000 + CNNL_MINOR * 100 + CNNL_PATCHLEVEL >= 11502)
-    DIOPI_CALLCNNL(cnnlMasked_v4(handle,
-                                 maskMode,
-                                 inputDesc.get(),
-                                 inputTensor.data(),
-                                 maskDesc.get(),
-                                 maskTensor.data(),
-                                 nullptr,
-                                 nullptr,
-                                 nullptr,
-                                 workspace,
-                                 workspaceSize,
-                                 outDesc.get(),
-                                 tempOutputTensor.data(),
-                                 reinterpret_cast<uint32_t *>(numTrue.data())));
+    DIOPI_CALL_CNNL(cnnlMasked_v4(handle,
+                                  maskMode,
+                                  inputDesc.get(),
+                                  inputTensor.data(),
+                                  maskDesc.get(),
+                                  maskTensor.data(),
+                                  nullptr,
+                                  nullptr,
+                                  nullptr,
+                                  workspace,
+                                  workspaceSize,
+                                  outDesc.get(),
+                                  tempOutputTensor.data(),
+                                  reinterpret_cast<uint32_t *>(numTrue.data())));
 #else
-    DIOPI_CALLCNNL(cnnlMasked_v3(handle,
-                                 maskMode,
-                                 inputDesc.get(),
-                                 inputTensor.data(),
-                                 maskDesc.get(),
-                                 maskTensor.data(),
-                                 nullptr,
-                                 nullptr,
-                                 workspace,
-                                 workspaceSize,
-                                 outDesc.get(),
-                                 tempOutputTensor.data(),
-                                 reinterpret_cast<uint32_t *>(numTrue.data())));
+    DIOPI_CALL_CNNL(cnnlMasked_v3(handle,
+                                  maskMode,
+                                  inputDesc.get(),
+                                  inputTensor.data(),
+                                  maskDesc.get(),
+                                  maskTensor.data(),
+                                  nullptr,
+                                  nullptr,
+                                  workspace,
+                                  workspaceSize,
+                                  outDesc.get(),
+                                  tempOutputTensor.data(),
+                                  reinterpret_cast<uint32_t *>(numTrue.data())));
 #endif
     syncStreamInCtx(ctx);
     uint32_t numTrueHost = 0;
@@ -110,7 +110,7 @@ DIOPI_API diopiError_t diopiMaskedSelectBackward(diopiContextHandle_t ctx, diopi
     cnnlMaskedOp_t maskMode = CNNL_MASKED_SCATTER;
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetMaskedWorkspaceSize(handle, maskMode, gradInputDesc.get(), maskDesc.get(), gradOutDesc.get(), gradInputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetMaskedWorkspaceSize(handle, maskMode, gradInputDesc.get(), maskDesc.get(), gradOutDesc.get(), gradInputDesc.get(), &workspaceSize));
     void *workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -118,34 +118,34 @@ DIOPI_API diopiError_t diopiMaskedSelectBackward(diopiContextHandle_t ctx, diopi
 
 // version should be greater than 1.15.2
 #if (CNNL_MAJOR * 10000 + CNNL_MINOR * 100 + CNNL_PATCHLEVEL >= 11502)
-    DIOPI_CALLCNNL(cnnlMasked_v4(handle,
-                                 maskMode,
-                                 gradInputDesc.get(),
-                                 tempGradInputTensor.data(),
-                                 maskDesc.get(),
-                                 maskTensor.data(),
-                                 gradOutDesc.get(),
-                                 gradOutputTensor.data(),
-                                 nullptr,
-                                 workspace,
-                                 workspaceSize,
-                                 gradInputDesc.get(),
-                                 gradInputTensor.data(),
-                                 nullptr));
+    DIOPI_CALL_CNNL(cnnlMasked_v4(handle,
+                                  maskMode,
+                                  gradInputDesc.get(),
+                                  tempGradInputTensor.data(),
+                                  maskDesc.get(),
+                                  maskTensor.data(),
+                                  gradOutDesc.get(),
+                                  gradOutputTensor.data(),
+                                  nullptr,
+                                  workspace,
+                                  workspaceSize,
+                                  gradInputDesc.get(),
+                                  gradInputTensor.data(),
+                                  nullptr));
 #else
-    DIOPI_CALLCNNL(cnnlMasked_v3(handle,
-                                 maskMode,
-                                 gradInputDesc.get(),
-                                 tempGradInputTensor.data(),
-                                 maskDesc.get(),
-                                 maskTensor.data(),
-                                 gradOutDesc.get(),
-                                 gradOutputTensor.data(),
-                                 workspace,
-                                 workspaceSize,
-                                 gradInputDesc.get(),
-                                 gradInputTensor.data(),
-                                 nullptr));
+    DIOPI_CALL_CNNL(cnnlMasked_v3(handle,
+                                  maskMode,
+                                  gradInputDesc.get(),
+                                  tempGradInputTensor.data(),
+                                  maskDesc.get(),
+                                  maskTensor.data(),
+                                  gradOutDesc.get(),
+                                  gradOutputTensor.data(),
+                                  workspace,
+                                  workspaceSize,
+                                  gradInputDesc.get(),
+                                  gradInputTensor.data(),
+                                  nullptr));
 #endif
     DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, tempGradInputTensor));
     DIOPI_CALL(diopiMul(ctx, gradInput, mask, gradInput));

--- a/impl/camb/functions/matmul.cpp
+++ b/impl/camb/functions/matmul.cpp
@@ -207,10 +207,10 @@ static diopiError_t batchMatmul(diopiContextHandle_t ctx, DiopiTensor outTensor,
     CnnlTensorDesc otherDesc(otherTensor, CNNL_LAYOUT_ARRAY);
 
     int32_t allowTf32Int = 1;
-    CnnlDescBase<cnnlMatMulDescriptor_t, cnnlMatMulDescCreate, cnnlMatMulDescDestroy> bmmDescGuard;
+    CnnlResourceGuard<cnnlMatMulDescriptor_t, cnnlMatMulDescCreate, cnnlMatMulDescDestroy> bmmDescGuard;
     cnnlSetMatMulDescAttr(bmmDescGuard.get(), CNNL_MATMUL_ALLOW_TF32, &allowTf32Int, sizeof(allowTf32Int));
-    CnnlDescBase<cnnlMatMulAlgo_t, cnnlMatMulAlgoCreate, cnnlMatMulAlgoDestroy> bmmAlgo;
-    CnnlDescBase<cnnlMatMulHeuristicResult_t, cnnlCreateMatMulHeuristicResult, cnnlDestroyMatMulHeuristicResult> bmmHeuristicResult;
+    CnnlResourceGuard<cnnlMatMulAlgo_t, cnnlMatMulAlgoCreate, cnnlMatMulAlgoDestroy> bmmAlgo;
+    CnnlResourceGuard<cnnlMatMulHeuristicResult_t, cnnlCreateMatMulHeuristicResult, cnnlDestroyMatMulHeuristicResult> bmmHeuristicResult;
 
     int returnAlgoCount = 0;
     cnnlGetBatchMatMulAlgoHeuristic(

--- a/impl/camb/functions/matmul.cpp
+++ b/impl/camb/functions/matmul.cpp
@@ -72,7 +72,7 @@ static diopiError_t vectorMulVector(diopiContextHandle_t ctx, DiopiTensor outTen
     inputs[0] = vector1Tensor.data();
     inputs[1] = vector2Tensor.data();
 
-    DIOPI_CALLCNNL(cnnlMulN(handle, inputsDesc.data(), inputs.data(), 2, tempOutDesc.get(), tempOut.data()));
+    DIOPI_CALL_CNNL(cnnlMulN(handle, inputsDesc.data(), inputs.data(), 2, tempOutDesc.get(), tempOut.data()));
     int64_t dimData = 0;
     diopiSize_t dim{&dimData, 1};
 
@@ -101,17 +101,17 @@ static diopiError_t matMulMat(diopiContextHandle_t ctx, DiopiTensor out, DiopiTe
     CnnlResourceGuard<cnnlMatMulDescriptor_t, cnnlMatMulDescCreate, cnnlMatMulDescDestroy> matmulDescGuard;
     cnnlMatMulDescriptor_t matmulDesc = matmulDescGuard.get();
     int32_t allowTf32I32 = 1;
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_ALLOW_TF32, &(allowTf32I32), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc, CNNL_MATMUL_ALLOW_TF32, &(allowTf32I32), sizeof(int32_t)));
     CnnlResourceGuard<cnnlMatMulAlgo_t, cnnlMatMulAlgoCreate, cnnlMatMulAlgoDestroy> matmulAlgo;
     cnnlMatMulAlgo_t algo = matmulAlgo.get();
 
     CnnlResourceGuard<cnnlMatMulHeuristicResult_t, cnnlCreateMatMulHeuristicResult, cnnlDestroyMatMulHeuristicResult> matMulHeuristic;
     cnnlMatMulHeuristicResult_t heuristicResult = matMulHeuristic.get();
     int returnAlgoCount = 0;
-    DIOPI_CALLCNNL(cnnlGetMatMulAlgoHeuristic(
+    DIOPI_CALL_CNNL(cnnlGetMatMulAlgoHeuristic(
         handle, matmulDesc, inputDesc.get(), otherDesc.get(), outDesc.get(), outDesc.get(), nullptr, 1, &heuristicResult, &returnAlgoCount));
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetMatMulHeuristicResult(heuristicResult, algo, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetMatMulHeuristicResult(heuristicResult, algo, &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -120,39 +120,39 @@ static diopiError_t matMulMat(diopiContextHandle_t ctx, DiopiTensor out, DiopiTe
     float alpha = 1;
     float beta = 0;
     if (out.dtype() == input.dtype()) {
-        DIOPI_CALLCNNL(cnnlMatMul_v2(handle,
-                                     matmulDesc,
-                                     algo,
-                                     &alpha,
-                                     inputDesc.get(),
-                                     input.data(),
-                                     otherDesc.get(),
-                                     other.data(),
-                                     &beta,
-                                     outDesc.get(),
-                                     out.data(),
-                                     workspace,
-                                     workspaceSize,
-                                     outDesc.get(),
-                                     out.data()));
+        DIOPI_CALL_CNNL(cnnlMatMul_v2(handle,
+                                      matmulDesc,
+                                      algo,
+                                      &alpha,
+                                      inputDesc.get(),
+                                      input.data(),
+                                      otherDesc.get(),
+                                      other.data(),
+                                      &beta,
+                                      outDesc.get(),
+                                      out.data(),
+                                      workspace,
+                                      workspaceSize,
+                                      outDesc.get(),
+                                      out.data()));
     } else {
         DiopiTensor outTemp = requiresTensor(ctx, out.shape(), input.dtype());
         CnnlTensorDesc outTempDesc(outTemp, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlMatMul_v2(handle,
-                                     matmulDesc,
-                                     algo,
-                                     &alpha,
-                                     inputDesc.get(),
-                                     input.data(),
-                                     otherDesc.get(),
-                                     other.data(),
-                                     &beta,
-                                     outTempDesc.get(),
-                                     outTemp.data(),
-                                     workspace,
-                                     workspaceSize,
-                                     outTempDesc.get(),
-                                     outTemp.data()));
+        DIOPI_CALL_CNNL(cnnlMatMul_v2(handle,
+                                      matmulDesc,
+                                      algo,
+                                      &alpha,
+                                      inputDesc.get(),
+                                      input.data(),
+                                      otherDesc.get(),
+                                      other.data(),
+                                      &beta,
+                                      outTempDesc.get(),
+                                      outTemp.data(),
+                                      workspace,
+                                      workspaceSize,
+                                      outTempDesc.get(),
+                                      outTemp.data()));
         DIOPI_CALL(dataTypeCast(ctx, out, outTemp));
     }
 
@@ -224,35 +224,35 @@ static diopiError_t batchMatmul(diopiContextHandle_t ctx, DiopiTensor outTensor,
     }
 
     if (outTensor.dtype() == inputTensor.dtype()) {
-        DIOPI_CALLCNNL(cnnlBatchMatMulBCast_v2(handle,
-                                               bmmDescGuard.get(),
-                                               bmmAlgo.get(),
-                                               nullptr,
-                                               inputDesc.get(),
-                                               inputTensor.data(),
-                                               otherDesc.get(),
-                                               otherTensor.data(),
-                                               nullptr,
-                                               outDesc.get(),
-                                               outTensor.data(),
-                                               workspace,
-                                               workspaceSize));
+        DIOPI_CALL_CNNL(cnnlBatchMatMulBCast_v2(handle,
+                                                bmmDescGuard.get(),
+                                                bmmAlgo.get(),
+                                                nullptr,
+                                                inputDesc.get(),
+                                                inputTensor.data(),
+                                                otherDesc.get(),
+                                                otherTensor.data(),
+                                                nullptr,
+                                                outDesc.get(),
+                                                outTensor.data(),
+                                                workspace,
+                                                workspaceSize));
     } else {
         DiopiTensor outTemp = requiresTensor(ctx, outTensor.shape(), inputTensor.dtype());
         CnnlTensorDesc outTempDesc(outTemp, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlBatchMatMulBCast_v2(handle,
-                                               bmmDescGuard.get(),
-                                               bmmAlgo.get(),
-                                               nullptr,
-                                               inputDesc.get(),
-                                               inputTensor.data(),
-                                               otherDesc.get(),
-                                               otherTensor.data(),
-                                               nullptr,
-                                               outTempDesc.get(),
-                                               outTemp.data(),
-                                               workspace,
-                                               workspaceSize));
+        DIOPI_CALL_CNNL(cnnlBatchMatMulBCast_v2(handle,
+                                                bmmDescGuard.get(),
+                                                bmmAlgo.get(),
+                                                nullptr,
+                                                inputDesc.get(),
+                                                inputTensor.data(),
+                                                otherDesc.get(),
+                                                otherTensor.data(),
+                                                nullptr,
+                                                outTempDesc.get(),
+                                                outTemp.data(),
+                                                workspace,
+                                                workspaceSize));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTemp));
     }
 

--- a/impl/camb/functions/max_pool2d.cpp
+++ b/impl/camb/functions/max_pool2d.cpp
@@ -72,14 +72,14 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     CnnlResourceGuard<cnnlPoolingDescriptor_t, cnnlCreatePoolingDescriptor, cnnlDestroyPoolingDescriptor> cnnlPoolDesc;
     cnnlPoolingDescriptor_t poolDesc = cnnlPoolDesc.get();
-    DIOPI_CALLCNNL(cnnlSetPooling2dDescriptor_v2(
+    DIOPI_CALL_CNNL(cnnlSetPooling2dDescriptor_v2(
         poolDesc, CNNL_POOLING_MAX, CNNL_PROPAGATE_NAN, kernelH, kernelW, padUp, padDown, padLeft, padRight, strideH, strideW, dilation0, dilation1, ceilMode));
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetPoolingWorkspaceSize(handle, CNNL_POOLING_MAX, outTr.shape()[3], inputTr.shape()[2], &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetPoolingWorkspaceSize(handle, CNNL_POOLING_MAX, outTr.shape()[3], inputTr.shape()[2], &workspaceSize));
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlPoolingForward_v2(
+    DIOPI_CALL_CNNL(cnnlPoolingForward_v2(
         handle, poolDesc, nullptr, inputDesc.get(), inputTr.data(), nullptr, nullptr, outDesc.get(), outTmpTr.data(), workspacePtr, workspaceSize));
 
     if (outTmpTr.dtype() != outTr.dtype()) {
@@ -162,41 +162,41 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
         std::vector<int> paddingTmp{padding.data, padding.data + padding.len};
         std::vector<int> strideTmp{stride.data, stride.data + stride.len};
         std::vector<int> dilationTmp{dilation.data, dilation.data + dilation.len};
-        DIOPI_CALLCNNL(cnnlSetPoolingNdDescriptor_v2(
+        DIOPI_CALL_CNNL(cnnlSetPoolingNdDescriptor_v2(
             poolDesc, CNNL_POOLING_MAX, CNNL_PROPAGATE_NAN, poolRank + 2, window.data(), paddingTmp.data(), strideTmp.data(), dilationTmp.data(), ceilMode));
     } else {
-        DIOPI_CALLCNNL(cnnlSetPooling2dDescriptor_v2(poolDesc,
-                                                     CNNL_POOLING_MAX,
-                                                     CNNL_PROPAGATE_NAN,
-                                                     kernelH,
-                                                     kernelW,
-                                                     padUp,
-                                                     padDown,
-                                                     padLeft,
-                                                     padRight,
-                                                     strideH,
-                                                     strideW,
-                                                     dilation0,
-                                                     dilation1,
-                                                     ceilMode));
+        DIOPI_CALL_CNNL(cnnlSetPooling2dDescriptor_v2(poolDesc,
+                                                      CNNL_POOLING_MAX,
+                                                      CNNL_PROPAGATE_NAN,
+                                                      kernelH,
+                                                      kernelW,
+                                                      padUp,
+                                                      padDown,
+                                                      padLeft,
+                                                      padRight,
+                                                      strideH,
+                                                      strideW,
+                                                      dilation0,
+                                                      dilation1,
+                                                      ceilMode));
     }
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetPoolingWithIndexWorkspaceSize(handle, inputDesc.get(), outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetPoolingWithIndexWorkspaceSize(handle, inputDesc.get(), outDesc.get(), &workspaceSize));
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlPoolingForwardWithIndex(handle,
-                                               poolDesc,
-                                               nullptr,
-                                               inputDesc.get(),
-                                               inputTr.data(),
-                                               nullptr,
-                                               outDesc.get(),
-                                               outTmpTr.data(),
-                                               indicesDesc.get(),
-                                               indicesTmpTr.data(),
-                                               workspacePtr,
-                                               workspaceSize));
+    DIOPI_CALL_CNNL(cnnlPoolingForwardWithIndex(handle,
+                                                poolDesc,
+                                                nullptr,
+                                                inputDesc.get(),
+                                                inputTr.data(),
+                                                nullptr,
+                                                outDesc.get(),
+                                                outTmpTr.data(),
+                                                indicesDesc.get(),
+                                                indicesTmpTr.data(),
+                                                workspacePtr,
+                                                workspaceSize));
 
     if (outTmpTr.dtype() != outTr.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTr, outTmpTr));
@@ -283,21 +283,21 @@ diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
 
     CnnlResourceGuard<cnnlPoolingDescriptor_t, cnnlCreatePoolingDescriptor, cnnlDestroyPoolingDescriptor> cnnlPoolDesc;
     cnnlPoolingDescriptor_t poolDesc = cnnlPoolDesc.get();
-    DIOPI_CALLCNNL(cnnlSetPooling2dDescriptor_v2(
+    DIOPI_CALL_CNNL(cnnlSetPooling2dDescriptor_v2(
         poolDesc, CNNL_POOLING_MAX, CNNL_PROPAGATE_NAN, kernelH, kernelW, padUp, padDown, padLeft, padRight, strideH, strideW, dilation0, dilation1, ceilMode));
 
-    DIOPI_CALLCNNL(cnnlPoolingBackward(handle,
-                                       poolDesc,
-                                       nullptr,
-                                       indicesDesc.get(),
-                                       indicesTr.data(),
-                                       gradOutputDesc.get(),
-                                       gradOutputTr.data(),
-                                       inputDesc.get(),
-                                       inputTr.data(),
-                                       nullptr,
-                                       gradInputDesc.get(),
-                                       gradInputTmpTr.data()));
+    DIOPI_CALL_CNNL(cnnlPoolingBackward(handle,
+                                        poolDesc,
+                                        nullptr,
+                                        indicesDesc.get(),
+                                        indicesTr.data(),
+                                        gradOutputDesc.get(),
+                                        gradOutputTr.data(),
+                                        inputDesc.get(),
+                                        inputTr.data(),
+                                        nullptr,
+                                        gradInputDesc.get(),
+                                        gradInputTmpTr.data()));
 
     // Channels last -> contiguous
     DIOPI_CALL(contiguous(ctx, gradInputTmpTr, diopiMemoryFormat_t::Contiguous));

--- a/impl/camb/functions/maximum.cpp
+++ b/impl/camb/functions/maximum.cpp
@@ -28,11 +28,11 @@ diopiError_t diopiMaximum(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     CnnlTensorDesc outputDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetMaximumWorkspaceSize(handle, outputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetMaximumWorkspaceSize(handle, outputDesc.get(), &workspaceSize));
 
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlMaximum(
+    DIOPI_CALL_CNNL(cnnlMaximum(
         handle, inputDesc.get(), inputTensor.data(), otherDesc.get(), otherTensor.data(), outputDesc.get(), outTensorTmp.data(), workspacePtr, workspaceSize));
 
     DIOPI_CALL(dataTypeCast(ctx, outputTensor, outTensorTmp));

--- a/impl/camb/functions/meshgrid.cpp
+++ b/impl/camb/functions/meshgrid.cpp
@@ -44,7 +44,7 @@ diopiError_t diopiMeshGrid(diopiContextHandle_t ctx, diopiTensorHandle_t* outs, 
         inputDesc.set(inputTensor, CNNL_LAYOUT_ARRAY, inDims);
         outDesc.set(outTensor, CNNL_LAYOUT_ARRAY, outDims);
 
-        DIOPI_CALLCNNL(cnnlTile(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
+        DIOPI_CALL_CNNL(cnnlTile(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
     }
 
     return diopiSuccess;

--- a/impl/camb/functions/minimum.cpp
+++ b/impl/camb/functions/minimum.cpp
@@ -28,11 +28,11 @@ diopiError_t diopiMinimum(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     CnnlTensorDesc outputDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetMinimumWorkspaceSize(handle, outputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetMinimumWorkspaceSize(handle, outputDesc.get(), &workspaceSize));
 
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlMinimum(
+    DIOPI_CALL_CNNL(cnnlMinimum(
         handle, inputDesc.get(), inputTensor.data(), otherDesc.get(), otherTensor.data(), outputDesc.get(), outTensorTmp.data(), workspacePtr, workspaceSize));
 
     DIOPI_CALL(dataTypeCast(ctx, outputTensor, outTensorTmp));

--- a/impl/camb/functions/mm.cpp
+++ b/impl/camb/functions/mm.cpp
@@ -37,35 +37,35 @@ diopiError_t diopiMm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCon
     } else {
         return diopiDtypeNotSupported;
     }
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_COMPUTE_TYPE, &(compType), sizeof(cnnlDataType_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_COMPUTE_TYPE, &(compType), sizeof(cnnlDataType_t)));
     int32_t isTransa = 0;
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_TRANSA, &(isTransa), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_TRANSA, &(isTransa), sizeof(int32_t)));
     int32_t isTransb = 0;
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_TRANSB, &(isTransb), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_DESC_TRANSB, &(isTransb), sizeof(int32_t)));
     int32_t allowTf32I32 = 1;
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_ALLOW_TF32, &(allowTf32I32), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_ALLOW_TF32, &(allowTf32I32), sizeof(int32_t)));
 
     int32_t useBeta = 0;
     float beta = 0.0;
 
-    DIOPI_CALLCNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_USE_BETA, &(useBeta), sizeof(int32_t)));
+    DIOPI_CALL_CNNL(cnnlSetMatMulDescAttr(matmulDesc.get(), CNNL_MATMUL_USE_BETA, &(useBeta), sizeof(int32_t)));
 
     size_t workspaceSize = 0;
     int requestedAlgoCount = 1;
     int returnAlgoCount = 0;
     CnnlResourceGuard<cnnlMatMulHeuristicResult_t, cnnlCreateMatMulHeuristicResult, cnnlDestroyMatMulHeuristicResult> heuristicResult;
     CnnlResourceGuard<cnnlMatMulAlgo_t, cnnlMatMulAlgoCreate, cnnlMatMulAlgoDestroy> algo;
-    DIOPI_CALLCNNL(cnnlGetMatMulAlgoHeuristic(handle,
-                                              matmulDesc.get(),
-                                              aDesc.get(),
-                                              bDesc.get(),
-                                              outDesc.get(),
-                                              outDesc.get(),
-                                              nullptr,
-                                              requestedAlgoCount,
-                                              &heuristicResult.get(),
-                                              &returnAlgoCount));
-    DIOPI_CALLCNNL(cnnlGetMatMulHeuristicResult(heuristicResult.get(), algo.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetMatMulAlgoHeuristic(handle,
+                                               matmulDesc.get(),
+                                               aDesc.get(),
+                                               bDesc.get(),
+                                               outDesc.get(),
+                                               outDesc.get(),
+                                               nullptr,
+                                               requestedAlgoCount,
+                                               &heuristicResult.get(),
+                                               &returnAlgoCount));
+    DIOPI_CALL_CNNL(cnnlGetMatMulHeuristicResult(heuristicResult.get(), algo.get(), &workspaceSize));
 
     void* workspace = nullptr;
     if (0 != workspaceSize) {
@@ -74,21 +74,21 @@ diopiError_t diopiMm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCon
 
     float alphaDefault = 1.0;
 
-    DIOPI_CALLCNNL(cnnlMatMul_v2(handle,
-                                 matmulDesc.get(),
-                                 algo.get(),
-                                 &alphaDefault,
-                                 aDesc.get(),
-                                 aCasted.data(),
-                                 bDesc.get(),
-                                 bCasted.data(),
-                                 &beta,
-                                 outDesc.get(),
-                                 outCasted.data(),
-                                 workspace,
-                                 workspaceSize,
-                                 outDesc.get(),
-                                 outCasted.data()));
+    DIOPI_CALL_CNNL(cnnlMatMul_v2(handle,
+                                  matmulDesc.get(),
+                                  algo.get(),
+                                  &alphaDefault,
+                                  aDesc.get(),
+                                  aCasted.data(),
+                                  bDesc.get(),
+                                  bCasted.data(),
+                                  &beta,
+                                  outDesc.get(),
+                                  outCasted.data(),
+                                  workspace,
+                                  workspaceSize,
+                                  outDesc.get(),
+                                  outCasted.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outCasted));
     return diopiSuccess;
 }

--- a/impl/camb/functions/multinomial.cpp
+++ b/impl/camb/functions/multinomial.cpp
@@ -12,8 +12,8 @@ namespace camb {
 
 class CnnlRandGenerator final {
 public:
-    CnnlRandGenerator() { DIOPI_CHECKCNNL(cnnlRandCreateGenerator(&resource_, CNNL_RAND_RNG_MTGP32)); }
-    ~CnnlRandGenerator() { DIOPI_CHECKCNNL(cnnlRandDestroyGenerator(resource_)); }
+    CnnlRandGenerator() { DIOPI_CHECK_CNNL(cnnlRandCreateGenerator(&resource_, CNNL_RAND_RNG_MTGP32)); }
+    ~CnnlRandGenerator() { DIOPI_CHECK_CNNL(cnnlRandDestroyGenerator(resource_)); }
     cnnlRandGenerator_t& get() { return resource_; }
 
 private:
@@ -36,7 +36,7 @@ diopiError_t diopiMultinomial(diopiContextHandle_t ctx, diopiTensorHandle_t out,
     CnnlTensorDesc outDesc(outTemp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize;
-    DIOPI_CALLCNNL(cnnlGetRandGenerateMultinomialWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetRandGenerateMultinomialWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (workspaceSize > 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -46,7 +46,7 @@ diopiError_t diopiMultinomial(diopiContextHandle_t ctx, diopiTensorHandle_t out,
     DIOPI_CALL(diopiGeneratorGetState(ctx, gen, &stateHandle));
     void* statePtr = nullptr;
     DIOPI_CALL(diopiGetTensorData(stateHandle, &statePtr));
-    DIOPI_CALLCNNL(cnnlRandGenerateMultinomial_v2(
+    DIOPI_CALL_CNNL(cnnlRandGenerateMultinomial_v2(
         handle, generator, inputDesc.get(), inputTensor.data(), replacement, false, statePtr, workspace, workspaceSize, outDesc.get(), outTemp.data()));
     DIOPI_CALL(diopiGeneratorSetState(gen, stateHandle));
     if (outTensor.dtype() != outTemp.dtype()) {

--- a/impl/camb/functions/neg.cpp
+++ b/impl/camb/functions/neg.cpp
@@ -23,7 +23,7 @@ diopiError_t diopiNeg(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
 
     CnnlTensorDesc inputDesc(inputTensorTmp, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlNegTensor(handle, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlNegTensor(handle, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     return diopiSuccess;
 }

--- a/impl/camb/functions/nonzero.cpp
+++ b/impl/camb/functions/nonzero.cpp
@@ -14,7 +14,7 @@ diopiError_t nonzeroCount(diopiContextHandle_t ctx, DiopiTensor inputTensor, Dio
     *numTrue = requiresTensor(ctx, shape, diopi_dtype_int32);
     CnnlTensorDesc numTrueDesc(*numTrue, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlNumTrue_v2(handle, inputDesc.get(), inputTensor.data(), numTrueDesc.get(), numTrue->data()));
+    DIOPI_CALL_CNNL(cnnlNumTrue_v2(handle, inputDesc.get(), inputTensor.data(), numTrueDesc.get(), numTrue->data()));
     return diopiSuccess;
 }
 
@@ -34,7 +34,7 @@ diopiError_t diopiNonzero(diopiContextHandle_t ctx, diopiTensorHandle_t* out, di
     CnnlTensorDesc numTrueDesc(numTrue, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize(0);
-    DIOPI_CALLCNNL(cnnlGetWhereWorkspaceSize(handle, numTrueDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetWhereWorkspaceSize(handle, numTrueDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -50,7 +50,7 @@ diopiError_t diopiNonzero(diopiContextHandle_t ctx, diopiTensorHandle_t* out, di
     auto outTensor = requiresTensor(ctx, shape, diopi_dtype_int32);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlWhere_v2(
+    DIOPI_CALL_CNNL(cnnlWhere_v2(
         handle, inputDesc.get(), inputTensor.data(), numTrueDesc.get(), numTrue.data(), false, workspace, workspaceSize, outDesc.get(), outTensor.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, diopi_dtype_int64));
     *out = diopiTensorHandle_t(outTensor);

--- a/impl/camb/functions/normal.cpp
+++ b/impl/camb/functions/normal.cpp
@@ -23,15 +23,15 @@ diopiError_t diopiNormal(diopiContextHandle_t ctx, diopiTensorHandle_t out, doub
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, tensor.dtype()));
     cnnlRandGenerator_t cnnlGenerator;
     // cnnlRandRngType_t rng_type is recommended to be set as CNNL_RAND_RNG_MTGP32 on MLU300 series and CNNL_RAND_RNG_FAST on MLU200 series.
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
+    DIOPI_CALL_CNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
 
     diopiTensorHandle_t stateHandle = nullptr;
     DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));
     void* statePtr = nullptr;
     DIOPI_CALL(diopiGetTensorData(stateHandle, &statePtr));
-    DIOPI_CALLCNNL(cnnlRandGenerateNormal(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), mean, std, tensor.data()));
+    DIOPI_CALL_CNNL(cnnlRandGenerateNormal(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), mean, std, tensor.data()));
     DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
-    DIOPI_CALLCNNL(cnnlRandDestroyGenerator(cnnlGenerator));
+    DIOPI_CALL_CNNL(cnnlRandDestroyGenerator(cnnlGenerator));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/one_hot.cpp
+++ b/impl/camb/functions/one_hot.cpp
@@ -28,7 +28,7 @@ diopiError_t maxAll(diopiContextHandle_t ctx, diopiTensorHandle_t max, diopiTens
     reduceDesc.set(inputTensor, dims, CNNL_REDUCE_MAX, CNNL_REDUCE_NO_INDICES, CNNL_32BIT_INDICES, dtype);
 
     size_t workspaceSize(0);
-    DIOPI_CALLCNNL(cnnlGetReduceOpWorkspaceSize(handle, inputDesc.get(), outputDesc.get(), reduceDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetReduceOpWorkspaceSize(handle, inputDesc.get(), outputDesc.get(), reduceDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -38,18 +38,18 @@ diopiError_t maxAll(diopiContextHandle_t ctx, diopiTensorHandle_t max, diopiTens
     void* indices = nullptr;
     void* alpha = nullptr;
     void* beta = nullptr;
-    DIOPI_CALLCNNL(cnnlReduce(handle,
-                              reduceDesc.get(),
-                              workspace,
-                              workspaceSize,
-                              alpha,
-                              inputDesc.get(),
-                              inputTensor.data(),
-                              indicesSizeInbytes,
-                              indices,
-                              beta,
-                              outputDesc.get(),
-                              outputTensor.data()));
+    DIOPI_CALL_CNNL(cnnlReduce(handle,
+                               reduceDesc.get(),
+                               workspace,
+                               workspaceSize,
+                               alpha,
+                               inputDesc.get(),
+                               inputTensor.data(),
+                               indicesSizeInbytes,
+                               indices,
+                               beta,
+                               outputDesc.get(),
+                               outputTensor.data()));
     return diopiSuccess;
 }
 
@@ -96,18 +96,18 @@ diopiError_t diopiOneHot(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     CnnlTensorDesc offTensorDesc(offValueTensor, CNNL_LAYOUT_ARRAY);
     int32_t one = 1;
     int32_t zero = 0;
-    DIOPI_CALLCNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, &one, onTensorDesc.get(), onValueTensor.data()));
-    DIOPI_CALLCNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, &zero, offTensorDesc.get(), offValueTensor.data()));
+    DIOPI_CALL_CNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, &one, onTensorDesc.get(), onValueTensor.data()));
+    DIOPI_CALL_CNNL(cnnlFill_v3(handle, CNNL_POINTER_MODE_HOST, &zero, offTensorDesc.get(), offValueTensor.data()));
     int axis = -1;
 
     // output must be int32, float16, float32
     if (diopi_dtype_int32 != outTensor.dtype()) {
         DiopiTensor out32Tensor = requiresTensor(ctx, outTensor.shape(), diopi_dtype_int32);
-        DIOPI_CALLCNNL(cnnlOneHot(
+        DIOPI_CALL_CNNL(cnnlOneHot(
             handle, inputDesc.get(), inputTensor.data(), clsNum, onValueTensor.data(), offValueTensor.data(), axis, CNNL_DTYPE_INT32, out32Tensor.data()));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, out32Tensor));
     } else {
-        DIOPI_CALLCNNL(cnnlOneHot(
+        DIOPI_CALL_CNNL(cnnlOneHot(
             handle, inputDesc.get(), inputTensor.data(), clsNum, onValueTensor.data(), offValueTensor.data(), axis, CNNL_DTYPE_INT32, outTensor.data()));
     }
 

--- a/impl/camb/functions/pad.cpp
+++ b/impl/camb/functions/pad.cpp
@@ -108,7 +108,7 @@ DIOPI_API diopiError_t diopiPad(diopiContextHandle_t ctx, diopiTensorHandle_t ou
             }
         }
         if (allPadsIsZero) {
-            DIOPI_CALLCNNL(cnnlCopy(handle, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
+            DIOPI_CALL_CNNL(cnnlCopy(handle, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
         }
 
         auto inputSizes = inputTensor.shape();
@@ -133,7 +133,7 @@ DIOPI_API diopiError_t diopiPad(diopiContextHandle_t ctx, diopiTensorHandle_t ou
         }
 
         void* valuePtr = getTypedValuePtr(inputTensorTmp.dtype(), value);
-        DIOPI_CALLCNNL(
+        DIOPI_CALL_CNNL(
             cnnlPad(handle, inputDesc.get(), inputTensorTmp.data(), newPad, (value == nullptr) ? nullptr : valuePtr, outDesc.get(), outTensorTmp.data()));
     } else if (padMode == "reflect") {
         std::vector<int> inputDim = getDim(inputTensorTmp);
@@ -153,7 +153,7 @@ DIOPI_API diopiError_t diopiPad(diopiContextHandle_t ctx, diopiTensorHandle_t ou
         } else {
             DIOPI_CHECK(false, "Only supports 2D padding for reflection padding mode now.");
         }
-        DIOPI_CALLCNNL(cnnlReflectionPad2d(handle, inputDesc.get(), inputTensorTmp.data(), padTmp, outDesc.get(), outTensorTmp.data()));
+        DIOPI_CALL_CNNL(cnnlReflectionPad2d(handle, inputDesc.get(), inputTensorTmp.data(), padTmp, outDesc.get(), outTensorTmp.data()));
     } else if (padMode == "replicate") {
         std::vector<int> inputDim = getDim(inputTensorTmp);
         std::vector<int> outDim = getDim(outTensorTmp);
@@ -172,7 +172,7 @@ DIOPI_API diopiError_t diopiPad(diopiContextHandle_t ctx, diopiTensorHandle_t ou
         } else {
             DIOPI_CHECK(false, "Only supports 2D padding for replicate padding mode now.");
         }
-        DIOPI_CALLCNNL(cnnlReplicationPad2d(handle, inputDesc.get(), inputTensorTmp.data(), padTmp, outDesc.get(), outTensorTmp.data()));
+        DIOPI_CALL_CNNL(cnnlReplicationPad2d(handle, inputDesc.get(), inputTensorTmp.data(), padTmp, outDesc.get(), outTensorTmp.data()));
     } else if (padMode == "circular") {
         inputDesc.set(inputTensorTmp, CNNL_LAYOUT_ARRAY);
         outDesc.set(outTensorTmp, CNNL_LAYOUT_ARRAY);

--- a/impl/camb/functions/permute.cpp
+++ b/impl/camb/functions/permute.cpp
@@ -35,21 +35,21 @@ diopiError_t diopiPermute(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
 
     const std::vector<int64_t> srcInputShape = inputTensor.shape();
     int dimNum = srcInputShape.size();
-    DIOPI_CALLCNNL(cnnlSetTransposeDescriptor(transDesc.get(), dimNum, permData.data()));
+    DIOPI_CALL_CNNL(cnnlSetTransposeDescriptor(transDesc.get(), dimNum, permData.data()));
     size_t workspaceSize;
-    DIOPI_CALLCNNL(cnnlGetTransposeWorkspaceSize(handle, inputDesc.get(), transDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetTransposeWorkspaceSize(handle, inputDesc.get(), transDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
     if (inputTensor.dtype() == outputTensor.dtype()) {
-        DIOPI_CALLCNNL(
+        DIOPI_CALL_CNNL(
             cnnlTranspose_v2(handle, transDesc.get(), inputDesc.get(), inputTensor.data(), outputDesc.get(), outputTensor.data(), workspace, workspaceSize));
     } else {
         DiopiTensor outTemp = requiresTensor(ctx, outputTensor.shape(), inputTensor.dtype());
         CnnlTensorDesc outTempDesc(outTemp, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(
+        DIOPI_CALL_CNNL(
             cnnlTranspose_v2(handle, transDesc.get(), inputDesc.get(), inputTensor.data(), outTempDesc.get(), outTemp.data(), workspace, workspaceSize));
         DIOPI_CALL(dataTypeCast(ctx, outputTensor, outTemp));
     }

--- a/impl/camb/functions/polar.cpp
+++ b/impl/camb/functions/polar.cpp
@@ -25,13 +25,13 @@ DIOPI_API diopiError_t diopiPolar(diopiContextHandle_t ctx, diopiTensorHandle_t 
     CnnlTensorDesc angleDesc(angleTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetPolarWorkspaceSize(handle, absDesc.get(), angleDesc.get(), outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetPolarWorkspaceSize(handle, absDesc.get(), angleDesc.get(), outDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(
+    DIOPI_CALL_CNNL(
         cnnlPolar(handle, absDesc.get(), absTensor.data(), angleDesc.get(), angleTensor.data(), outDesc.get(), outTensor.data(), workspace, workspaceSize));
     return diopiSuccess;
 }

--- a/impl/camb/functions/pow.cpp
+++ b/impl/camb/functions/pow.cpp
@@ -35,22 +35,22 @@ diopiError_t diopiPowTensor(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     CnnlTensorDesc exponentDesc(exponentTensorTmp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetPowWorkspaceSize(handle, inputDesc.get(), exponentDesc.get(), outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetPowWorkspaceSize(handle, inputDesc.get(), exponentDesc.get(), outDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlPow(handle,
-                           CNNL_COMPUTATION_HIGH_PRECISION,
-                           inputDesc.get(),
-                           inputTensorTmp.data(),
-                           exponentDesc.get(),
-                           exponentTensorTmp.data(),
-                           workspace,
-                           workspaceSize,
-                           outDesc.get(),
-                           outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlPow(handle,
+                            CNNL_COMPUTATION_HIGH_PRECISION,
+                            inputDesc.get(),
+                            inputTensorTmp.data(),
+                            exponentDesc.get(),
+                            exponentTensorTmp.data(),
+                            workspace,
+                            workspaceSize,
+                            outDesc.get(),
+                            outTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     return diopiSuccess;
 }

--- a/impl/camb/functions/random.cpp
+++ b/impl/camb/functions/random.cpp
@@ -20,7 +20,7 @@ extern "C" diopiError_t diopiRandomInp(diopiContextHandle_t ctx, diopiTensorHand
     cnnlDataType_t dtype;
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, tensor.dtype()));
     cnnlRandGenerator_t cnnlGenerator;
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
+    DIOPI_CALL_CNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
 
     if (dtype == CNNL_DTYPE_FLOAT || dtype == CNNL_DTYPE_HALF) {
         float min = from;
@@ -34,13 +34,13 @@ extern "C" diopiError_t diopiRandomInp(diopiContextHandle_t ctx, diopiTensorHand
         DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));
         void* statePtr = nullptr;
         DIOPI_CALL(diopiGetTensorData(stateHandle, &statePtr));
-        DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), min, max, tensor.data()));
+        DIOPI_CALL_CNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), min, max, tensor.data()));
         DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
     } else {
         setLastErrorString("%s%d", "cnnl random not support datatype: ", dtype);
         return diopiDtypeNotSupported;
     }
-    DIOPI_CALLCNNL(cnnlRandDestroyGenerator(cnnlGenerator));
+    DIOPI_CALL_CNNL(cnnlRandDestroyGenerator(cnnlGenerator));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/reciprocal.cpp
+++ b/impl/camb/functions/reciprocal.cpp
@@ -22,7 +22,7 @@ diopiError_t diopiReciprocal(diopiContextHandle_t ctx, diopiTensorHandle_t out, 
 
     CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlReciprocal(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlReciprocal(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
 
     if (originDtype == diopi_dtype_float64) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, originDtype));

--- a/impl/camb/functions/reduce.cpp
+++ b/impl/camb/functions/reduce.cpp
@@ -102,21 +102,21 @@ diopiError_t reduceInternal(diopiContextHandle_t ctx, DiopiTensor& inputTr, Diop
     }
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetReduceOpWorkspaceSize(handle, inputDesc.get(), outputDesc.get(), reduceDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetReduceOpWorkspaceSize(handle, inputDesc.get(), outputDesc.get(), reduceDesc.get(), &workspaceSize));
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlReduce(handle,
-                              reduceDesc.get(),
-                              workspacePtr,
-                              workspaceSize,
-                              nullptr,
-                              inputDesc.get(),
-                              inputTr.data(),
-                              sizeof(int) * indexTr.numel(),
-                              reduceIndices != CNNL_REDUCE_NO_INDICES ? indexTr.data() : nullptr,
-                              nullptr,
-                              outputDesc.get(),
-                              outputTr.data()));
+    DIOPI_CALL_CNNL(cnnlReduce(handle,
+                               reduceDesc.get(),
+                               workspacePtr,
+                               workspaceSize,
+                               nullptr,
+                               inputDesc.get(),
+                               inputTr.data(),
+                               sizeof(int) * indexTr.numel(),
+                               reduceIndices != CNNL_REDUCE_NO_INDICES ? indexTr.data() : nullptr,
+                               nullptr,
+                               outputDesc.get(),
+                               outputTr.data()));
 
     return diopiSuccess;
 }

--- a/impl/camb/functions/remainder.cpp
+++ b/impl/camb/functions/remainder.cpp
@@ -26,13 +26,13 @@ DIOPI_API diopiError_t diopiRemainderTensor(diopiContextHandle_t ctx, diopiTenso
     CnnlTensorDesc outDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetFloorModWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetFloorModWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outDesc.get(), &workspaceSize));
     void *workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlFloorMod(
+    DIOPI_CALL_CNNL(cnnlFloorMod(
         handle, inputDesc.get(), inputTensor.data(), otherDesc.get(), otherTensor.data(), outDesc.get(), outTensorTemp.data(), workspace, workspaceSize));
 
     if (outTensor.dtype() != outTensorTemp.dtype()) {

--- a/impl/camb/functions/repeat.cpp
+++ b/impl/camb/functions/repeat.cpp
@@ -18,7 +18,7 @@ diopiError_t diopiRepeat(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlTile(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlTile(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/roll.cpp
+++ b/impl/camb/functions/roll.cpp
@@ -18,23 +18,23 @@ diopiError_t diopiRoll(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
     std::vector<int> shiftsTmp{shifts.data, shifts.data + shifts.len};
     std::vector<int> dimsTmp{dims.data, dims.data + dims.len};
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetRollWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetRollWorkspaceSize(handle, inputDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlRoll(handle,
-                            inputDesc.get(),
-                            inputTensor.data(),
-                            shiftsTmp.data(),
-                            shiftsTmp.size(),
-                            !dimsTmp.empty() ? dimsTmp.data() : nullptr,
-                            dimsTmp.size(),
-                            workspace,
-                            workspaceSize,
-                            outDesc.get(),
-                            outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlRoll(handle,
+                             inputDesc.get(),
+                             inputTensor.data(),
+                             shiftsTmp.data(),
+                             shiftsTmp.size(),
+                             !dimsTmp.empty() ? dimsTmp.data() : nullptr,
+                             dimsTmp.size(),
+                             workspace,
+                             workspaceSize,
+                             outDesc.get(),
+                             outTensor.data()));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/rsqrt.cpp
+++ b/impl/camb/functions/rsqrt.cpp
@@ -26,7 +26,7 @@ static diopiError_t rsqrt(diopiContextHandle_t ctx, DiopiTensor& output, DiopiTe
     }
 
     CnnlTensorDesc desc(input, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlRsqrt_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, desc.get(), input.data(), desc.get(), outputTmp.data()));
+    DIOPI_CALL_CNNL(cnnlRsqrt_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, desc.get(), input.data(), desc.get(), outputTmp.data()));
     if (outputTmp.dtype() != output.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, output, outputTmp));
     }

--- a/impl/camb/functions/scatter.cpp
+++ b/impl/camb/functions/scatter.cpp
@@ -16,7 +16,7 @@ static diopiError_t slice(cnnlHandle_t handle, DiopiTensor outTensor, DiopiTenso
                           std::vector<int32_t> step) {
     CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlStridedSlice(handle, inputDesc.get(), inputTensor.data(), start.data(), end.data(), step.data(), outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlStridedSlice(handle, inputDesc.get(), inputTensor.data(), start.data(), end.data(), step.data(), outDesc.get(), outTensor.data()));
     return diopiSuccess;
 }
 
@@ -65,17 +65,17 @@ static diopiError_t scatter(diopiContextHandle_t ctx, DiopiTensor outTensor, Dio
     CnnlTensorDesc srcDesc(actualSrcTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc indexDesc(indexTensor, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlScatter(handle,
-                               dim,
-                               inputDesc.get(),
-                               inputTensorTmp.data(),
-                               indexDesc.get(),
-                               indexTensor.data(),
-                               srcDesc.get(),
-                               actualSrcTensor.data(),
-                               outDesc.get(),
-                               outTensorTmp.data(),
-                               mode));
+    DIOPI_CALL_CNNL(cnnlScatter(handle,
+                                dim,
+                                inputDesc.get(),
+                                inputTensorTmp.data(),
+                                indexDesc.get(),
+                                indexTensor.data(),
+                                srcDesc.get(),
+                                actualSrcTensor.data(),
+                                outDesc.get(),
+                                outTensorTmp.data(),
+                                mode));
     if (outTensor.dtype() != outTensorTmp.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     }

--- a/impl/camb/functions/sgd.cpp
+++ b/impl/camb/functions/sgd.cpp
@@ -23,14 +23,14 @@ static diopiError_t addMulFunc(diopiContextHandle_t ctx, DiopiTensor &a, float s
     DIOPI_CALL(aDesc.set(a, CNNL_LAYOUT_ARRAY, shape));
     DIOPI_CALL(bDesc.set(b, CNNL_LAYOUT_ARRAY, shape));
 
-    DIOPI_CALLCNNL(cnnlGetBiasAddWorkspaceSize(handle, bDesc.get(), aDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetBiasAddWorkspaceSize(handle, bDesc.get(), aDesc.get(), &workspaceSize));
 
     void *workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlBiasAdd(handle, &scaleB, bDesc.get(), b.data(), workspace, workspaceSize, &scaleA, aDesc.get(), a.data()));
+    DIOPI_CALL_CNNL(cnnlBiasAdd(handle, &scaleB, bDesc.get(), b.data(), workspace, workspaceSize, &scaleA, aDesc.get(), a.data()));
     return diopiSuccess;
 }
 
@@ -88,7 +88,7 @@ diopiError_t diopiSgd(diopiContextHandle_t ctx, diopiTensorHandle_t w, diopiTens
     diopiScalar_t lrScalar = constructDiopiScalarT(diopi_dtype_float64, lr);
     DIOPI_CALL(makeTensorFromScalar(ctx, &lrScalar, lrTensor));
     DIOPI_CALL(dataTypeCast(ctx, lrTensor, dwTensorTmp.dtype()));
-    DIOPI_CALLCNNL(cnnlGradientDescent(handle, dwDesc.get(), dwTensorTmp.data(), lrTensor.data(), wDescTmp.get(), wTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlGradientDescent(handle, dwDesc.get(), dwTensorTmp.data(), lrTensor.data(), wDescTmp.get(), wTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, wTensor, wTensorTmp));
     if (buf != nullptr) {
         DIOPI_CALL(dataTypeCast(ctx, bufTensor, bufTensorTmp));

--- a/impl/camb/functions/sgn.cpp
+++ b/impl/camb/functions/sgn.cpp
@@ -28,7 +28,7 @@ diopiError_t diopiSgn(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
 
     CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlSign(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlSign(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensorTemp.data()));
 
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));

--- a/impl/camb/functions/sign.cpp
+++ b/impl/camb/functions/sign.cpp
@@ -26,7 +26,7 @@ diopiError_t diopiSign(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
 
     CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlSign(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlSign(handle, inputDesc.get(), inputTensor.data(), outDesc.get(), outTensorTemp.data()));
 
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));

--- a/impl/camb/functions/sin.cpp
+++ b/impl/camb/functions/sin.cpp
@@ -23,7 +23,7 @@ static diopiError_t sin(diopiContextHandle_t ctx, DiopiTensor& output, DiopiTens
         outputTmp = requiresTensor(ctx, output.shape(), input.dtype());
     }
     CnnlTensorDesc desc(input, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlSin_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, desc.get(), input.data(), desc.get(), outputTmp.data()));
+    DIOPI_CALL_CNNL(cnnlSin_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, desc.get(), input.data(), desc.get(), outputTmp.data()));
     if (outputTmp.dtype() != output.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, output, outputTmp));
     }

--- a/impl/camb/functions/slice.cpp
+++ b/impl/camb/functions/slice.cpp
@@ -27,11 +27,12 @@ diopiError_t diopiIndexSelect(diopiContextHandle_t ctx, diopiTensorHandle_t out,
         dim = dim + inputTensor.dim();
     }
     if (outTensor.dtype() == inputTensor.dtype()) {
-        DIOPI_CALLCNNL(cnnlIndexSelect(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outDesc.get(), outTensor.data()));
+        DIOPI_CALL_CNNL(
+            cnnlIndexSelect(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outDesc.get(), outTensor.data()));
     } else {
         DiopiTensor outTempTensor = requiresTensor(ctx, outTensor.shape(), inputTensor.dtype());
         CnnlTensorDesc outTempDesc(outTempTensor, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(
+        DIOPI_CALL_CNNL(
             cnnlIndexSelect(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outTempDesc.get(), outTempTensor.data()));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTempTensor));
     }
@@ -72,27 +73,27 @@ diopiError_t diopiIndexSelectBackward(diopiContextHandle_t ctx, diopiTensorHandl
     }
 
     if (gradInputTensor.dtype() == outDtype) {
-        DIOPI_CALLCNNL(cnnlIndexAdd(handle,
-                                    dim,
-                                    gradInputDesc.get(),
-                                    gradInputTensor.data(),
-                                    indexDesc.get(),
-                                    indexTensor.data(),
-                                    gradDesc.get(),
-                                    gradTensor.data(),
-                                    gradInputDesc.get(),
-                                    gradInputTensor.data()));
+        DIOPI_CALL_CNNL(cnnlIndexAdd(handle,
+                                     dim,
+                                     gradInputDesc.get(),
+                                     gradInputTensor.data(),
+                                     indexDesc.get(),
+                                     indexTensor.data(),
+                                     gradDesc.get(),
+                                     gradTensor.data(),
+                                     gradInputDesc.get(),
+                                     gradInputTensor.data()));
     } else {
-        DIOPI_CALLCNNL(cnnlIndexAdd(handle,
-                                    dim,
-                                    gradInputDesc.get(),
-                                    gradInputTensor.data(),
-                                    indexDesc.get(),
-                                    indexTensor.data(),
-                                    gradDesc.get(),
-                                    gradTensor.data(),
-                                    gradInputDesc.get(),
-                                    gradInputTensor.data()));
+        DIOPI_CALL_CNNL(cnnlIndexAdd(handle,
+                                     dim,
+                                     gradInputDesc.get(),
+                                     gradInputTensor.data(),
+                                     indexDesc.get(),
+                                     indexTensor.data(),
+                                     gradDesc.get(),
+                                     gradTensor.data(),
+                                     gradInputDesc.get(),
+                                     gradInputTensor.data()));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, gradInputTensor));
     }
     return diopiSuccess;
@@ -123,11 +124,12 @@ diopiError_t diopiSelect(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
 
     if (outTensor.dtype() == inputTensor.dtype()) {
-        DIOPI_CALLCNNL(cnnlIndexSelect(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outDesc.get(), outTensor.data()));
+        DIOPI_CALL_CNNL(
+            cnnlIndexSelect(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outDesc.get(), outTensor.data()));
     } else {
         DiopiTensor outTempTensor = requiresTensor(ctx, outTensor.shape(), inputTensor.dtype());
         CnnlTensorDesc outTempDesc(outTempTensor, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(
+        DIOPI_CALL_CNNL(
             cnnlIndexSelect(handle, dim, inputDesc.get(), inputTensor.data(), indexDesc.get(), indexTensor.data(), outTempDesc.get(), outTempTensor.data()));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTempTensor));
     }
@@ -172,27 +174,27 @@ diopiError_t diopiSelectBackward(diopiContextHandle_t ctx, diopiTensorHandle_t g
     CnnlTensorDesc indexDesc(indexTensor, CNNL_LAYOUT_ARRAY);
 
     if (gradInputTensor.dtype() == outDtype) {
-        DIOPI_CALLCNNL(cnnlIndexAdd(handle,
-                                    dim,
-                                    gradInputDesc.get(),
-                                    gradInputTensor.data(),
-                                    indexDesc.get(),
-                                    indexTensor.data(),
-                                    gradDesc.get(),
-                                    gradTensor.data(),
-                                    gradInputDesc.get(),
-                                    gradInputTensor.data()));
+        DIOPI_CALL_CNNL(cnnlIndexAdd(handle,
+                                     dim,
+                                     gradInputDesc.get(),
+                                     gradInputTensor.data(),
+                                     indexDesc.get(),
+                                     indexTensor.data(),
+                                     gradDesc.get(),
+                                     gradTensor.data(),
+                                     gradInputDesc.get(),
+                                     gradInputTensor.data()));
     } else {
-        DIOPI_CALLCNNL(cnnlIndexAdd(handle,
-                                    dim,
-                                    gradInputDesc.get(),
-                                    gradInputTensor.data(),
-                                    indexDesc.get(),
-                                    indexTensor.data(),
-                                    gradDesc.get(),
-                                    gradTensor.data(),
-                                    gradInputDesc.get(),
-                                    gradInputTensor.data()));
+        DIOPI_CALL_CNNL(cnnlIndexAdd(handle,
+                                     dim,
+                                     gradInputDesc.get(),
+                                     gradInputTensor.data(),
+                                     indexDesc.get(),
+                                     indexTensor.data(),
+                                     gradDesc.get(),
+                                     gradTensor.data(),
+                                     gradInputDesc.get(),
+                                     gradInputTensor.data()));
         DiopiTensor outTensor(gradInput);
         DIOPI_CALL(dataTypeCast(ctx, outTensor, gradInputTensor));
     }
@@ -215,7 +217,8 @@ diopiError_t diopiSlice(diopiContextHandle_t ctx, diopiTensorHandle_t nullOut, d
     step32[dim] = step;
     end32[dim] = end;
 
-    DIOPI_CALLCNNL(cnnlStridedSlice(handle, inputDesc.get(), inputTensor.data(), start32.data(), end32.data(), step32.data(), outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(
+        cnnlStridedSlice(handle, inputDesc.get(), inputTensor.data(), start32.data(), end32.data(), step32.data(), outDesc.get(), outTensor.data()));
     return diopiSuccess;
 }
 
@@ -238,12 +241,12 @@ diopiError_t diopiSliceBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gr
     end32[dim] = end;
 
     if (outTensor.dtype() == inputTensor.dtype()) {
-        DIOPI_CALLCNNL(cnnlStridedSliceBackward(
+        DIOPI_CALL_CNNL(cnnlStridedSliceBackward(
             handle, start32.data(), end32.data(), step32.data(), inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
     } else {
         DiopiTensor outTempTensor = requiresTensor(ctx, outTensor.shape(), inputTensor.dtype());
         CnnlTensorDesc outTempDesc(outTempTensor, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlStridedSliceBackward(
+        DIOPI_CALL_CNNL(cnnlStridedSliceBackward(
             handle, start32.data(), end32.data(), step32.data(), inputDesc.get(), inputTensor.data(), outTempDesc.get(), outTempTensor.data()));
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTempTensor));
     }

--- a/impl/camb/functions/softmax.cpp
+++ b/impl/camb/functions/softmax.cpp
@@ -64,16 +64,16 @@ diopiError_t softmaxForward(diopiContextHandle_t ctx, DiopiTensor input, DiopiTe
     CnnlTensorDesc xDesc, yDesc;
     DIOPI_CALL(xDesc.set(inputCasted, CNNL_LAYOUT_ARRAY, inputShape));
     DIOPI_CALL(yDesc.set(outputCasted, CNNL_LAYOUT_ARRAY, inputShape));
-    DIOPI_CALLCNNL(cnnlSoftmaxForward_v2(handle,
-                                         isLog ? CNNL_SOFTMAX_LOG : CNNL_SOFTMAX_ACCURATE,
-                                         modeTmp,
-                                         CNNL_COMPUTATION_FAST,
-                                         alpha,
-                                         xDesc.get(),
-                                         inputCasted.data(),
-                                         beta,
-                                         yDesc.get(),
-                                         outputCasted.data()));
+    DIOPI_CALL_CNNL(cnnlSoftmaxForward_v2(handle,
+                                          isLog ? CNNL_SOFTMAX_LOG : CNNL_SOFTMAX_ACCURATE,
+                                          modeTmp,
+                                          CNNL_COMPUTATION_FAST,
+                                          alpha,
+                                          xDesc.get(),
+                                          inputCasted.data(),
+                                          beta,
+                                          yDesc.get(),
+                                          outputCasted.data()));
 
     DIOPI_CALL(dataTypeCast(ctx, output, outputCasted));
     return diopiSuccess;
@@ -136,17 +136,17 @@ diopiError_t softmaxBackward(diopiContextHandle_t ctx, DiopiTensor gradInputTens
 
     const void *alpha = nullptr;
     const void *beta = nullptr;
-    DIOPI_CALLCNNL(cnnlSoftmaxBackward(handle,
-                                       isLog ? CNNL_SOFTMAX_LOG : CNNL_SOFTMAX_ACCURATE,
-                                       modeTmp,
-                                       alpha,
-                                       outputDesc.get(),
-                                       outputCasted.data(),
-                                       gradOutputDesc.get(),
-                                       gradOutputCasted.data(),
-                                       beta,
-                                       gradInputDesc.get(),
-                                       gradInputCasted.data()));
+    DIOPI_CALL_CNNL(cnnlSoftmaxBackward(handle,
+                                        isLog ? CNNL_SOFTMAX_LOG : CNNL_SOFTMAX_ACCURATE,
+                                        modeTmp,
+                                        alpha,
+                                        outputDesc.get(),
+                                        outputCasted.data(),
+                                        gradOutputDesc.get(),
+                                        gradOutputCasted.data(),
+                                        beta,
+                                        gradInputDesc.get(),
+                                        gradInputCasted.data()));
     DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputCasted));
     return diopiSuccess;
 }

--- a/impl/camb/functions/sort.cpp
+++ b/impl/camb/functions/sort.cpp
@@ -46,25 +46,25 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
     k = inputShape[dim];
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetTopKTensorWorkspaceSize(handle, inputDesc.get(), k, dim, descending, valuesDesc.get(), indicesDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetTopKTensorWorkspaceSize(handle, inputDesc.get(), k, dim, descending, valuesDesc.get(), indicesDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
-    DIOPI_CALLCNNL(cnnlTopKTensor_v3(handle,
-                                     inputDesc.get(),
-                                     inputTensorTemp.data(),
-                                     k,
-                                     dim,
-                                     descending,
-                                     true,
-                                     stable,
-                                     workspace,
-                                     workspaceSize,
-                                     valuesDesc.get(),
-                                     valuesTensorTemp.data(),
-                                     indicesDesc.get(),
-                                     indicesTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlTopKTensor_v3(handle,
+                                      inputDesc.get(),
+                                      inputTensorTemp.data(),
+                                      k,
+                                      dim,
+                                      descending,
+                                      true,
+                                      stable,
+                                      workspace,
+                                      workspaceSize,
+                                      valuesDesc.get(),
+                                      valuesTensorTemp.data(),
+                                      indicesDesc.get(),
+                                      indicesTensorTemp.data()));
     if (valuesTensorTemp.dtype() != valuesTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, valuesTensor, valuesTensorTemp));
     }

--- a/impl/camb/functions/split.cpp
+++ b/impl/camb/functions/split.cpp
@@ -30,14 +30,14 @@ diopiError_t diopiSplitWithSizes(diopiContextHandle_t ctx, diopiTensorHandle_t* 
     }
 
     size_t worksapceSize;
-    DIOPI_CALLCNNL(cnnlGetSplitWorkspaceSize(handle, numOuts, &worksapceSize));
+    DIOPI_CALL_CNNL(cnnlGetSplitWorkspaceSize(handle, numOuts, &worksapceSize));
 
     void* worksapce = nullptr;
     if (worksapceSize != 0) {
         worksapce = requiresBuffer(ctx, worksapceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlSplit(handle, numOuts, dim, inputDesc.get(), inputTensor.data(), worksapce, worksapceSize, descPtrs.data(), dataPtrs.data()));
+    DIOPI_CALL_CNNL(cnnlSplit(handle, numOuts, dim, inputDesc.get(), inputTensor.data(), worksapce, worksapceSize, descPtrs.data(), dataPtrs.data()));
     return diopiSuccess;
 }
 }  // namespace camb

--- a/impl/camb/functions/sqrt.cpp
+++ b/impl/camb/functions/sqrt.cpp
@@ -22,7 +22,7 @@ static diopiError_t sqrt(diopiContextHandle_t ctx, DiopiTensor& output, DiopiTen
         outputTmp = requiresTensor(ctx, output.shape(), input.dtype());
     }
     CnnlTensorDesc desc(input, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlSqrt_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, desc.get(), input.data(), desc.get(), outputTmp.data()));
+    DIOPI_CALL_CNNL(cnnlSqrt_v2(handle, CNNL_COMPUTATION_HIGH_PRECISION, desc.get(), input.data(), desc.get(), outputTmp.data()));
     if (outputTmp.dtype() != output.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, output, outputTmp));
     }

--- a/impl/camb/functions/stack.cpp
+++ b/impl/camb/functions/stack.cpp
@@ -23,17 +23,17 @@ diopiError_t diopiStack(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
         inputsData[i] = tempTensor.data();
         inputsDesc[i].set(tempTensor, CNNL_LAYOUT_ARRAY);
         inputsDescTmp[i] = inputsDesc[i].get();
-        DIOPI_CALLCNNL(cnnlSetTensorDescriptor(inputsDescTmp[i], CNNL_LAYOUT_ARRAY, dtype, catDimNb, catShape.data()));
+        DIOPI_CALL_CNNL(cnnlSetTensorDescriptor(inputsDescTmp[i], CNNL_LAYOUT_ARRAY, dtype, catDimNb, catShape.data()));
     }
     size_t workspaceSize(0);
-    DIOPI_CALLCNNL(cnnlGetConcatWorkspaceSize(handle, numTensors, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetConcatWorkspaceSize(handle, numTensors, &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
     DiopiTensor outTensor(out);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
-    DIOPI_CALLCNNL(cnnlConcat(handle, numTensors, dim, inputsDescTmp.data(), inputsData.data(), workspace, workspaceSize, outDesc.get(), outTensor.data()));
+    DIOPI_CALL_CNNL(cnnlConcat(handle, numTensors, dim, inputsDescTmp.data(), inputsData.data(), workspace, workspaceSize, outDesc.get(), outTensor.data()));
     return diopiSuccess;
 }
 }  // namespace camb

--- a/impl/camb/functions/std.cpp
+++ b/impl/camb/functions/std.cpp
@@ -77,28 +77,28 @@ DIOPI_API diopiError_t diopiStd(diopiContextHandle_t ctx, diopiTensorHandle_t ou
 
     CnnlResourceGuard<cnnlStdVarMeanDescriptor_t, cnnlCreateStdVarMeanDescriptor, cnnlDestroyStdVarMeanDescriptor> stdVarMeanObj;
     cnnlStdVarMeanDescriptor_t stdVarMeanDesc = stdVarMeanObj.get();
-    DIOPI_CALLCNNL(cnnlSetStdVarMeanDescriptor(stdVarMeanDesc, CNNL_STD, axisNum, axis, unbiased));
+    DIOPI_CALL_CNNL(cnnlSetStdVarMeanDescriptor(stdVarMeanDesc, CNNL_STD, axisNum, axis, unbiased));
     delete[] axis;
 
     size_t workspaceSize = 0;
     void *workspace = nullptr;
-    DIOPI_CALLCNNL(cnnlGetStdVarMeanWorkspaceSize(handle, stdVarMeanDesc, inputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetStdVarMeanWorkspaceSize(handle, stdVarMeanDesc, inputDesc.get(), &workspaceSize));
     if (workspaceSize > 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
 
-    DIOPI_CALLCNNL(cnnlStdVarMean(handle,
-                                  stdVarMeanDesc,
-                                  inputDesc.get(),
-                                  inputTensor.data(),
-                                  workspace,
-                                  workspaceSize,
-                                  outDesc.get(),
-                                  outTensor.data(),
-                                  nullptr,
-                                  nullptr,
-                                  nullptr,
-                                  nullptr));
+    DIOPI_CALL_CNNL(cnnlStdVarMean(handle,
+                                   stdVarMeanDesc,
+                                   inputDesc.get(),
+                                   inputTensor.data(),
+                                   workspace,
+                                   workspaceSize,
+                                   outDesc.get(),
+                                   outTensor.data(),
+                                   nullptr,
+                                   nullptr,
+                                   nullptr,
+                                   nullptr));
     if (outTensor.dtype() != outDtype) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outDtype));
     }

--- a/impl/camb/functions/threshold.cpp
+++ b/impl/camb/functions/threshold.cpp
@@ -84,7 +84,7 @@ diopiError_t diopiThreshold(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
             break;
     }
 
-    DIOPI_CALLCNNL(cnnlThreshold(handle, inputTensorDesc.get(), inputTensor.data(), thresholdVal, valueVal, outTensorDesc.get(), outTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlThreshold(handle, inputTensorDesc.get(), inputTensor.data(), thresholdVal, valueVal, outTensorDesc.get(), outTensorTemp.data()));
 
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));
@@ -137,14 +137,14 @@ diopiError_t diopiThresholdBackward(diopiContextHandle_t ctx, diopiTensorHandle_
             break;
     }
 
-    DIOPI_CALLCNNL(cnnlThresholdBackward(handle,
-                                         inputDesc.get(),
-                                         inputTensor.data(),
-                                         gradOutputDesc.get(),
-                                         gradOutputTensor.data(),
-                                         thresholdVal,
-                                         gradInputDesc.get(),
-                                         gradInputTensorTemp.data()))
+    DIOPI_CALL_CNNL(cnnlThresholdBackward(handle,
+                                          inputDesc.get(),
+                                          inputTensor.data(),
+                                          gradOutputDesc.get(),
+                                          gradOutputTensor.data(),
+                                          thresholdVal,
+                                          gradInputDesc.get(),
+                                          gradInputTensorTemp.data()))
 
     if (gradInputTensorTemp.dtype() != gradInputTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputTensorTemp));

--- a/impl/camb/functions/topk.cpp
+++ b/impl/camb/functions/topk.cpp
@@ -37,26 +37,26 @@ diopiError_t diopiTopk(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
     CnnlTensorDesc indicesDesc(indicesTensorTemp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetTopKTensorWorkspaceSize(handle, inputDesc.get(), k, dim, largest, valuesDesc.get(), indicesDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetTopKTensorWorkspaceSize(handle, inputDesc.get(), k, dim, largest, valuesDesc.get(), indicesDesc.get(), &workspaceSize));
     void *workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
     const bool lowerIndexFirst = true;
-    DIOPI_CALLCNNL(cnnlTopKTensor_v3(handle,
-                                     inputDesc.get(),
-                                     inputTensorTemp.data(),
-                                     k,
-                                     dim,
-                                     largest,
-                                     sorted,
-                                     lowerIndexFirst,
-                                     workspace,
-                                     workspaceSize,
-                                     valuesDesc.get(),
-                                     valuesTensorTemp.data(),
-                                     indicesDesc.get(),
-                                     indicesTensorTemp.data()))
+    DIOPI_CALL_CNNL(cnnlTopKTensor_v3(handle,
+                                      inputDesc.get(),
+                                      inputTensorTemp.data(),
+                                      k,
+                                      dim,
+                                      largest,
+                                      sorted,
+                                      lowerIndexFirst,
+                                      workspace,
+                                      workspaceSize,
+                                      valuesDesc.get(),
+                                      valuesTensorTemp.data(),
+                                      indicesDesc.get(),
+                                      indicesTensorTemp.data()))
     if (valuesTensorTemp.dtype() != valuesTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, valuesTensor, valuesTensorTemp));
     }

--- a/impl/camb/functions/transpose.cpp
+++ b/impl/camb/functions/transpose.cpp
@@ -39,12 +39,12 @@ diopiError_t diopiTranspose(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     auto stream = getStream(ctx);
     CnnlResourceGuard<cnnlHandle_t, cnnlCreate, cnnlDestroy> cnnlHandle;
     cnnlHandle_t handle = cnnlHandle.get();
-    DIOPI_CALLCNNL(cnnlSetQueue(handle, stream));
+    DIOPI_CALL_CNNL(cnnlSetQueue(handle, stream));
 
     CnnlResourceGuard<cnnlTransposeDescriptor_t, cnnlCreateTransposeDescriptor, cnnlDestroyTransposeDescriptor> cnnlTransposeDesc;
     cnnlTransposeDescriptor_t transposeDesc = cnnlTransposeDesc.get();
     std::vector<int> perms = getPerm(input, dim0, dim1);
-    DIOPI_CALLCNNL(cnnlSetTransposeDescriptor(transposeDesc, perms.size(), perms.data()));
+    DIOPI_CALL_CNNL(cnnlSetTransposeDescriptor(transposeDesc, perms.size(), perms.data()));
 
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(out);
@@ -57,12 +57,12 @@ diopiError_t diopiTranspose(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     void* outPtr = outputTensor.data();
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetTransposeWorkspaceSize(handle, inputDesc.get(), transposeDesc, &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetTransposeWorkspaceSize(handle, inputDesc.get(), transposeDesc, &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
     }
-    DIOPI_CALLCNNL(cnnlTranspose_v2(handle, transposeDesc, inputDesc.get(), inputPtr, outputDesc.get(), outPtr, workspace, workspaceSize));
+    DIOPI_CALL_CNNL(cnnlTranspose_v2(handle, transposeDesc, inputDesc.get(), inputPtr, outputDesc.get(), outPtr, workspace, workspaceSize));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/tril.cpp
+++ b/impl/camb/functions/tril.cpp
@@ -24,7 +24,7 @@ DIOPI_API diopiError_t diopiTril(diopiContextHandle_t ctx, diopiTensorHandle_t o
     CnnlTensorDesc inputDesc(inputTensorTmp, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlTri(handle, static_cast<int>(diagonal), false, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlTri(handle, static_cast<int>(diagonal), false, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
     DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
 
     return diopiSuccess;

--- a/impl/camb/functions/triu.cpp
+++ b/impl/camb/functions/triu.cpp
@@ -30,7 +30,7 @@ diopiError_t diopiTriu(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
     CnnlTensorDesc outDesc(outTensorTmp, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc inputDesc(inputTensorTmp, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CALLCNNL(cnnlTri(handle, static_cast<int32_t>(diagonal), true, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
+    DIOPI_CALL_CNNL(cnnlTri(handle, static_cast<int32_t>(diagonal), true, inputDesc.get(), inputTensorTmp.data(), outDesc.get(), outTensorTmp.data()));
     if (outTensor.dtype() != outTensorTmp.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTmp));
     }

--- a/impl/camb/functions/unfold.cpp
+++ b/impl/camb/functions/unfold.cpp
@@ -55,7 +55,7 @@ DIOPI_API diopiError_t diopiUnfold(diopiContextHandle_t ctx, diopiTensorHandle_t
     CnnlTensorDesc inputDesc(inputTensor, CNNL_LAYOUT_ARRAY);
     CnnlTensorDesc outDesc(outTensor, CNNL_LAYOUT_ARRAY);
 
-    DIOPI_CHECKCNNL(cnnlUnfold(
+    DIOPI_CHECK_CNNL(cnnlUnfold(
         handle, static_cast<int>(dim), static_cast<int>(size), static_cast<int>(step), inputDesc.get(), inputTensor.data(), outDesc.get(), outTensor.data()));
     return diopiSuccess;
 }
@@ -79,7 +79,7 @@ DIOPI_API diopiError_t diopiUnfoldBackward(diopiContextHandle_t ctx, diopiTensor
     CnnlTensorDesc gradInputDesc(gradInputTensorTmp, CNNL_LAYOUT_ARRAY);
 
     uint32_t workspaceSize = 0;
-    DIOPI_CHECKCNNL(cnnlGetAsStridedBackwardWorkspaceSize(handle, gradInputDesc.get(), &workspaceSize));
+    DIOPI_CHECK_CNNL(cnnlGetAsStridedBackwardWorkspaceSize(handle, gradInputDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     if (0 != workspaceSize) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -87,7 +87,7 @@ DIOPI_API diopiError_t diopiUnfoldBackward(diopiContextHandle_t ctx, diopiTensor
 
     auto strides = getStride(dim, inputSizes.len, step, inputSizes.data);
 
-    DIOPI_CHECKCNNL(cnnlAsStridedBackward(
+    DIOPI_CHECK_CNNL(cnnlAsStridedBackward(
         handle, gradOutputDesc.get(), gradOutputTensorTmp.data(), gradInputDesc.get(), gradInputTensorTmp.data(), strides.data(), 0, workspace, workspaceSize));
     DIOPI_CALL(dataTypeCast(ctx, gradInputTensor, gradInputTensorTmp));
 

--- a/impl/camb/functions/uniform.cpp
+++ b/impl/camb/functions/uniform.cpp
@@ -24,15 +24,15 @@ diopiError_t diopiUniformInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&dtype, tensor.dtype()));
     cnnlRandGenerator_t cnnlGenerator = nullptr;
     // cnnlRandRngType_t rng_type is recommended to be set as CNNL_RAND_RNG_MTGP32 on MLU300 series and CNNL_RAND_RNG_FAST on MLU200 series.
-    DIOPI_CALLCNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
+    DIOPI_CALL_CNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
 
     diopiTensorHandle_t stateHandle = nullptr;
     DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));
     void* statePtr = nullptr;
     DIOPI_CALL(diopiGetTensorData(stateHandle, &statePtr));
-    DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), from, to, tensor.data()));
+    DIOPI_CALL_CNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), from, to, tensor.data()));
     DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
-    DIOPI_CALLCNNL(cnnlRandDestroyGenerator(cnnlGenerator));
+    DIOPI_CALL_CNNL(cnnlRandDestroyGenerator(cnnlGenerator));
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/unique.cpp
+++ b/impl/camb/functions/unique.cpp
@@ -61,9 +61,9 @@ diopiError_t diopiUnique(diopiContextHandle_t ctx, diopiTensorHandle_t *out, dio
                     "the dimension of input must be one-dimensional "
                     "when mode is CNNL_UNSORT_FORWARD");
     }
-    DIOPI_CALLCNNL(cnnlSetUniqueDescriptor(uniqueDesc.get(), mode, realDim, returnIndices, returnCounts));
+    DIOPI_CALL_CNNL(cnnlSetUniqueDescriptor(uniqueDesc.get(), mode, realDim, returnIndices, returnCounts));
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetUniqueWorkspaceSize(handle, uniqueDesc.get(), inputDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetUniqueWorkspaceSize(handle, uniqueDesc.get(), inputDesc.get(), &workspaceSize));
     void *workspace = nullptr;
     if (workspaceSize != 0) {
         workspace = requiresBuffer(ctx, workspaceSize).data();
@@ -72,19 +72,19 @@ diopiError_t diopiUnique(diopiContextHandle_t ctx, diopiTensorHandle_t *out, dio
     std::vector<int64_t> temp{1, 1};
     DiopiTensor outlenTensor = requiresTensor(ctx, temp, diopi_dtype_int32);
 
-    DIOPI_CALLCNNL(cnnlUnique_v2(handle,
-                                 uniqueDesc.get(),
-                                 inputDesc.get(),
-                                 inputTensor.data(),
-                                 workspace,
-                                 workspaceSize,
-                                 static_cast<int *>(outlenTensor.data()),
-                                 outputDesc.get(),
-                                 outputTensor.data(),
-                                 indexDesc.get(),
-                                 returnIndices ? indexTensor.data() : nullptr,
-                                 countsDesc.get(),
-                                 returnCounts ? countsTensor.data() : nullptr));
+    DIOPI_CALL_CNNL(cnnlUnique_v2(handle,
+                                  uniqueDesc.get(),
+                                  inputDesc.get(),
+                                  inputTensor.data(),
+                                  workspace,
+                                  workspaceSize,
+                                  static_cast<int *>(outlenTensor.data()),
+                                  outputDesc.get(),
+                                  outputTensor.data(),
+                                  indexDesc.get(),
+                                  returnIndices ? indexTensor.data() : nullptr,
+                                  countsDesc.get(),
+                                  returnCounts ? countsTensor.data() : nullptr));
 
     DIOPI_CALL(dataTypeCast(ctx, outputTensor, originInputDtype));
     int32_t outlenHost = 0;
@@ -108,7 +108,7 @@ diopiError_t diopiUnique(diopiContextHandle_t ctx, diopiTensorHandle_t *out, dio
     int end[] = {static_cast<int>(slicedOutputTensor.numel())};
     int step[] = {1};
     // slice
-    DIOPI_CALLCNNL(cnnlStridedSlice(handle, newOutputDesc.get(), outputTensor.data(), begin, end, step, slicedOutputDesc.get(), slicedOutputTensor.data()));
+    DIOPI_CALL_CNNL(cnnlStridedSlice(handle, newOutputDesc.get(), outputTensor.data(), begin, end, step, slicedOutputDesc.get(), slicedOutputTensor.data()));
 
     *out = diopiTensorHandle_t(slicedOutputTensor);
 
@@ -117,7 +117,7 @@ diopiError_t diopiUnique(diopiContextHandle_t ctx, diopiTensorHandle_t *out, dio
         CnnlTensorDesc trueIndexDesc(trueIndexTensor, CNNL_LAYOUT_ARRAY);
         DIOPI_CALL(dataTypeCast(ctx, indexTensor, diopi_dtype_int64));
         CnnlTensorDesc indexDesc64(indexTensor, CNNL_LAYOUT_ARRAY);
-        DIOPI_CALLCNNL(cnnlCopy(handle, indexDesc64.get(), indexTensor.data(), trueIndexDesc.get(), trueIndexTensor.data()));
+        DIOPI_CALL_CNNL(cnnlCopy(handle, indexDesc64.get(), indexTensor.data(), trueIndexDesc.get(), trueIndexTensor.data()));
     }
     if (returnCounts) {
         DiopiTensor slicedCountsTensor = requiresTensor(ctx, {outlenHost}, diopi_dtype_int32);

--- a/impl/camb/functions/upsample.cpp
+++ b/impl/camb/functions/upsample.cpp
@@ -55,7 +55,7 @@ diopiError_t upsampleInternal(diopiContextHandle_t ctx, diopiTensorHandle_t out,
     DIOPI_CALL(interpDesc.set(inputDesc.get(), interpMode, coordinateTransMode, nullptr));
 
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
-    DIOPI_CALLCNNL(cnnlInterp_v3(handle, interpDesc.get(), inputDesc.get(), inputTensor.data(), outputDesc.get(), outputTensor.data()));
+    DIOPI_CALL_CNNL(cnnlInterp_v3(handle, interpDesc.get(), inputDesc.get(), inputTensor.data(), outputDesc.get(), outputTensor.data()));
 
     return diopiSuccess;
 }
@@ -91,7 +91,7 @@ diopiError_t upsampleBackwardInternal(diopiContextHandle_t ctx, diopiTensorHandl
     CnnlTensorDesc outputDesc(outputTensor, layout);
 
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
-    DIOPI_CALLCNNL(cnnlInterpBackward_v2(
+    DIOPI_CALL_CNNL(cnnlInterpBackward_v2(
         handle, alignCorners, alignCenter, interpMode, nullptr, true, inputDesc.get(), inputTensor.data(), outputDesc.get(), outputTensor.data()));
 
     return diopiSuccess;

--- a/impl/camb/functions/where.cpp
+++ b/impl/camb/functions/where.cpp
@@ -32,21 +32,21 @@ diopiError_t diopiWhere(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopi
     CnnlTensorDesc outDesc(outTensorTemp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetSelectV2WorkspaceSize(handle, condDesc.get(), inputDesc.get(), otherDesc.get(), &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetSelectV2WorkspaceSize(handle, condDesc.get(), inputDesc.get(), otherDesc.get(), &workspaceSize));
     void* workspace = nullptr;
     workspace = requiresBuffer(ctx, workspaceSize).data();
 
-    DIOPI_CALLCNNL(cnnlSelectV2(handle,
-                                condDesc.get(),
-                                condTensor.data(),
-                                inputDesc.get(),
-                                inputTensor.data(),
-                                otherDesc.get(),
-                                otherTensor.data(),
-                                workspace,
-                                workspaceSize,
-                                outDesc.get(),
-                                outTensorTemp.data()));
+    DIOPI_CALL_CNNL(cnnlSelectV2(handle,
+                                 condDesc.get(),
+                                 condTensor.data(),
+                                 inputDesc.get(),
+                                 inputTensor.data(),
+                                 otherDesc.get(),
+                                 otherTensor.data(),
+                                 workspace,
+                                 workspaceSize,
+                                 outDesc.get(),
+                                 outTensorTemp.data()));
 
     if (outTensorTemp.dtype() != outTensor.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outTensor, outTensorTemp));


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Delete CnnlDescBase and some static functions in CnnlDataType.
* Using more appropriate macro definition name: DIOPI_CALL_CNNL and DIOPI_CHECK_CNNL.

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

