### PR TITLE
Fix the layer_norm op for Ascend

### DIFF
--- a/impl/ascend/convert_config.yaml
+++ b/impl/ascend/convert_config.yaml
@@ -209,3 +209,11 @@
 - diopiGroupNorm:
     dtype: (float64)->float32
     layout: NCHW
+
+- diopiLayerNorm:
+    dtype: (float64)->float32
+    layout: NCHW
+
+- diopiLayerNormBackward:
+    dtype: (float64)->float32
+    layout: NCHW

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -2300,6 +2300,7 @@ device_configs = {
     'layer_norm': dict(
         name=['layer_norm'],
         atol=1e-4,
+        rtol=1e-4,
         para=dict(
             eps=[Skip(2),],
         ),

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -2299,25 +2299,9 @@ device_configs = {
 
     'layer_norm': dict(
         name=['layer_norm'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((2, 5, 3, 5)),Skip((2, 3136, 128)),Skip((2, 64)),Skip((32,)),Skip((2, 5, 3, 5)),Skip((2, 16, 128)),],
-                },
-            ]
-        ),
-    ),
-
-    'layer_norm_empty_tensor': dict(
-        name=['layer_norm'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((0,)),Skip((0, 12)),Skip((6, 0, 9)),],
-                },
-            ]
+        atol=1e-4,
+        para=dict(
+            eps=[Skip(2),],
         ),
     ),
 

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -58,12 +58,12 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
                             diopiTensorHandle_t runningVar, bool training, double momentum, double eps) {
     if (runningMean == nullptr) {
         makeTensorLike(ctx, &runningMean, weight, diopi_dtype_float32);
-        diopiScalar_t zero = constructDiopiScalarT(diopi_dtype_float32, 0);
+        diopiScalar_t zero = constructDiopiScalarT(diopi_dtype_float64, 0);
         diopiFill(ctx, runningMean, &zero);
     }
     if (runningVar == nullptr) {
         makeTensorLike(ctx, &runningVar, weight, diopi_dtype_float32);
-        diopiScalar_t one = constructDiopiScalarT(diopi_dtype_float32, 1);
+        diopiScalar_t one = constructDiopiScalarT(diopi_dtype_float64, 1);
         diopiFill(ctx, runningVar, &one);
     }
 

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -64,7 +64,7 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     if (runningVar == nullptr) {
         makeTensorLike(ctx, &runningVar, weight, diopi_dtype_float32);
         diopiScalar_t one = constructDiopiScalarT(diopi_dtype_float32, 1);
-        diopiFill(ctx, runningMean, &one);
+        diopiFill(ctx, runningVar, &one);
     }
 
     AscendTensor inputAt(input), outputAt(out);

--- a/impl/ascend/functions/group_norm.cpp
+++ b/impl/ascend/functions/group_norm.cpp
@@ -23,7 +23,7 @@ DIOPI_API diopiError_t diopiGroupNorm(diopiContextHandle_t ctx, diopiTensorHandl
         .addInput(bias)
         .setAttr("num_groups", static_cast<int32_t>(numGroups))
         .setAttr("epsilon", static_cast<float>(eps))
-        .setAttr("data_format", std::string{getAclDataFormat(input) > 2 ? "NCHW" : "ND"})
+        .setAttr("data_format", std::string{getAclDataFormat(input) == ACL_FORMAT_ND ? "ND" : "NCHW"})
         .setAttr("is_training", true)
         .addOutput(out)
         .addOutput(saveMean)

--- a/impl/ascend/functions/layer_norm.cpp
+++ b/impl/ascend/functions/layer_norm.cpp
@@ -9,9 +9,43 @@
 namespace impl {
 namespace ascend {
 
+diopiSize_t computeStrideFromShape(diopiSize_t &shape, std::vector<int64_t> &strideVec) {
+    strideVec.resize(shape.len, 1);
+    for (int64_t i = shape.len - 2; i >= 0; --i) {
+        strideVec[i] = strideVec[i + 1] * shape.data[i + 1];
+    }
+    return vectorToDiopiSize(strideVec);
+}
+
+diopiTensorHandle_t createTensorIfNullptr(diopiContextHandle_t ctx, diopiConstTensorHandle_t in, diopiSize_t &shape, diopiSize_t &stride, diopiDtype_t dtype,
+                                          bool isFillingRequired, double value) {
+    diopiTensorHandle_t out;
+    if (nullptr == in) {
+        diopiRequireTensor(ctx, &out, &shape, &stride, dtype, diopi_device);
+        if (isFillingRequired) {
+            diopiScalar_t valueScalar = constructDiopiScalarT(diopi_dtype_float64, value);
+            diopiFill(ctx, out, &valueScalar);
+        }
+    } else {
+        out = const_cast<diopiTensorHandle_t>(in);
+    }
+    return out;
+}
+
 diopiError_t diopiLayerNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t saveMean, diopiTensorHandle_t saveInvstd,
                             diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiSize_t normalizedShape,
                             double eps) {
+    AscendTensor inputAt(input);
+    if (0 == inputAt.numel()) {
+        AclOpRunner<1, 1>("Fills", ctx).addInput(out).setAttr<float>("value", 0).addOutput(out).run();
+        return diopiSuccess;
+    }
+
+    std::vector<int64_t> normalizedStrideVec;
+    diopiSize_t normalizedStride = computeStrideFromShape(normalizedShape, normalizedStrideVec);
+    diopiTensorHandle_t weightTemp = createTensorIfNullptr(ctx, weight, normalizedShape, normalizedStride, inputAt.dtype(), true, 1);
+    diopiTensorHandle_t biasTemp = createTensorIfNullptr(ctx, bias, normalizedShape, normalizedStride, inputAt.dtype(), true, 0);
+
     // gen begin normalized dim
     diopiSize_t inShape;
     diopiGetTensorShape(input, &inShape);
@@ -21,8 +55,8 @@ diopiError_t diopiLayerNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     // call acl op
     AclOpRunner<3, 3>("LayerNorm", ctx)
         .addInput(input)
-        .addInput(weight)
-        .addInput(bias)
+        .addInput(weightTemp)
+        .addInput(biasTemp)
         .addOutput(out)
         .addOutput(saveMean)
         .addOutput(saveInvstd)
@@ -36,17 +70,32 @@ diopiError_t diopiLayerNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 diopiError_t diopiLayerNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gradInput, diopiTensorHandle_t gradWeight, diopiTensorHandle_t gradBias,
                                     diopiConstTensorHandle_t gradOutput, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
                                     diopiConstTensorHandle_t bias, diopiConstTensorHandle_t mean, diopiConstTensorHandle_t rstd, diopiSize_t normalizedShape) {
+    std::vector<int64_t> normalizedStrideVec;
+    diopiSize_t normalizedStride = computeStrideFromShape(normalizedShape, normalizedStrideVec);
+    AscendTensor inputAt(input);
+    diopiTensorHandle_t weightTemp = createTensorIfNullptr(ctx, weight, normalizedShape, normalizedStride, inputAt.dtype(), true, 1);
+    diopiTensorHandle_t gradWeightTemp = createTensorIfNullptr(ctx, gradWeight, normalizedShape, normalizedStride, inputAt.dtype(), false, 0);
+    diopiTensorHandle_t gradBiasTemp = createTensorIfNullptr(ctx, gradBias, normalizedShape, normalizedStride, inputAt.dtype(), false, 0);
+
+    // Align the shape of mean and rstd with input
+    AscendTensor meanAt(mean), rstdAt(rstd);
+    while (meanAt.dim() < inputAt.dim()) {
+        meanAt.unsqueeze(meanAt.dim());
+        rstdAt.unsqueeze(rstdAt.dim());
+    }
+
     AclOpRunner<5, 3>("LayerNormGrad", ctx)
         .addInput(gradOutput)
         .addInput(input)
-        .addInput(rstd)
-        .addInput(mean)
-        .addInput(weight)
+        .addInput(rstdAt)
+        .addInput(meanAt)
+        .addInput(weightTemp)
         .addOutput(gradInput)
-        .addOutput(gradWeight)
-        .addOutput(gradBias)
+        .addOutput(gradWeightTemp)
+        .addOutput(gradBiasTemp)
         .run();
     return diopiSuccess;
 }
+
 }  // namespace ascend
 }  // namespace impl


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The layer_norm op can cause segmentation fault in conformance tests

## Description
<!--- Describe your changes in detail. -->

- Fix the layer_norm op for Ascend
- Fix a bug in filling nullptr runningVar in diopiBatchNorm
- Fix the data_format setting in diopiGroupNorm

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

