### PR TITLE
fix camb diopiRandomInp: align with torch.Tensor.random_

### DIFF
--- a/impl/camb/functions/random.cpp
+++ b/impl/camb/functions/random.cpp
@@ -40,7 +40,7 @@ extern "C" diopiError_t diopiRandomInp(diopiContextHandle_t ctx, diopiTensorHand
         DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));
         void* statePtr = nullptr;
         DIOPI_CALL(diopiGetTensorData(stateHandle, &statePtr));
-        DIOPI_CALLCNNL(cnnlRandGenerateDescreteUniform(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), min, max, tensor.data()));
+        DIOPI_CALLCNNL(cnnlRandGenerateDescreteUniform(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), min, max + 1, tensor.data()));
         DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
     } else {
         setLastErrorString("%s%d", "cnnl random not support datatype: ", dtype);

--- a/impl/camb/functions/random.cpp
+++ b/impl/camb/functions/random.cpp
@@ -4,7 +4,9 @@
  * @copyright  (c) 2023, DeepLink.
  */
 
-#include <cfloat>
+#include <algorithm>
+#include <cstdint>
+#include <limits>
 #include <vector>
 
 #include "../cnnl_helper.hpp"
@@ -12,6 +14,13 @@
 
 namespace impl {
 namespace camb {
+
+namespace {
+
+// clamp x into range [-largest, largest]
+int clamp(int64_t x, int largest) { return static_cast<int>(std::min<int64_t>(std::max<int64_t>(x, -largest), largest)); }
+
+}  // namespace
 
 extern "C" diopiError_t diopiRandomInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout, int64_t from, const int64_t* to, diopiGeneratorHandle_t generator) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
@@ -23,18 +32,15 @@ extern "C" diopiError_t diopiRandomInp(diopiContextHandle_t ctx, diopiTensorHand
     DIOPI_CALLCNNL(cnnlRandCreateGenerator(&cnnlGenerator, CNNL_RAND_RNG_MTGP32));
 
     if (dtype == CNNL_DTYPE_FLOAT || dtype == CNNL_DTYPE_HALF) {
-        float min = from;
-        float max;
-        if (to != nullptr) {
-            max = *to - 1;
-        } else {
-            max = (dtype == CNNL_DTYPE_FLOAT ? FLT_MAX : std::numeric_limits<half_float::half>::max());
-        }
+        auto mantissa = dtype == CNNL_DTYPE_FLOAT ? std::numeric_limits<float>::digits : std::numeric_limits<half_float::half>::digits;
+        auto largestIntAsFp = 1 << mantissa;
+        int min = clamp(from, largestIntAsFp);
+        int max = to ? clamp(*to - 1, largestIntAsFp) : largestIntAsFp;
         diopiTensorHandle_t stateHandle = nullptr;
         DIOPI_CALL(diopiGeneratorGetState(ctx, generator, &stateHandle));
         void* statePtr = nullptr;
         DIOPI_CALL(diopiGetTensorData(stateHandle, &statePtr));
-        DIOPI_CALLCNNL(cnnlRandGenerateUniform(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), min, max, tensor.data()));
+        DIOPI_CALLCNNL(cnnlRandGenerateDescreteUniform(handle, cnnlGenerator, dtype, statePtr, tensor.numel(), min, max, tensor.data()));
         DIOPI_CALL(diopiGeneratorSetState(generator, stateHandle));
     } else {
         setLastErrorString("%s%d", "cnnl random not support datatype: ", dtype);

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -2983,7 +2983,10 @@ DIOPI_API diopiError_t diopiIndexPut(diopiContextHandle_t ctx, diopiTensorHandle
                                      diopiConstTensorHandle_t* indices, int64_t indices_counts, bool accumulate);
 
 /**
- * @brief Distribution and random numbers.
+ * @brief Gnereate random numbers from discrete uniform distribution.
+ *
+ * Fills inout tensor with numbers sampled from the discrete uniform distribution over [from, to - 1]. If not specified, the values are usually only bounded by
+ * self tensor’s data type. However, for floating point types, if unspecified, range will be [0, 2^mantissa] to ensure that every value is representable.
  * @param[in] ctx Context environment.
  * @param[in] inout the input and output tensor, type = [float32, float64, float16, int64, int32, int16, int8]
  * @param[in] from the lower bound of the random function. type = [int64].


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

diopiRandomInp 的 camb 行为与 torch 不一致。

DIPU 的相应 test 也无法通过：https://github.com/DeepLink-org/DIPU/blob/main/dipu/tests/python/unittests/test_random.py

## Description
<!--- Describe your changes in detail. -->

根据 https://pytorch.org/docs/stable/generated/torch.Tensor.random_.html 的描述，做出以下修改：
- `cnnlRandGenerateUniform` -> `cnnlRandGenerateDescreteUniform`
- 修改默认 range
- 完善 DIOPI proto docstring

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->

https://github.com/DeepLink-org/DIPU/blob/main/dipu/tests/python/unittests/test_random.py

## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

