### PR TITLE
Add normal and normal_ ops for Ascend

### DIFF
--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -2503,27 +2503,6 @@ device_configs = {
         ),
     ),
 
-    'normal': dict(
-        name=['normal'],
-        para=dict(
-            mean=[Skip(-1),Skip(-0.5),Skip(0),Skip(0.1),Skip(2),Skip(True),Skip(False),Skip(0.2),Skip(-2),Skip(0),],
-            std=[Skip(0),Skip(0.5),Skip(1),Skip(2.3),Skip(3),Skip(True),Skip(True),Skip(0.5),Skip(0),Skip(3),],
-            size=[Skip(()),Skip((1280,)),Skip((32, 160)),Skip((320, 8)),Skip((32, 80)),Skip((2, 2, 20, 16)),Skip((320, 2, 3, 3)),Skip((0,)),Skip((4, 0)),Skip((2, 0, 9)),],
-        ),
-    ),
-
-    'normal_': dict(
-        name=['normal_'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float16),Skip(Dtype.float32),Skip(Dtype.float64),],
-                },
-            ]
-        ),
-    ),
-
     'normal_std_tensor': dict(
         name=['normal'],
         tensor_para=dict(

--- a/impl/ascend/functions/normal.cpp
+++ b/impl/ascend/functions/normal.cpp
@@ -1,0 +1,45 @@
+/**
+ * @file
+ * @author DeepLink
+ * @copyright  (c) 2023, DeepLink.
+ */
+
+#include "../common/acloprunner.hpp"
+
+namespace impl {
+namespace ascend {
+
+diopiError_t diopiNormal(diopiContextHandle_t ctx, diopiTensorHandle_t out, double mean, double std, diopiGeneratorHandle_t generator) {
+    AscendTensor outputAt(out);
+    auto pair = getSeedAndOffset(ctx, generator, 10);
+    diopiScalar_t seedScalar = constructDiopiScalarT(diopi_dtype_int64, pair.first);
+    diopiTensorHandle_t seedTh;
+    makeTensorFromScalar(ctx, &seedScalar, &seedTh, diopi_dtype_uint64);
+    diopiScalar_t offsetScalar = constructDiopiScalarT(diopi_dtype_int64, pair.second);
+    diopiTensorHandle_t offsetTh;
+    makeTensorFromScalar(ctx, &offsetScalar, &offsetTh, diopi_dtype_uint64);
+    diopiScalar_t alg = constructDiopiScalarT(diopi_dtype_int64, 1);
+    AclOpRunner<4, 1>("StatelessRandomNormalV2", ctx)
+        .addConstInput(outputAt.dim() == 0 ? std::vector<int64_t>{1} : outputAt.shape())
+        .addConstInput(seedTh, false)
+        .addConstInput(offsetTh, false)
+        .addConstInput(alg, diopi_dtype_int32)
+        .setAttr("dtype", getAclDataType(out))
+        .addOutput(out)
+        .run();
+
+    // StatelessRandomNormalV2 output: N(0,1) --> N(mean,std)
+    diopiScalar_t stdScalar = constructDiopiScalarT(diopi_dtype_float64, std);
+    diopiMulInpScalar(ctx, out, &stdScalar);
+    diopiScalar_t meanScalar = constructDiopiScalarT(diopi_dtype_float64, mean);
+    diopiScalar_t alphaScalar = constructDiopiScalarT(diopi_dtype_float64, 1);
+    diopiAddInpScalar(ctx, out, &meanScalar, &alphaScalar);
+    return diopiSuccess;
+}
+
+diopiError_t diopiNormalInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout, double mean, double std, diopiGeneratorHandle_t generator) {
+    return diopiNormal(ctx, inout, mean, std, generator);
+}
+
+}  // namespace ascend
+}  // namespace impl


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The normal and normal_ ops haven't been implemented on Ascend

## Description
<!--- Describe your changes in detail. -->

Implement normal and normal_. Specifically, diopiNormal and diopiNormalInp are implemented, which only allows mean and std inputs as scalars. Note that diopiNormalTensor, diopiNormalTensorScalar, diopiNormalScalarTensor are not implemented in this PR for mean and std inputs being tensors.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

