### PR TITLE
Add the diopiGroupNorm op for Ascend

### DIFF
--- a/diopi_test/python/conformance/conformance_test.py
+++ b/diopi_test/python/conformance/conformance_test.py
@@ -98,7 +98,7 @@ def allclose(cfg: dict, tensor1: np.ndarray, tensor2: np.ndarray, sum_to_compare
                     \n" + f"{var_name} is {tensor1},\n{var_name}_ref is {tensor2},\nMask is {mask}\n")
         else:
             assert tensor1.size == tensor2.size, "tensor1 element num does not equal tensor2's."
-            diff = np.abs(tensor1 - tensor2)
+            diff = np.abs(tensor1 - tensor2) * ~matched
             max_diff = np.nanmax(diff)
             max_diff_index = np.unravel_index(np.nanargmax(diff), diff.shape)
             max_diff_elem = tensor1[max_diff_index]

--- a/impl/ascend/ascend_tensor.cpp
+++ b/impl/ascend/ascend_tensor.cpp
@@ -194,7 +194,7 @@ aclFormat AscendTensor::getAclDataFormat() const {
             return ACL_FORMAT_NDHWC;
         }
 
-        warning("getAclDataFormat error. Acl only support NCDHW or NDHWC format! but get %s", dumpTensor(tensor_).c_str());
+        warning("getAclDataFormat warning. Acl only support NCDHW or NDHWC format! but get %s", dumpTensor(tensor_).c_str());
     } else if (dim() == 4) {
         std::array<int64_t, 4> thStride{stride(0), stride(1), stride(2), stride(3)};
         {
@@ -221,7 +221,7 @@ aclFormat AscendTensor::getAclDataFormat() const {
         if (thStride == nhwcStride) {
             return ACL_FORMAT_NHWC;
         }
-        warning("getAclDataFormat error. Acl only support NCHW or NHWC format! but get %s", dumpTensor(tensor_).c_str());
+        warning("getAclDataFormat warning. Acl only support NCHW or NHWC format! but get %s", dumpTensor(tensor_).c_str());
     }
     return ACL_FORMAT_ND;
 }

--- a/impl/ascend/convert_config.yaml
+++ b/impl/ascend/convert_config.yaml
@@ -170,3 +170,6 @@
     dtype: (float16)->float32
     layout: NCHW
 
+- diopiGroupNorm:
+    dtype: (float64)->float32
+    layout: NCHW

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -88,30 +88,14 @@ device_configs = {
 
     'baddbmm': dict(
         name=['baddbmm'],
-        tensor_para=dict(
-            atol=4e-2,
-            rtol=4e-2,
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((32, 64, 16)),Skip((32, 64, 32)),Skip((168, 52, 64)),Skip((2, 0, 2)),],
-                },
-            ]
-        ),
+        atol=1e-2,
+        rtol=1e-2,
     ),
 
     'baddbmm_without_inplace': dict(
         name=['baddbmm'],
-        tensor_para=dict(
-            atol=4e-2,
-            rtol=4e-2,
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((32, 64, 16)),Skip((32, 64, 32)),Skip((168, 52, 64)),Skip((16,)),Skip((64, 32)),Skip((1, 52, 64)),Skip((32, 1, 16)),Skip((32, 64, 1)),Skip((64,)),Skip((2,)),Skip((0, 2)),],
-                },
-            ]
-        ),
+        atol=1e-2,
+        rtol=1e-2,
     ),
 
     'conv_2d': dict(

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -1954,14 +1954,10 @@ device_configs = {
 
     'group_norm': dict(
         name=['group_norm'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(Dtype.float32),Skip(Dtype.float64),Skip(Dtype.float16),],
-                },
-            ]
-        ),
+        atol=5e-2,
+        rtol=1e-2,
+        atol_half=5e-2,
+        rtol_half=5e-2,
     ),
 
     'unique': dict(

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -1087,8 +1087,8 @@ device_configs = {
 
     'linear': dict(
         name=['linear'],
-        atol = 3e-2,
-        rtol = 3e-2,
+        atol = 5e-2,
+        rtol = 5e-2,
     ),
 
     'embedding': dict(
@@ -1943,7 +1943,7 @@ device_configs = {
     'group_norm': dict(
         name=['group_norm'],
         atol=5e-2,
-        rtol=1e-2,
+        rtol=5e-2,
         atol_half=5e-2,
         rtol_half=5e-2,
     ),

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -97,7 +97,7 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
         diopiGetTensorStride(runningMean, &stride);
         diopiRequireTensor(ctx, &sum, &shape, &stride, diopiDtype_t::diopi_dtype_float32, diopi_device);
         diopiRequireTensor(ctx, &squareSum, &shape, &stride, diopiDtype_t::diopi_dtype_float32, diopi_device);
-        AclOpRunner<1, 2>("BNTrainingReduce", ctx).addInput(inputAt).setAttr("epsilon", static_cast<float>(eps)).addOutput(sum).addOutput(squareSum).run();
+        AclOpRunner<1, 2>("BNTrainingReduce", ctx).addInput(inputAt).addOutput(sum).addOutput(squareSum).run();
         AclOpRunner<7, 5>("BNTrainingUpdate", ctx)
             .addInput(inputAt)
             .addInput(sum)

--- a/impl/ascend/functions/group_norm.cpp
+++ b/impl/ascend/functions/group_norm.cpp
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * @author DeepLink
+ * @copyright  (c) 2023, DeepLink.
+ */
+
+#include "../common/acloprunner.hpp"
+
+namespace impl {
+namespace ascend {
+
+DIOPI_API diopiError_t diopiGroupNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t saveMean, diopiTensorHandle_t saveInvstd,
+                                      diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, int64_t numGroups,
+                                      double eps) {
+    if (0 == AscendTensor(input).numel()) {
+        AclOpRunner<1, 1>("Fills", ctx).addInput(out).setAttr<float>("value", 0).addOutput(out).run();
+        return diopiSuccess;
+    }
+
+    AclOpRunner<3, 3>("GroupNorm", ctx)
+        .addInput(input)
+        .addInput(weight)
+        .addInput(bias)
+        .setAttr("num_groups", static_cast<int32_t>(numGroups))
+        .setAttr("epsilon", static_cast<float>(eps))
+        .setAttr("data_format", std::string{getAclDataFormat(input) > 2 ? "NCHW" : "ND"})
+        .setAttr("is_training", true)
+        .addOutput(out)
+        .addOutput(saveMean)
+        .addOutput(saveInvstd)
+        .run();
+    return diopiSuccess;
+}
+
+}  // namespace ascend
+}  // namespace impl


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The diopiGroupNorm op hasn't been implemented on Ascend.

## Description
<!--- Describe your changes in detail. -->

- Implement diopiGroupNorm (Note that diopiGroupNormBackward is not implemented in this PR due to its lower priority)
- Fix max diff computation to find max diff only from mismatched values
- Fix baddbmm configs in device_configs.py
- Change getAclDataFormat error to warning
- Remove an unnecessary attr setting in batch_norm
- Update atol and rtol in device_configs.py for the linear op

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

