### PR TITLE
save memory for add/sub/mul/div-scalar on cuda

### DIFF
--- a/impl/torch/functions.cpp
+++ b/impl/torch/functions.cpp
@@ -164,7 +164,7 @@ diopiError_t diopiDivScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     auto atOther = impl::aten::buildAtScalar(other);
     auto roundingMode = impl::aten::getRoundingMode(rounding_mode);
     auto atOut = impl::aten::buildATen(out);
-    at::div_out(atOut, atInput, atOther, roundingMode);
+    at::div_out(atOut, atInput, c10::scalar_to_tensor(atOther), roundingMode);
     impl::aten::unsetCurCtx();
     return diopiSuccess;
 }
@@ -1126,7 +1126,7 @@ diopiError_t diopiAddScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     at::Scalar atOther = impl::aten::buildAtScalar(other);
     at::Scalar atAlpha = impl::aten::buildAtScalar(alpha);
     at::Tensor atOut = impl::aten::buildATen(out);
-    at::add_out(atOut, atInput, atOther, atAlpha);
+    at::add_out(atOut, atInput, c10::scalar_to_tensor(atOther), atAlpha);
 
     impl::aten::unsetCurCtx();
     return diopiSuccess;
@@ -1171,7 +1171,7 @@ diopiError_t diopiSubScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     at::Scalar atOther = impl::aten::buildAtScalar(other);
     at::Scalar atAlpha = impl::aten::buildAtScalar(alpha);
     at::Tensor atOut = impl::aten::buildATen(out);
-    at::sub_out(atOut, atInput, atOther, atAlpha);
+    at::sub_out(atOut, atInput, c10::scalar_to_tensor(atOther), atAlpha);
 
     impl::aten::unsetCurCtx();
     return diopiSuccess;
@@ -1211,7 +1211,7 @@ diopiError_t diopiMulScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     at::Tensor atInput = impl::aten::buildATen(input);
     at::Scalar atOther = impl::aten::buildAtScalar(other);
     at::Tensor atOut = impl::aten::buildATen(out);
-    at::mul_out(atOut, atInput, atOther);
+    at::mul_out(atOut, atInput, c10::scalar_to_tensor(atOther));
     impl::aten::unsetCurCtx();
     return diopiSuccess;
 }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
impl/torch 里的某些实现（至少有add/sub/mul/div-scalar）会占用额外的临时显存，在32g的v100上用下面的代码可以复现问题

```python
import torch 
# import torch_dipu
a=torch.empty((1024,1024,1024),device='cuda')
y=[torch.empty_like(a) for _ in range(6)]
[torch.add(a,1e-5,out=o) for o in y]
torch.cuda.synchronize()
```

## Description
<!--- Describe your changes in detail. -->
以add为例，原本调用的 at::add_out(at::Tensor&, const at::Tensor&, const at::Scalar&, const at::Scalar&) 会调用到 
![企业微信截图_16987407726531](https://github.com/DeepLink-org/DIOPI/assets/109072365/98c16160-8fc9-4d34-afde-54cd8643d223) tmp_output 占用了额外的显存 pytorch从python层不会调用到这个接口

改为调用 at::add_out(at::Tensor&, const at::Tensor&, const at::Tensor&, const at::Scalar&)


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

