### PR TITLE
fix_LogSoftMaxBackward_usingf32

### DIFF
--- a/impl/ascend/functions/activation.cpp
+++ b/impl/ascend/functions/activation.cpp
@@ -42,27 +42,13 @@ diopiError_t diopiLogSoftmax(diopiContextHandle_t ctx, diopiTensorHandle_t out, 
 
 diopiError_t diopiLogSoftmaxBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gradInput, diopiConstTensorHandle_t gradOutput,
                                      diopiConstTensorHandle_t output, int64_t dim) {
-    diopiSize_t sumSize;
-    diopiGetTensorShape(gradOutput, &sumSize);
-    std::vector<int64_t> sumSizeVec(sumSize.data, sumSize.data + sumSize.len);
-    if (sumSize.len == 0) return diopiSuccess;
-    if (dim < 0) dim += sumSize.len;
-    sumSizeVec[dim] = 1;
-    sumSize = vectorToDiopiSize(sumSizeVec);
-    diopiTensorHandle_t sum, exp;
-    diopiDtype_t dtype;
-    diopiGetTensorDtype(gradOutput, &dtype);
-    diopiRequireTensor(ctx, &sum, &sumSize, nullptr, dtype, diopi_device);
-    std::vector<int64_t> dimVec({dim});
-    auto dimSize = vectorToDiopiSize(dimVec);
-    diopiSum(ctx, sum, gradOutput, dimSize);
-    makeTensorLike(ctx, &exp, output);
-    diopiExp(ctx, exp, output);
-    diopiMul(ctx, gradInput, exp, sum);
-    diopiScalar_t scalar;
-    scalar.stype = diopi_dtype_float64;
-    scalar.fval = 1.0;
-    diopiSub(ctx, gradInput, gradOutput, gradInput, &scalar);
+    std::vector<int64_t> dimList = {dim};
+    AclOpRunner<2, 1>("LogSoftmaxGrad", ctx)
+        .addInput(gradOutput, diopi_dtype_float32)
+        .addInput(output, diopi_dtype_float32)
+        .addOutput(gradInput)
+        .setAttr("axis", dimList)
+        .run();
     return diopiSuccess;
 }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
fix_LogSoftMaxBackward
In GitHub, there were test cases for both f32 and f16 that did not pass. I conducted a thorough check of the code completeness and, in the end, attempted to resolve the issue by invoking native Huawei operators.
the problem is :
<img width="681" alt="企业微信截图_16971814101834" src="https://github.com/DeepLink-org/DIOPI/assets/108985861/d88798d1-732d-4494-9ac4-44d23bec614f">



## Description
<!--- Describe your changes in detail. -->
fix_LogSoftMaxBackward,use f32

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

