### PR TITLE
Add log2, log10, and fix log for Ascend

### DIFF
--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -422,13 +422,40 @@ diopiError_t negativeInputRtnFillNan(diopiContextHandle_t ctx, diopiTensorHandle
     zeroValueScalar.fval = 0.0;
     diopiDivInpScalar(ctx, nanValue, &zeroValueScalar, diopiRoundMode_t::RoundModeNone);
 
+    diopiDtype_t inputDtype;
+    diopiGetTensorDtype(input, &inputDtype);
+    diopiTensorHandle_t inputTemp;
+    if (diopi_dtype_float16 == inputDtype) {
+        makeTensorLike(ctx, &inputTemp, input, diopi_dtype_float32);
+        diopiCastDtype(ctx, inputTemp, input);
+    } else {
+        inputTemp = const_cast<diopiTensorHandle_t>(input);
+    }
+
     // get negative mask
     diopiTensorHandle_t mask;
-    makeTensorLike(ctx, &mask, input, diopi_dtype_bool);
-    diopiLtScalar(ctx, mask, input, &zeroValueScalar);
+    makeTensorLike(ctx, &mask, inputTemp, diopi_dtype_bool);
+    diopiLtScalar(ctx, mask, inputTemp, &zeroValueScalar);
+
+    // NaN of float16 can only be cast from NaN of float64
+    diopiDtype_t outputDtype;
+    diopiGetTensorDtype(out, &outputDtype);
+    diopiTensorHandle_t outputTemp;
+    if (diopi_dtype_float16 == outputDtype) {
+        makeTensorLike(ctx, &outputTemp, out, diopi_dtype_float64);
+        diopiCastDtype(ctx, outputTemp, out);
+    } else {
+        outputTemp = out;
+    }
 
     // masked_fill nan
-    return diopiMaskedFillInp(ctx, out, mask, nanValue);
+    diopiMaskedFillInp(ctx, outputTemp, mask, nanValue);
+
+    if (diopi_dtype_float16 == outputDtype) {
+        diopiCastDtype(ctx, out, outputTemp);
+    }
+
+    return diopiSuccess;
 }
 
 aclDataType getAclDataType(diopiDtype_t type) {

--- a/impl/ascend/convert_config.yaml
+++ b/impl/ascend/convert_config.yaml
@@ -117,3 +117,27 @@
 - diopiAll:
     dtype: (float16, float32, float64, int16, int32, int64, uint8, int8)->bool
     layout: NCHW
+
+- diopiLog:
+    dtype: (int16, int32, int64, uint8, int8)->float32
+    layout: NCHW
+
+- diopiLogInp:
+    dtype: (int16, int32, int64, uint8, int8)->float32
+    layout: NCHW
+
+- diopiLog2:
+    dtype: (float64, int16, int32, int64, uint8, int8)->float32
+    layout: NCHW
+
+- diopiLog2Inp:
+    dtype: (float64, int16, int32, int64, uint8, int8)->float32
+    layout: NCHW
+
+- diopiLog10:
+    dtype: (float64, int16, int32, int64, uint8, int8)->float32
+    layout: NCHW
+
+- diopiLog10Inp:
+    dtype: (float64, int16, int32, int64, uint8, int8)->float32
+    layout: NCHW

--- a/impl/ascend/convert_config.yaml
+++ b/impl/ascend/convert_config.yaml
@@ -119,11 +119,11 @@
     layout: NCHW
 
 - diopiLog:
-    dtype: (int16, int32, int64, uint8, int8)->float32
+    dtype: (float16, float32, int16, int32, int64, uint8, int8)->float64
     layout: NCHW
 
 - diopiLogInp:
-    dtype: (int16, int32, int64, uint8, int8)->float32
+    dtype: (float16, float32, int16, int32, int64, uint8, int8)->float64
     layout: NCHW
 
 - diopiLog2:

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -409,7 +409,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "shape": [Skip(()),Skip((1,)),Skip((1024,)),Skip((364800, 4)),Skip((2, 128, 3072)),Skip((256, 128, 3, 3)),Skip((2, 31, 512, 6, 40)),Skip((0,)),Skip((0, 16)),Skip((8, 0, 4)),],
+                    "dtype": [Skip(Dtype.float16),],
                 },
             ]
         ),
@@ -445,7 +445,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "shape": [Skip((1,)),Skip((1024,)),Skip((364800, 4)),Skip((2, 128, 3072)),Skip((256, 128, 3, 3)),Skip((2, 31, 512, 6, 40)),],
+                    "dtype": [Skip(Dtype.float16), Skip(Dtype.int16), Skip(Dtype.int32), Skip(Dtype.int64), Skip(Dtype.uint8), Skip(Dtype.int8),],
                 },
             ]
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -404,19 +404,19 @@ device_configs = {
     ),
 
     'pointwise_op_abs_input': dict(
-        name=['log', 'log2', 'log10', 'sqrt', 'rsqrt'],
+        name=['sqrt', 'rsqrt'],
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16),],
+                    "shape": [Skip(()),Skip((1,)),Skip((1024,)),Skip((364800, 4)),Skip((2, 128, 3072)),Skip((256, 128, 3, 3)),Skip((2, 31, 512, 6, 40)),Skip((0,)),Skip((0, 16)),Skip((8, 0, 4)),],
                 },
             ]
         ),
     ),
 
     'log_integer_input': dict(
-        name=['log', 'log2', 'log10'],
+        name=['log2', 'log10'],
         tensor_para=dict(
             args=[
                 {
@@ -428,7 +428,7 @@ device_configs = {
     ),
 
     'log_zero_input': dict(
-        name=['log', 'log2', 'log10'],
+        name=['log2', 'log10'],
         tensor_para=dict(
             args=[
                 {
@@ -440,12 +440,12 @@ device_configs = {
     ),
 
     'log_neg_input': dict(
-        name=['log', 'log2', 'log10'],
+        name=['log2', 'log10'],
         tensor_para=dict(
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16), Skip(Dtype.int16), Skip(Dtype.int32), Skip(Dtype.int64), Skip(Dtype.uint8), Skip(Dtype.int8),],
+                    "dtype": [Skip(Dtype.int16), Skip(Dtype.int32), Skip(Dtype.int64), Skip(Dtype.uint8), Skip(Dtype.int8),],
                 },
             ]
         ),

--- a/impl/ascend/functions/unary.cpp
+++ b/impl/ascend/functions/unary.cpp
@@ -53,10 +53,19 @@ diopiError_t diopiAbsInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) { 
 
 void logInternal(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, float base) {
     AclOpRunner<1, 1>("Log", ctx).addInput(input).setAttr<float>("base", base).setAttr<float>("scale", 1).setAttr<float>("shift", 0).addOutput(out).run();
-    negativeInputRtnFillNan(ctx, out, input);
+    diopiDtype_t dtype;
+    diopiGetTensorDtype(input, &dtype);
+    if (diopi_dtype_float64 != dtype) {
+        negativeInputRtnFillNan(ctx, out, input);
+    }
 }
 
 void logInpInternal(diopiContextHandle_t ctx, diopiTensorHandle_t input, float base) {
+    diopiDtype_t dtype;
+    diopiGetTensorDtype(input, &dtype);
+    if (diopi_dtype_float64 != dtype) {
+        negativeInputRtnFillNan(ctx, input, input);
+    }
     negativeInputRtnFillNan(ctx, input, input);
     AclOpRunner<1, 1>("Log", ctx).addInput(input).setAttr<float>("base", base).setAttr<float>("scale", 1).setAttr<float>("shift", 0).addOutput(input).run();
 }

--- a/impl/ascend/functions/unary.cpp
+++ b/impl/ascend/functions/unary.cpp
@@ -51,14 +51,43 @@ DIOPI_API diopiError_t diopiAbs(diopiContextHandle_t ctx, diopiTensorHandle_t ou
 
 diopiError_t diopiAbsInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) { return diopiAbs(ctx, input, input); }
 
-diopiError_t diopiLog(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
-    AclOpRunner<1, 1>("Log", ctx).addInput(input).setAttr<float>("base", -1.0).setAttr<float>("scale", 1.0).setAttr<float>("shift", 0.0).addOutput(out).run();
+void logInternal(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, float base) {
+    AclOpRunner<1, 1>("Log", ctx).addInput(input).setAttr<float>("base", base).setAttr<float>("scale", 1).setAttr<float>("shift", 0).addOutput(out).run();
     negativeInputRtnFillNan(ctx, out, input);
+}
+
+void logInpInternal(diopiContextHandle_t ctx, diopiTensorHandle_t input, float base) {
+    negativeInputRtnFillNan(ctx, input, input);
+    AclOpRunner<1, 1>("Log", ctx).addInput(input).setAttr<float>("base", base).setAttr<float>("scale", 1).setAttr<float>("shift", 0).addOutput(input).run();
+}
+
+diopiError_t diopiLog(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    logInternal(ctx, out, input, -1);
     return diopiSuccess;
 }
 
 diopiError_t diopiLogInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
-    AclOpRunner<1, 1>("Log", ctx).addInput(input).setAttr<float>("base", -1.0).setAttr<float>("scale", 1.0).setAttr<float>("shift", 0.0).addOutput(input).run();
+    logInpInternal(ctx, input, -1);
+    return diopiSuccess;
+}
+
+diopiError_t diopiLog2(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    logInternal(ctx, out, input, 2);
+    return diopiSuccess;
+}
+
+diopiError_t diopiLog2Inp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    logInpInternal(ctx, input, 2);
+    return diopiSuccess;
+}
+
+diopiError_t diopiLog10(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    logInternal(ctx, out, input, 10);
+    return diopiSuccess;
+}
+
+diopiError_t diopiLog10Inp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    logInpInternal(ctx, input, 10);
     return diopiSuccess;
 }
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- log2, log10 haven't been implemented on Ascend
- log cannot correctly handle different types of input


## Description
<!--- Describe your changes in detail. -->

- Implement log2, log10
- Fix log by converting all dtypes to float64
- Add support for NaN of float16 in negativeInputRtnFillNan


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

