### PR TITLE
Remove skips in device configs for Ascend

### DIFF
--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -927,36 +927,12 @@ device_configs = {
     ),
 
     'pointwise_binary_scalar': dict(
-        name=['div', 'ne', 'le', 'lt'],
+        name=['ne', 'le', 'lt'],
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
                     "shape": [Skip(()),Skip((1024,)),Skip((384, 128)),Skip((2, 64, 128)),Skip((128, 64, 3, 3)),Skip((128, 32, 2, 2)),Skip((2, 32, 130, 130)),],
-                },
-            ]
-        ),
-    ),
-
-    'div_zero': dict(
-        name=['div'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((1024,)),Skip((384, 128)),Skip((128, 64, 3, 3)),Skip((2, 32, 130, 130)),],
-                },
-            ]
-        ),
-    ),
-
-    'pointwise_binary_scalar_div_zero': dict(
-        name=['div'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((1024,)),Skip((384, 128)),Skip((128, 64, 3, 3)),Skip((2, 32, 130, 130)),],
                 },
             ]
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -723,7 +723,7 @@ device_configs = {
     ),
 
     'pointwise_binary': dict(
-        name=['add', 'mul', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -735,7 +735,7 @@ device_configs = {
     ),
 
     'pointwise_binary_broadcast': dict(
-        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -747,7 +747,7 @@ device_configs = {
     ),
 
     'pointwise_binary_broadcast_inplace': dict(
-        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -759,7 +759,7 @@ device_configs = {
     ),
 
     'pointwise_binary_diff_dtype': dict(
-        name=['mul', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['mul', 'eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -771,7 +771,7 @@ device_configs = {
     ),
 
     'pointwise_binary_diff_dtype_inplace': dict(
-        name=['eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -927,7 +927,7 @@ device_configs = {
     ),
 
     'pointwise_binary_scalar': dict(
-        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'gt', 'ge'],
+        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'ge'],
         tensor_para=dict(
             args=[
                 {
@@ -963,7 +963,7 @@ device_configs = {
     ),
 
     'pointwise_binary_test_equal_and_logic_specific': dict(
-        name=['eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -723,7 +723,7 @@ device_configs = {
     ),
 
     'pointwise_binary': dict(
-        name=['add', 'mul', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -735,7 +735,7 @@ device_configs = {
     ),
 
     'pointwise_binary_broadcast': dict(
-        name=['add', 'mul', 'div', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'div', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -747,7 +747,7 @@ device_configs = {
     ),
 
     'pointwise_binary_broadcast_inplace': dict(
-        name=['add', 'mul', 'div', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'div', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -759,7 +759,7 @@ device_configs = {
     ),
 
     'pointwise_binary_diff_dtype': dict(
-        name=['mul', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -795,7 +795,7 @@ device_configs = {
     ),
 
     'pointwise_binary_dtype_bool': dict(
-        name=['add', 'mul', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -927,7 +927,7 @@ device_configs = {
     ),
 
     'pointwise_binary_scalar': dict(
-        name=['add', 'mul', 'div', 'ne', 'le', 'lt'],
+        name=['add', 'div', 'ne', 'le', 'lt'],
         tensor_para=dict(
             args=[
                 {

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -723,7 +723,7 @@ device_configs = {
     ),
 
     'pointwise_binary': dict(
-        name=['add', 'sub', 'mul', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -735,7 +735,7 @@ device_configs = {
     ),
 
     'pointwise_binary_broadcast': dict(
-        name=['add', 'sub', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -747,7 +747,7 @@ device_configs = {
     ),
 
     'pointwise_binary_broadcast_inplace': dict(
-        name=['add', 'sub', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -926,18 +926,6 @@ device_configs = {
         ),
     ),
 
-    'sub_scalar': dict(
-        name=['sub'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip(()),Skip((1024,)),Skip((384, 128)),Skip((2, 64, 128)),Skip((128, 64, 3, 3)),Skip((128, 32, 2, 2)),Skip((2, 32, 130, 130)),],
-                },
-            ]
-        ),
-    ),
-
     'pointwise_binary_scalar': dict(
         name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'gt', 'ge'],
         tensor_para=dict(
@@ -1011,7 +999,7 @@ device_configs = {
     ),
 
     'pointwise_binary_with_alpha': dict(
-        name=['add', 'sub'],
+        name=['add'],
         tensor_para=dict(
             args=[
                 {

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -387,7 +387,7 @@ device_configs = {
     ),
 
     'pointwise_op': dict(
-        name=['abs', 'erf', 'erfinv', 'exp', 'floor', 'neg', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'ceil', 'atan'],
+        name=['abs', 'erf', 'erfinv', 'exp', 'neg', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'ceil', 'atan'],
         tensor_para=dict(
             args=[
                 {
@@ -531,7 +531,7 @@ device_configs = {
     ),
 
     'pointwise_op_zero': dict(
-        name=['abs', 'exp', 'floor', 'neg', 'sqrt', 'logical_not', 'rsqrt', 'ceil'],
+        name=['abs', 'exp', 'neg', 'sqrt', 'logical_not', 'rsqrt', 'ceil'],
         tensor_para=dict(
             args=[
                 {

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -927,7 +927,7 @@ device_configs = {
     ),
 
     'pointwise_binary_scalar': dict(
-        name=['add', 'mul', 'div', 'ne', 'le', 'lt', 'ge'],
+        name=['add', 'mul', 'div', 'ne', 'le', 'lt'],
         tensor_para=dict(
             args=[
                 {

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -1434,54 +1434,6 @@ device_configs = {
         ),
     ),
 
-    'nonzero': dict(
-        name=['nonzero'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((1482,)),Skip((16, 24)),Skip((5, 8, 20)),Skip((4, 4, 16, 20)),Skip((4, 4, 16, 2, 20)),Skip((0,)),Skip((12, 0)),Skip((2, 0, 9)),],
-                },
-            ]
-        ),
-    ),
-
-    'nonzero_float': dict(
-        name=['nonzero'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((1482,)),Skip((16, 24)),],
-                },
-            ]
-        ),
-    ),
-
-    'nonzero_int': dict(
-        name=['nonzero'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((4, 4, 16, 20)),Skip((4, 4, 16, 2, 20)),],
-                },
-            ]
-        ),
-    ),
-
-    'nonzero_uint': dict(
-        name=['nonzero'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((4, 4, 16, 20)),Skip((4, 4, 16, 2, 20)),],
-                },
-            ]
-        ),
-    ),
-
     'linear': dict(
         name=['linear'],
         tensor_para=dict(

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -723,7 +723,7 @@ device_configs = {
     ),
 
     'pointwise_binary': dict(
-        name=['add', 'mul', 'eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -735,7 +735,7 @@ device_configs = {
     ),
 
     'pointwise_binary_broadcast': dict(
-        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'div', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -747,7 +747,7 @@ device_configs = {
     ),
 
     'pointwise_binary_broadcast_inplace': dict(
-        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'div', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -759,7 +759,7 @@ device_configs = {
     ),
 
     'pointwise_binary_diff_dtype': dict(
-        name=['mul', 'eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['mul', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -771,7 +771,7 @@ device_configs = {
     ),
 
     'pointwise_binary_diff_dtype_inplace': dict(
-        name=['eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -795,7 +795,7 @@ device_configs = {
     ),
 
     'pointwise_binary_dtype_bool': dict(
-        name=['add', 'mul', 'eq', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
+        name=['add', 'mul', 'ne', 'le', 'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {
@@ -927,7 +927,7 @@ device_configs = {
     ),
 
     'pointwise_binary_scalar': dict(
-        name=['add', 'mul', 'div', 'eq', 'ne', 'le', 'lt', 'ge'],
+        name=['add', 'mul', 'div', 'ne', 'le', 'lt', 'ge'],
         tensor_para=dict(
             args=[
                 {
@@ -963,7 +963,7 @@ device_configs = {
     ),
 
     'pointwise_binary_test_equal_and_logic_specific': dict(
-        name=['eq', 'ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
+        name=['ne', 'le', 'lt', 'ge', 'logical_and', 'logical_or'],
         tensor_para=dict(
             args=[
                 {

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -927,7 +927,7 @@ device_configs = {
     ),
 
     'pointwise_binary_scalar': dict(
-        name=['add', 'div', 'ne', 'le', 'lt'],
+        name=['div', 'ne', 'le', 'lt'],
         tensor_para=dict(
             args=[
                 {


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Conformance tests have been performed for all ops that were marked as implemented for Ascend. This PR is to update Ascend device_configs.py to remove skips for the ops that have passed the conformance tests.


## Description
<!--- Describe your changes in detail. -->
- Remove skips for diopiSub, diopiSubInp, diopiSubScalar
- Remove skips for diopiFloor, diopiFloorInp
- Remove skips for diopiGt, diopiGtInp, diopiGtScalar, diopiGtInpScalar
- Remove skips for diopiNonzero
- Remove skips for diopiEq, diopiEqInp, diopiEqScalar, diopiEqInpScalar
- Remove skips for diopiGeScalar, diopiGeInpScalar
- Remove skips for diopiMul, diopiMulInp, diopiMulScalar, diopiMulInpScalar
- Remove skips for diopiAddScalar
- Remove skips for diopiDivScalar, diopiDivInpScalar


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

