### PR TITLE
fix diopiBatchNorm and diopiBatchNormBackward for Ascend

### DIFF
--- a/impl/ascend/common/acloprunner.hpp
+++ b/impl/ascend/common/acloprunner.hpp
@@ -36,7 +36,35 @@ inline aclFormat getAclDataFormat(diopiConstTensorHandle_t th) {
     diopiGetTensorShape(th, &shape);
     diopiGetTensorStride(th, &stride);
     ASCEND_CHECK_ABORT(stride.len == shape.len, "stride.len == shape.len check failed");
-    if (shape.len == 4) {
+    if (shape.len == 5) {
+        std::array<int64_t, 5> thStride{stride.data[0], stride.data[1], stride.data[2], stride.data[3], stride.data[4]};
+
+        int st = 1;
+        std::array<int64_t, 5> ncdhwStride;
+        for (auto k : {4, 3, 2, 1, 0}) {
+            ncdhwStride[k] = st;
+            if (shape.data[k] == 0) continue;
+            if (shape.data[k] == -1) st = -1;
+            if (st != -1) st *= shape.data[k];
+        }
+        if (thStride == ncdhwStride) {
+            return ACL_FORMAT_NCDHW;
+        }
+
+        st = 1;
+        std::array<int64_t, 5> ndhwcStride;
+        for (auto k : {1, 4, 3, 2, 0}) {
+            ndhwcStride[k] = st;
+            if (shape.data[k] == 0) continue;
+            if (shape.data[k] == -1) st = -1;
+            if (st != -1) st *= shape.data[k];
+        }
+        if (thStride == ndhwcStride) {
+            return ACL_FORMAT_NDHWC;
+        }
+
+        warning("Acl only support NCDHW or NDHWC format! but get %s", dumpTensor(th).c_str());
+    } else if (shape.len == 4) {
         std::array<int64_t, 4> thStride{stride.data[0], stride.data[1], stride.data[2], stride.data[3]};
         {
             std::array<int64_t, 4> nchwStride;

--- a/impl/ascend/common/acloprunner.hpp
+++ b/impl/ascend/common/acloprunner.hpp
@@ -36,63 +36,7 @@ inline aclFormat getAclDataFormat(diopiConstTensorHandle_t th) {
     diopiGetTensorShape(th, &shape);
     diopiGetTensorStride(th, &stride);
     ASCEND_CHECK_ABORT(stride.len == shape.len, "stride.len == shape.len check failed");
-    if (shape.len == 5) {
-        std::array<int64_t, 5> thStride{stride.data[0], stride.data[1], stride.data[2], stride.data[3], stride.data[4]};
-
-        int st = 1;
-        std::array<int64_t, 5> ncdhwStride;
-        for (auto k : {4, 3, 2, 1, 0}) {
-            ncdhwStride[k] = st;
-            if (shape.data[k] == 0) continue;
-            if (shape.data[k] == -1) st = -1;
-            if (st != -1) st *= shape.data[k];
-        }
-        if (thStride == ncdhwStride) {
-            return ACL_FORMAT_NCDHW;
-        }
-
-        st = 1;
-        std::array<int64_t, 5> ndhwcStride;
-        for (auto k : {1, 4, 3, 2, 0}) {
-            ndhwcStride[k] = st;
-            if (shape.data[k] == 0) continue;
-            if (shape.data[k] == -1) st = -1;
-            if (st != -1) st *= shape.data[k];
-        }
-        if (thStride == ndhwcStride) {
-            return ACL_FORMAT_NDHWC;
-        }
-
-        warning("Acl only support NCDHW or NDHWC format! but get %s", dumpTensor(th).c_str());
-    } else if (shape.len == 4) {
-        std::array<int64_t, 4> thStride{stride.data[0], stride.data[1], stride.data[2], stride.data[3]};
-        {
-            std::array<int64_t, 4> nchwStride;
-            int st = 1;
-            for (auto k : {3, 2, 1, 0}) {
-                nchwStride[k] = st;
-                if (shape.data[k] == 0) continue;
-                if (shape.data[k] == -1) st = -1;
-                if (st != -1) st *= shape.data[k];
-            }
-            if (thStride == nchwStride) {
-                return ACL_FORMAT_NCHW;
-            }
-        }
-        std::array<int64_t, 4> nhwcStride;
-        int st = 1;
-        for (auto k : {1, 3, 2, 0}) {
-            nhwcStride[k] = st;
-            if (shape.data[k] == 0) continue;
-            if (shape.data[k] == -1) st = -1;
-            if (st != -1) st *= shape.data[k];
-        }
-        if (thStride == nhwcStride) {
-            return ACL_FORMAT_NHWC;
-        }
-        warning("Acl only support NCHW or NHWC format! but get %s", dumpTensor(th).c_str());
-    }
-    return ACL_FORMAT_ND;
+    return AscendTensor(th).getAclDataFormat();
 }
 
 diopiError_t fillTensor(diopiContextHandle_t ctx, diopiTensorHandle_t* out, float val);

--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -395,6 +395,27 @@ diopiError_t makeOnesLike(diopiContextHandle_t ctx, diopiTensorHandle_t* out, di
     return makeOnesLike(ctx, out, src, dtype);
 }
 
+diopiError_t negativeInputRtnFillNan(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    // get nan value tensor
+    diopiTensorHandle_t nanValue;
+    auto nanValueScalar = diopiScalar_t();
+    nanValueScalar.stype = diopi_dtype_float64;
+    nanValueScalar.fval = 0.0;
+    makeTensorFromScalar(ctx, &nanValueScalar, &nanValue, diopi_dtype_float32, diopi_device);
+    auto zeroValueScalar = diopiScalar_t();
+    zeroValueScalar.stype = diopi_dtype_float64;
+    zeroValueScalar.fval = 0.0;
+    diopiDivInpScalar(ctx, nanValue, &zeroValueScalar, diopiRoundMode_t::RoundModeNone);
+
+    // get negative mask
+    diopiTensorHandle_t mask;
+    makeTensorLike(ctx, &mask, input, diopi_dtype_bool);
+    diopiLtScalar(ctx, mask, input, &zeroValueScalar);
+
+    // masked_fill nan
+    return diopiMaskedFillInp(ctx, out, mask, nanValue);
+}
+
 aclDataType getAclDataType(diopiDtype_t type) {
     switch (type) {
         case diopi_dtype_float16:

--- a/impl/ascend/common/utils.hpp
+++ b/impl/ascend/common/utils.hpp
@@ -37,6 +37,8 @@ diopiError_t makeTensorLike(diopiContextHandle_t ctx, AscendTensor& dst, const A
 
 diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, AscendTensor& dst, const diopiScalar_t* scalar, diopiDevice_t device = diopi_device);
 
+diopiError_t negativeInputRtnFillNan(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
 diopiError_t reshape(diopiContextHandle_t ctx, const AscendTensor& src, AscendTensor& dst, const std::vector<int64_t>& shape);
 
 diopiError_t contiguous(diopiContextHandle_t ctx, const AscendTensor& src, AscendTensor& dst, diopiMemoryFormat_t format = diopiMemoryFormat_t::Contiguous);

--- a/impl/ascend/convert_config.yaml
+++ b/impl/ascend/convert_config.yaml
@@ -1,0 +1,7 @@
+- diopiBatchNorm:
+    dtype: (float64)->float32
+    layout: NCHW
+
+- diopiBatchNormBackward:
+    dtype: (float64)->float32
+    layout: NCHW

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -20,7 +20,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16),],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.float64),],
                 },
             ]
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -8,19 +8,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "shape": [Skip((2, 8, 32, 56, 56)),Skip((2, 64, 32, 32)),Skip((2, 96, 28)),Skip((2, 16)),],
-                },
-            ]
-        ),
-    ),
-
-    'batch_norm_nan': dict(
-        name=['batch_norm'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((2, 8, 32, 56, 56)),Skip((2, 64, 32, 32)),Skip((2, 96, 28)),Skip((16, 2)),],
+                    "dtype": [Skip(Dtype.float16),],
                 },
             ]
         ),
@@ -32,7 +20,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "shape": [Skip((2, 8, 32, 56, 56)),Skip((2, 64, 32, 32)),Skip((2, 96, 28)),Skip((32, 16)),],
+                    "dtype": [Skip(Dtype.float16),],
                 },
             ]
         ),

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -81,7 +81,7 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
             .addOutput(outputAt)
             .setAttr("epsilon", static_cast<float>(eps))
             .run();
-        
+
         diopiTensorHandle_t runningVarBroadcasted;
         makeTensorLike(ctx, &runningVarBroadcasted, input);
         AscendTensor runningVarAt(runningVar);

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -9,41 +9,46 @@
 namespace impl {
 namespace ascend {
 
-void batchNormBackwardTrainingUpdate(diopiContextHandle_t ctx, diopiTensorHandle_t gradWeight, diopiTensorHandle_t gradBias, diopiConstTensorHandle_t gradOut,
-                                     diopiConstTensorHandle_t input, diopiConstTensorHandle_t saveMean, diopiConstTensorHandle_t saveInvstd, double eps) {
-    diopiSize_t inputSize;
-    diopiGetTensorShape(input, &inputSize);
-    std::string name = (inputSize.len == 5) ? "BN3DTrainingUpdateGrad" : "BNTrainingUpdateGrad";
-    auto format = (inputSize.len == 5) ? ACL_FORMAT_NCDHW : ACL_FORMAT_NCHW;
+void updateInputAscendTensorDim(AscendTensor &inputAt, bool training) {
+    int64_t dim = inputAt.dim();
+    if (2 == dim) {
+        inputAt.unsqueeze(2);
+        inputAt.unsqueeze(3);
+    } else if (3 == dim) {
+        inputAt.unsqueeze(3);
+    } else if (5 == dim && !training) {
+        std::vector<int64_t> shape4d{inputAt.shape(0), inputAt.shape(1), inputAt.shape(2), inputAt.shape(3) * inputAt.shape(4)};
+        inputAt.view(shape4d);
+    }
+}
 
+void batchNormBackwardTrainingUpdate(diopiContextHandle_t ctx, diopiTensorHandle_t gradWeight, diopiTensorHandle_t gradBias, AscendTensor gradOutputAt,
+                                     AscendTensor inputAt, diopiConstTensorHandle_t saveMean, diopiConstTensorHandle_t saveInvstd, double eps) {
+    std::string name = (inputAt.dim() == 5) ? "BN3DTrainingUpdateGrad" : "BNTrainingUpdateGrad";
     AclOpRunner<4, 2>(name, ctx)
-        .addInput(gradOut, format)
-        .addInput(input, format)
-        .addInput(saveMean, format)
-        .addInput(saveInvstd, format)
-        .addOutput(gradWeight, format)
-        .addOutput(gradBias, format)
+        .addInput(gradOutputAt)
+        .addInput(inputAt)
+        .addInput(saveMean)
+        .addInput(saveInvstd)
+        .addOutput(gradWeight)
+        .addOutput(gradBias)
         .setAttr<float>("epsilon", static_cast<float>(eps))
         .run();
 }
 
-void batchNormBackwardTrainingReduceNocheck(diopiContextHandle_t ctx, diopiTensorHandle_t gradInput, diopiConstTensorHandle_t gradWeight,
-                                            diopiConstTensorHandle_t gradBias, diopiConstTensorHandle_t gradOut, diopiConstTensorHandle_t input,
-                                            diopiConstTensorHandle_t weight, diopiConstTensorHandle_t saveMean, diopiConstTensorHandle_t saveInvstd,
-                                            double eps) {
-    diopiSize_t inputSize;
-    diopiGetTensorShape(input, &inputSize);
-    std::string name = (inputSize.len == 5) ? "BN3DTrainingReduceGrad" : "BNTrainingReduceGrad";
-    auto format = (inputSize.len == 5) ? ACL_FORMAT_NCDHW : ACL_FORMAT_NCHW;
+void batchNormBackwardTrainingReduceNocheck(diopiContextHandle_t ctx, AscendTensor gradInputAt, diopiConstTensorHandle_t gradWeight,
+                                            diopiConstTensorHandle_t gradBias, AscendTensor gradOutputAt, AscendTensor inputAt, diopiConstTensorHandle_t weight,
+                                            diopiConstTensorHandle_t saveMean, diopiConstTensorHandle_t saveInvstd, double eps) {
+    std::string name = (inputAt.dim() == 5) ? "BN3DTrainingReduceGrad" : "BNTrainingReduceGrad";
     AclOpRunner<7, 1>(name, ctx)
-        .addInput(gradOut, format)
-        .addInput(input, format)
-        .addInput(gradWeight, format)
-        .addInput(gradBias, format)
-        .addInput(weight, format)
-        .addInput(saveMean, format)
-        .addInput(saveInvstd, format)
-        .addOutput(gradInput, format)
+        .addInput(gradOutputAt)
+        .addInput(inputAt)
+        .addInput(gradWeight)
+        .addInput(gradBias)
+        .addInput(weight)
+        .addInput(saveMean)
+        .addInput(saveInvstd)
+        .addOutput(gradInputAt)
         .setAttr<float>("epsilon", static_cast<float>(eps))
         .run();
 }
@@ -51,16 +56,40 @@ void batchNormBackwardTrainingReduceNocheck(diopiContextHandle_t ctx, diopiTenso
 diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t saveMean, diopiTensorHandle_t saveInvstd,
                             diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiTensorHandle_t runningMean,
                             diopiTensorHandle_t runningVar, bool training, double momentum, double eps) {
+    if (runningMean == nullptr) {
+        makeTensorLike(ctx, &runningMean, weight, diopi_dtype_float32);
+        diopiScalar_t zero = {diopi_dtype_float32, {0}};
+        diopiFill(ctx, runningMean, &zero);
+    }
+    if (runningVar == nullptr) {
+        makeTensorLike(ctx, &runningVar, weight, diopi_dtype_float32);
+        diopiScalar_t one = {diopi_dtype_float32, {1}};
+        diopiFill(ctx, runningMean, &one);
+    }
+
+    AscendTensor inputAt(input), outputAt(out);
+    updateInputAscendTensorDim(inputAt, training);
+    outputAt.view(inputAt.getAclMemShape());
+
     if (!training) {
         AclOpRunner<5, 1>("BNInfer", ctx)
-            .addInput(input)
+            .addInput(inputAt)
             .addInput(weight)
             .addInput(bias)
             .addInput(runningMean)
             .addInput(runningVar)
-            .addOutput(out)
+            .addOutput(outputAt)
             .setAttr("epsilon", static_cast<float>(eps))
             .run();
+        
+        diopiTensorHandle_t runningVarBroadcasted;
+        makeTensorLike(ctx, &runningVarBroadcasted, input);
+        AscendTensor runningVarAt(runningVar);
+        runningVarAt.unsqueeze(0);
+        runningVarAt.unsqueeze(2);
+        runningVarAt.unsqueeze(3);
+        AclOpRunner<2, 1>("BroadcastTo", ctx).addInput(runningVarAt).addConstInput(inputAt.shape()).addOutput(runningVarBroadcasted).run();
+        negativeInputRtnFillNan(ctx, out, runningVarBroadcasted);
     } else {
         diopiTensorHandle_t sum = nullptr, squareSum = nullptr;
         diopiSize_t shape, stride;
@@ -68,9 +97,9 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
         diopiGetTensorStride(runningMean, &stride);
         diopiRequireTensor(ctx, &sum, &shape, &stride, diopiDtype_t::diopi_dtype_float32, diopi_device);
         diopiRequireTensor(ctx, &squareSum, &shape, &stride, diopiDtype_t::diopi_dtype_float32, diopi_device);
-        AclOpRunner<1, 2>("BNTrainingReduce", ctx).addInput(input).setAttr("epsilon", static_cast<float>(eps)).addOutput(sum).addOutput(squareSum).run();
+        AclOpRunner<1, 2>("BNTrainingReduce", ctx).addInput(inputAt).setAttr("epsilon", static_cast<float>(eps)).addOutput(sum).addOutput(squareSum).run();
         AclOpRunner<7, 5>("BNTrainingUpdate", ctx)
-            .addInput(input)
+            .addInput(inputAt)
             .addInput(sum)
             .addInput(squareSum)
             .addInput(weight)
@@ -79,7 +108,7 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
             .addInput(runningVar)
             .setAttr("epsilon", static_cast<float>(eps))
             .setAttr("factor", static_cast<float>(momentum))
-            .addOutput(out)
+            .addOutput(outputAt)
             .addOutput(runningMean)
             .addOutput(runningVar)
             .addOutput(saveMean)
@@ -93,18 +122,34 @@ diopiError_t diopiBatchNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_
                                     diopiConstTensorHandle_t gradOutput, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
                                     diopiConstTensorHandle_t runninMean, diopiConstTensorHandle_t runningVar, diopiConstTensorHandle_t saveMean,
                                     diopiConstTensorHandle_t saveInvstd, bool training, double eps) {
+    AscendTensor inputAt(input), gradOutputAt(gradOutput), gradInputAt(gradInput);
+    updateInputAscendTensorDim(inputAt, training);
+    gradOutputAt.view(inputAt.getAclMemShape());
+    gradInputAt.view(inputAt.getAclMemShape());
+
     if (!training) {
-        batchNormBackwardTrainingUpdate(ctx, gradWeight, gradBias, gradOutput, input, runninMean, runningVar, eps);
+        batchNormBackwardTrainingUpdate(ctx, gradWeight, gradBias, gradOutputAt, inputAt, runninMean, runningVar, eps);
+        negativeInputRtnFillNan(ctx, gradWeight, runningVar);
+
         AclOpRunner<3, 1>("BNInferGrad", ctx)
-            .addInput(gradOutput)
+            .addInput(gradOutputAt)
             .addInput(weight)
             .addInput(runningVar)
-            .addOutput(gradInput)
+            .addOutput(gradInputAt)
             .setAttr<float>("epsilon", static_cast<float>(eps))
             .run();
+
+        diopiTensorHandle_t runningVarBroadcasted;
+        makeTensorLike(ctx, &runningVarBroadcasted, input);
+        AscendTensor runningVarAt(runningVar);
+        runningVarAt.unsqueeze(0);
+        runningVarAt.unsqueeze(2);
+        runningVarAt.unsqueeze(3);
+        AclOpRunner<2, 1>("BroadcastTo", ctx).addInput(runningVarAt).addConstInput(inputAt.shape()).addOutput(runningVarBroadcasted).run();
+        negativeInputRtnFillNan(ctx, gradInput, runningVarBroadcasted);
     } else {
-        batchNormBackwardTrainingUpdate(ctx, gradWeight, gradBias, gradOutput, input, saveMean, saveInvstd, eps);
-        batchNormBackwardTrainingReduceNocheck(ctx, gradInput, gradWeight, gradBias, gradOutput, input, weight, saveMean, saveInvstd, eps);
+        batchNormBackwardTrainingUpdate(ctx, gradWeight, gradBias, gradOutputAt, inputAt, saveMean, saveInvstd, eps);
+        batchNormBackwardTrainingReduceNocheck(ctx, gradInputAt, gradWeight, gradBias, gradOutputAt, inputAt, weight, saveMean, saveInvstd, eps);
     }
     return diopiSuccess;
 }

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -58,12 +58,12 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
                             diopiTensorHandle_t runningVar, bool training, double momentum, double eps) {
     if (runningMean == nullptr) {
         makeTensorLike(ctx, &runningMean, weight, diopi_dtype_float32);
-        diopiScalar_t zero = {diopi_dtype_float32, {0}};
+        diopiScalar_t zero = constructDiopiScalarT(diopi_dtype_float32, 0);
         diopiFill(ctx, runningMean, &zero);
     }
     if (runningVar == nullptr) {
         makeTensorLike(ctx, &runningVar, weight, diopi_dtype_float32);
-        diopiScalar_t one = {diopi_dtype_float32, {1}};
+        diopiScalar_t one = constructDiopiScalarT(diopi_dtype_float32, 1);
         diopiFill(ctx, runningMean, &one);
     }
 

--- a/impl/ascend/functions/unary.cpp
+++ b/impl/ascend/functions/unary.cpp
@@ -9,27 +9,6 @@
 namespace impl {
 namespace ascend {
 
-diopiError_t negativeInputRtnFillNan(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
-    // get nan value tensor
-    diopiTensorHandle_t nanValue;
-    auto nanValueScalar = diopiScalar_t();
-    nanValueScalar.stype = diopi_dtype_float64;
-    nanValueScalar.fval = 0.0;
-    makeTensorFromScalar(ctx, &nanValueScalar, &nanValue, diopi_dtype_float32, diopi_device);
-    auto zeroValueScalar = diopiScalar_t();
-    zeroValueScalar.stype = diopi_dtype_float64;
-    zeroValueScalar.fval = 0.0;
-    diopiDivInpScalar(ctx, nanValue, &zeroValueScalar, diopiRoundMode_t::RoundModeNone);
-
-    // get negative mask
-    diopiTensorHandle_t mask;
-    makeTensorLike(ctx, &mask, input, diopi_dtype_bool);
-    diopiLtScalar(ctx, mask, input, &zeroValueScalar);
-
-    // masked_fill nan
-    return diopiMaskedFillInp(ctx, out, mask, nanValue);
-}
-
 diopiError_t diopiNeg(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     AclOpRunner<1, 1>("Neg", ctx).addInput(input).addOutput(out).run();
     return diopiSuccess;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

diopiBatchNorm and diopiBatchNormBackward for Ascend are broken.


## Description
<!--- Describe your changes in detail. -->

Fix the following issues for diopiBatchNorm and diopiBatchNormBackward on Ascend:
- 2D, 3D, 5D input error
- Incomplete memory format identification
- float64 input error
- Lack of pre-processing and post-processing for None values of running_mean and running_var


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

