### PR TITLE
yb/add the installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,5 @@ wrap_func.cpp
 kernel_meta_*
 
 # generate files
-impl/camb/test/export_functions.cpp
+impl/*/test/export_functions.cpp
 proto/include/diopi/diopi_adaptors.hpp

--- a/impl/CMakeLists.txt
+++ b/impl/CMakeLists.txt
@@ -71,3 +71,7 @@ else()
     message(WARNING "No implementation module is compiled, cmake requires option -DIMPL_OPT=CUDA or TORCH")
 endif()
 
+
+# install
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/../proto/include lib DESTINATION include)
+install(DIRECTORY lib DESTINATION lib)

--- a/impl/CMakeLists.txt
+++ b/impl/CMakeLists.txt
@@ -71,7 +71,6 @@ else()
     message(WARNING "No implementation module is compiled, cmake requires option -DIMPL_OPT=CUDA or TORCH")
 endif()
 
-
 # install
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/../proto/include lib DESTINATION include)
-install(DIRECTORY lib DESTINATION lib)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/../proto/include/ TYPE INCLUDE)
+install(DIRECTORY lib/ TYPE INCLUDE)

--- a/impl/supa/CMakeLists.txt
+++ b/impl/supa/CMakeLists.txt
@@ -45,8 +45,11 @@ if(NOT DIOPI_BR_LIB)
     message(FATAL_ERROR "${DEVICEIMPL} library not found !")
 endif()
 
-# ln -s /*/libdiopi_impl.so impl/lib/libdiopi_impl.so
-execute_process(COMMAND ln -s ${DIOPI_BR_LIB} ${LIBRARY_OUTPUT_PATH}/lib${DEVICEIMPL}.so)
+# ln -sf /*/libdiopi_impl.so impl/lib/libdiopi_impl.so
+execute_process(
+    COMMAND mkdir -p ${LIBRARY_OUTPUT_PATH}
+    COMMAND ln -fs ${DIOPI_BR_LIB} ${LIBRARY_OUTPUT_PATH}/lib${DEVICEIMPL}.so
+)
 
 if (TEST)
   add_subdirectory(test)

--- a/impl/supa/CMakeLists.txt
+++ b/impl/supa/CMakeLists.txt
@@ -40,9 +40,13 @@ endif()
 
 find_library(DIOPI_BR_LIB NAMES ${DEVICEIMPL} HINTS ${DIOPI_SUPA_DIR}/lib ${DIOPI_SUPA_DIR}/lib64)
 message(STATUS "DIOPI-IMPL lib: ${DIOPI_BR_LIB}")
+
 if(NOT DIOPI_BR_LIB)
     message(FATAL_ERROR "${DEVICEIMPL} library not found !")
 endif()
+
+# ln -s /*/libdiopi_impl.so impl/lib/libdiopi_impl.so
+execute_process(COMMAND ln -s ${DIOPI_BR_LIB} ${LIBRARY_OUTPUT_PATH}/${DEVICEIMPL})
 
 if (TEST)
   add_subdirectory(test)

--- a/impl/supa/CMakeLists.txt
+++ b/impl/supa/CMakeLists.txt
@@ -46,7 +46,7 @@ if(NOT DIOPI_BR_LIB)
 endif()
 
 # ln -s /*/libdiopi_impl.so impl/lib/libdiopi_impl.so
-execute_process(COMMAND ln -s ${DIOPI_BR_LIB} ${LIBRARY_OUTPUT_PATH}/${DEVICEIMPL})
+execute_process(COMMAND ln -s ${DIOPI_BR_LIB} ${LIBRARY_OUTPUT_PATH}/lib${DEVICEIMPL}.so)
 
 if (TEST)
   add_subdirectory(test)


### PR DESCRIPTION
## Motivation and Context
* On supa, the libdiopi_impl.so is missing under the impl/lib 
* Not support the `make install`


## Description
* create the symbolic link for  libdiopi_impl.so under the  impl/lib 
* support `make install` by specifying the installation path `-DCMAKE_INSTALL_PREFIX=...`. 


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

