### PR TITLE
Fix generator and the multinomial op, and implement the uniform op for Ascend

### DIFF
--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -284,34 +284,34 @@ diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t*
         diopiGetTensorData(outCopy, &ptr);
         switch (dtype) {
             case diopiDtype_t::diopi_dtype_float32:
-                reinterpret_cast<float*>(ptr)[0] = getValue<float>(scalar);
+                *reinterpret_cast<float*>(ptr) = getValue<float>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_float64:
-                reinterpret_cast<double*>(ptr)[0] = getValue<double>(scalar);
+                *reinterpret_cast<double*>(ptr) = getValue<double>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_int32:
-                reinterpret_cast<int*>(ptr)[0] = getValue<int>(scalar);
+                *reinterpret_cast<int*>(ptr) = getValue<int>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_int64:
-                reinterpret_cast<int64_t*>(ptr)[0] = getValue<int64_t>(scalar);
+                *reinterpret_cast<int64_t*>(ptr) = getValue<int64_t>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_uint64:
-                reinterpret_cast<uint64_t*>(ptr)[0] = getValue<uint64_t>(scalar);
+                *reinterpret_cast<uint64_t*>(ptr) = getValue<uint64_t>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_uint8:
-                reinterpret_cast<uint8_t*>(ptr)[0] = getValue<uint8_t>(scalar);
+                *reinterpret_cast<uint8_t*>(ptr) = getValue<uint8_t>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_int8:
-                reinterpret_cast<int8_t*>(ptr)[0] = getValue<int8_t>(scalar);
+                *reinterpret_cast<int8_t*>(ptr) = getValue<int8_t>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_bool:
-                reinterpret_cast<bool*>(ptr)[0] = getValue<bool>(scalar);
+                *reinterpret_cast<bool*>(ptr) = getValue<bool>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_int16:
-                reinterpret_cast<int16_t*>(ptr)[0] = getValue<int16_t>(scalar);
+                *reinterpret_cast<int16_t*>(ptr) = getValue<int16_t>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_uint16:
-                reinterpret_cast<uint16_t*>(ptr)[0] = getValue<uint16_t>(scalar);
+                *reinterpret_cast<uint16_t*>(ptr) = getValue<uint16_t>(scalar);
                 break;
             default:
                 error("dtype %d not supported on host", dtype);

--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -295,6 +295,9 @@ diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t*
             case diopiDtype_t::diopi_dtype_int64:
                 reinterpret_cast<int64_t*>(ptr)[0] = getValue<int64_t>(scalar);
                 break;
+            case diopiDtype_t::diopi_dtype_uint64:
+                reinterpret_cast<int64_t*>(ptr)[0] = getValue<uint64_t>(scalar);
+                break;
             case diopiDtype_t::diopi_dtype_uint8:
                 reinterpret_cast<uint8_t*>(ptr)[0] = getValue<uint8_t>(scalar);
                 break;

--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -296,7 +296,7 @@ diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t*
                 reinterpret_cast<int64_t*>(ptr)[0] = getValue<int64_t>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_uint64:
-                reinterpret_cast<int64_t*>(ptr)[0] = getValue<uint64_t>(scalar);
+                reinterpret_cast<uint64_t*>(ptr)[0] = getValue<uint64_t>(scalar);
                 break;
             case diopiDtype_t::diopi_dtype_uint8:
                 reinterpret_cast<uint8_t*>(ptr)[0] = getValue<uint8_t>(scalar);

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -2620,18 +2620,6 @@ device_configs = {
         ),
     ),
 
-    'multinomial': dict(
-        name=['multinomial'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16),Skip(Dtype.float32),Skip(Dtype.float64),],
-                }
-            ]
-        ),
-    ),
-
     'cast_dtype': dict(
         name=['cast_dtype'],
         tensor_para=dict(

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -2345,18 +2345,6 @@ device_configs = {
         ),
     ),
 
-    'uniform': dict(
-        name=['uniform'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float32),Skip(Dtype.float64),Skip(Dtype.float16),],
-                },
-            ]
-        ),
-    ),
-
     'random': dict(
         name=['random'],
         tensor_para=dict(

--- a/impl/ascend/functions/uniform.cpp
+++ b/impl/ascend/functions/uniform.cpp
@@ -1,0 +1,40 @@
+/**
+ * @file
+ * @author DeepLink
+ * @copyright  (c) 2023, DeepLink.
+ */
+
+#include "../common/acloprunner.hpp"
+
+namespace impl {
+namespace ascend {
+
+diopiError_t diopiUniformInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout, double from, double to, diopiGeneratorHandle_t generator) {
+    auto pair = getSeedAndOffset(ctx, generator, 10);
+    diopiScalar_t seedScalar = constructDiopiScalarT(diopi_dtype_int64, pair.first);
+    diopiTensorHandle_t seedTh;
+    makeTensorFromScalar(ctx, &seedScalar, &seedTh, diopi_dtype_uint64);
+    diopiScalar_t offsetScalar = constructDiopiScalarT(diopi_dtype_int64, pair.second);
+    diopiTensorHandle_t offsetTh;
+    makeTensorFromScalar(ctx, &offsetScalar, &offsetTh, diopi_dtype_uint64);
+    diopiScalar_t alg = constructDiopiScalarT(diopi_dtype_int64, 1);
+    AclOpRunner<4, 1>("StatelessRandomUniformV2", ctx)
+        .addConstInput(AscendTensor(inout).shape())
+        .addConstInput(seedTh, false)
+        .addConstInput(offsetTh, false)
+        .addConstInput(alg, diopi_dtype_int32)
+        .setAttr("dtype", getAclDataType(inout))
+        .addOutput(inout)
+        .run();
+
+    // StatelessRandomUniformV2 output: U(0~1) --> U(from~to)
+    diopiScalar_t diffScalar = constructDiopiScalarT(diopi_dtype_float64, to - from);
+    diopiMulInpScalar(ctx, inout, &diffScalar);
+    diopiScalar_t fromScalar = constructDiopiScalarT(diopi_dtype_float64, from);
+    diopiScalar_t alphaScalar = constructDiopiScalarT(diopi_dtype_float64, 1);
+    diopiAddInpScalar(ctx, inout, &fromScalar, &alphaScalar);
+    return diopiSuccess;
+}
+
+}  // namespace ascend
+}  // namespace impl

--- a/impl/ascend/test/conform_test.cpp
+++ b/impl/ascend/test/conform_test.cpp
@@ -15,7 +15,7 @@
 
 #include "../ascend_tensor.hpp"
 #include "../error.hpp"
-
+#include "litert.hpp"
 namespace impl {
 namespace ascend {
 
@@ -81,8 +81,15 @@ diopiError_t finalizeLibrary() {
     return diopiSuccess;
 }
 
-// temporary solution, which needs to be re-implemented later
-diopiError_t buildGeneratorState(diopiContextHandle_t ctx, diopiTensorHandle_t out) { return diopiSuccess; }
+diopiError_t buildGeneratorState(diopiContextHandle_t ctx, diopiTensorHandle_t out) {
+    // state size = seed size + offset size
+    std::vector<int64_t> vec{sizeof(uint64_t) + sizeof(int64_t)};
+    diopiSize_t size{vec.data(), static_cast<int64_t>(vec.size())};
+    diopiTensorHandle_t tensor = nullptr;
+    diopiRequireTensor(ctx, &tensor, &size, nullptr, diopi_dtype_uint8, diopi_host);
+    *out = *tensor;
+    return diopiSuccess;
+}
 
 }  // extern "C"
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- The generator function and multinomial op are broken on Ascend
- The uniform op hasn't been implemented on Ascend


## Description
<!--- Describe your changes in detail. -->

- Fix the buildGeneratorState function to make generator work
- Fix multinomial
- Implement uniform


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

