### PR TITLE
lcy/fix dropelet diopi test error

### DIFF
--- a/impl/droplet/test/CMakeLists.txt
+++ b/impl/droplet/test/CMakeLists.txt
@@ -32,6 +32,9 @@ set(EXPORT_SRC
 
 message("CXX_LITERT_SRC:" ${CXX_LITERT_SRC})
 
+find_package(Python COMPONENTS Interpreter Development)
+set(PYBIND11_PYTHON_VERSION ${Python_VERSION})
+
 pybind11_add_module(${DIOPI_EXPORT_RT} SHARED ${EXPORT_SRC})
 add_library(diopiruntime SHARED ${RUNTIME_SRC})
 
@@ -76,6 +79,6 @@ endif()
 
 file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/../diopi_test/python)
 add_custom_target(python_copy ALL
-    COMMAND ln -f ${LIBRARY_OUTPUT_PATH}/$<TARGET_FILE_NAME:${DIOPI_EXPORT_FUNCTIONS}> ${CMAKE_SOURCE_DIR}/../diopi_test/python
-    COMMAND ln -f ${LIBRARY_OUTPUT_PATH}/$<TARGET_FILE_NAME:${DIOPI_EXPORT_RT}> ${CMAKE_SOURCE_DIR}/../diopi_test/python
+    COMMAND ln -f ${LIBRARY_OUTPUT_PATH}/$<TARGET_FILE_NAME:${DIOPI_EXPORT_FUNCTIONS}> ${CMAKE_SOURCE_DIR}/../diopi_test/python/diopilib
+    COMMAND ln -f ${LIBRARY_OUTPUT_PATH}/$<TARGET_FILE_NAME:${DIOPI_EXPORT_RT}> ${CMAKE_SOURCE_DIR}/../diopi_test/python/diopilib
     DEPENDS ${DIOPI_EXPORT_FUNCTIONS} ${DIOPI_EXPORT_RT})

--- a/impl/droplet/test/CMakeLists.txt
+++ b/impl/droplet/test/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(DIOPI_EXPORT_RT export_runtime)
 set(DIOPI_EXPORT_FUNCTIONS export_functions)
 
+find_package(Python COMPONENTS Interpreter Development)
+set(PYBIND11_PYTHON_VERSION ${Python_VERSION})
+
 add_compile_options(-fno-elide-constructors)
 add_subdirectory(${CMAKE_SOURCE_DIR}/third_party/pybind11 build)
 
@@ -31,9 +34,6 @@ set(EXPORT_SRC
 )
 
 message("CXX_LITERT_SRC:" ${CXX_LITERT_SRC})
-
-find_package(Python COMPONENTS Interpreter Development)
-set(PYBIND11_PYTHON_VERSION ${Python_VERSION})
 
 pybind11_add_module(${DIOPI_EXPORT_RT} SHARED ${EXPORT_SRC})
 add_library(diopiruntime SHARED ${RUNTIME_SRC})

--- a/impl/droplet/test/conform_test.cpp
+++ b/impl/droplet/test/conform_test.cpp
@@ -8,9 +8,12 @@
 #include <diopi/diopirt.h>
 #include <tang_compiler_api.h>
 #include <tang_runtime.h>
+#include <vector>
 
 #include <cstdio>
 #include <mutex>
+
+#include "litert.hpp"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -83,6 +86,15 @@ const char* device_get_last_error_string() {
 diopiError_t finalizeLibrary() { return diopiSuccess; }
 
 diopiError_t initLibrary() { return diopiSuccess; }
+
+diopiError_t buildGeneratorState(diopiContextHandle_t ctx, diopiTensorHandle_t out) {
+    std::vector<int64_t> vec{808};
+    diopiSize_t size{vec.data(), static_cast<int64_t>(vec.size())};
+    diopiTensorHandle_t tensor = nullptr;
+    diopiRequireTensor(ctx, &tensor, &size, nullptr, diopi_dtype_uint8, diopi_host);
+    *out = *tensor;
+    return diopiSuccess;
+}
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/impl/droplet/test/conform_test.cpp
+++ b/impl/droplet/test/conform_test.cpp
@@ -4,14 +4,15 @@
  * Author
  *
  *************************************************************************************************/
+
 #include <conform_test.h>
 #include <diopi/diopirt.h>
 #include <tang_compiler_api.h>
 #include <tang_runtime.h>
-#include <vector>
 
 #include <cstdio>
 #include <mutex>
+#include <vector>
 
 #include "litert.hpp"
 


### PR DESCRIPTION


## Motivation and Context
droplet 跑diopi test会报错找不到python库，修改了export_runtime.so和export_functions.so的生成路径，补充了一些编译过程需要的函数


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

