### PR TITLE
Add diopiSigmoidInp for Ascend and update Ascend device_config.py to align with the latest diopi_configs.py

### DIFF
--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -2004,7 +2004,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['param', 'param_grad'],
-                    "shape": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64),],
+                    "shape": [Skip(()), Skip((16,)), Skip((16, 8)), Skip((2, 3, 16)), Skip((4, 32, 7, 7)), Skip((0,)), Skip((4, 0)), Skip((12, 0, 9)),],
                 },
             ]
         ),
@@ -2016,7 +2016,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['param', 'param_grad'],
-                    "shape": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64),],
+                    "shape": [Skip(()), Skip((16,)), Skip((16, 8)), Skip((2, 3, 16)), Skip((4, 32, 7, 7)), Skip((0,)), Skip((4, 0)), Skip((12, 0, 9)),],
                 },
             ]
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -1124,7 +1124,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64)],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64),],
                 },
             ]
         ),
@@ -1136,7 +1136,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64)],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64),],
                 },
             ]
         ),
@@ -1148,7 +1148,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64)],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64),],
                 },
             ]
         ),
@@ -1812,7 +1812,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['param', 'param_grad'],
-                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64)],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64),],
                 },
             ]
         ),
@@ -1824,7 +1824,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['param', 'param_grad'],
-                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32)],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32),],
                 },
             ]
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -2004,7 +2004,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['param', 'param_grad'],
-                    "shape": [Skip((2, 3, 16)),Skip((4, 32, 7, 7)),],
+                    "shape": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64),],
                 },
             ]
         ),
@@ -2016,7 +2016,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['param', 'param_grad'],
-                    "shape": [Skip((2, 3, 16)),Skip((4, 32, 7, 7)),],
+                    "shape": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64),],
                 },
             ]
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -566,18 +566,6 @@ device_configs = {
         ),
     ),
 
-    'sigmoid': dict(
-        name=['sigmoid'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16),Skip(Dtype.float32),Skip(Dtype.float64),],
-                },
-            ]
-        ),
-    ),
-
     'silu': dict(
         name=['silu'],
         tensor_para=dict(

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -2391,6 +2391,18 @@ device_configs = {
         ),
     ),
 
+    'unique_same_value': dict(
+        name=['unique'],
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "dtype": [Skip(Dtype.int64),Skip(Dtype.float32),Skip(Dtype.float64),Skip(Dtype.float16),Skip(Dtype.int16),Skip(Dtype.int32),Skip(Dtype.uint8),Skip(Dtype.int8),Skip(Dtype.bool),],
+                },
+            ]
+        ),
+    ),
+
     'prod': dict(
         name=['prod'],
         tensor_para=dict(

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -1124,8 +1124,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "shape": [Skip((182,)),Skip((384, 128)),Skip((1, 242991, 2)),Skip((2, 4, 100, 152)),Skip((0,)),Skip((2, 0,)),Skip((16, 0, 9)),],
-                    "dtype": [Skip(Dtype.float64)]
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64)],
                 },
             ]
         ),
@@ -1137,7 +1136,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "shape": [Skip((182,)),Skip((384, 128)),Skip((2, 4, 100, 152)),],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64)],
                 },
             ]
         ),
@@ -1149,7 +1148,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "shape": [Skip((182,)),Skip((384, 128)),Skip((2, 4, 100, 152)),],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64)],
                 },
             ]
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -1950,13 +1950,13 @@ device_configs = {
         ),
     ),
 
-    'bitwise_not': dict(
+    'bitwise_not_uint8': dict(
         name=['bitwise_not'],
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.bool),Skip(Dtype.int32),],
+                    "dtype": [Skip(Dtype.uint8),],
                 },
             ]
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -1812,7 +1812,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['param', 'param_grad'],
-                    "shape": [Skip((2, 3, 16)),Skip((4, 32, 7, 7)),],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32), Skip(Dtype.float64)],
                 },
             ]
         ),
@@ -1824,7 +1824,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['param', 'param_grad'],
-                    "shape": [Skip((2, 3, 16)),Skip((4, 32, 7, 7)),],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float32)],
                 },
             ]
         ),

--- a/impl/ascend/functions/activation.cpp
+++ b/impl/ascend/functions/activation.cpp
@@ -88,6 +88,8 @@ DIOPI_API diopiError_t diopiSigmoid(diopiContextHandle_t ctx, diopiTensorHandle_
     return diopiSuccess;
 }
 
+DIOPI_API diopiError_t diopiSigmoidInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) { return diopiSigmoid(ctx, input, input); }
+
 DIOPI_API diopiError_t diopiSigmoidBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gradInput, diopiConstTensorHandle_t gradOutput,
                                             diopiConstTensorHandle_t output) {
     AclOpRunner<2, 1>("SigmoidGrad", ctx).addInput(output).addInput(gradOutput).addOutput(gradInput).run();


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- diopiSigmoidInp is not implemented for Ascend and the sigmoid op is skipped in conformance tests
- Ascend device_configs.py is not aligned with the latest diopi_configs.py, which can possibly cause conformance tests failures.


## Description
<!--- Describe your changes in detail. -->
- Add diopiSigmoidInp for Ascend and remove sigmoid skips in device_config.py
- Update Ascend device_config.py to align with the latest diopi_configs.py
  - Update skips to completely skip clamp_tensor, clamp_max_tensor, clamp_min_tensor
  - Update skips to completely skip sgd, sgd_without_buf
  - Update skips to replace bitwise_not with bitwise_not_uint8
  - Update skips to completely skip adadelta, rmsprop
  - Add skips for unique_same_value


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

