### PR TITLE
Fix a segmentation fault for Ascend batch_norm with weight/bias being nullptr

### DIFF
--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -236,6 +236,20 @@ diopiError_t fillTensor(diopiContextHandle_t ctx, diopiTensorHandle_t out, doubl
     return diopiSuccess;
 }
 
+diopiTensorHandle_t createTensorIfNullptr(diopiContextHandle_t ctx, diopiConstTensorHandle_t in, diopiSize_t& shape, diopiDtype_t dtype, bool isFillingRequired,
+                                          double value) {
+    diopiTensorHandle_t out;
+    if (nullptr == in) {
+        diopiRequireTensor(ctx, &out, &shape, nullptr, dtype, diopi_device);
+        if (isFillingRequired) {
+            fillTensor(ctx, out, value);
+        }
+    } else {
+        out = const_cast<diopiTensorHandle_t>(in);
+    }
+    return out;
+}
+
 diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t* scalar, diopiTensorHandle_t* out, diopiDtype_t dtype, diopiDevice_t device) {
     int64_t sizeTmp[1] = {1};
     diopiSize_t sSize = arrayToDiopiSize(sizeTmp, 1);

--- a/impl/ascend/common/utils.hpp
+++ b/impl/ascend/common/utils.hpp
@@ -65,6 +65,9 @@ diopiError_t castTensor(diopiContextHandle_t ctx, const AscendTensor& src, Ascen
 
 diopiError_t castTensor(diopiContextHandle_t ctx, const std::vector<AscendTensor>& src, std::vector<AscendTensor>& dst, diopiDtype_t supportDtype);
 
+diopiTensorHandle_t createTensorIfNullptr(diopiContextHandle_t ctx, diopiConstTensorHandle_t in, diopiSize_t& shape, diopiDtype_t dtype, bool isFillingRequired,
+                                          double value);
+
 /**
  * @brief Convert the data type of an AscendTensor src to the specified supported data type dtype.
  *

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -56,28 +56,24 @@ void batchNormBackwardTrainingReduceNocheck(diopiContextHandle_t ctx, AscendTens
 diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t saveMean, diopiTensorHandle_t saveInvstd,
                             diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiTensorHandle_t runningMean,
                             diopiTensorHandle_t runningVar, bool training, double momentum, double eps) {
-    if (runningMean == nullptr) {
-        makeTensorLike(ctx, &runningMean, weight, diopi_dtype_float32);
-        diopiScalar_t zero = constructDiopiScalarT(diopi_dtype_float64, 0);
-        diopiFill(ctx, runningMean, &zero);
-    }
-    if (runningVar == nullptr) {
-        makeTensorLike(ctx, &runningVar, weight, diopi_dtype_float32);
-        diopiScalar_t one = constructDiopiScalarT(diopi_dtype_float64, 1);
-        diopiFill(ctx, runningVar, &one);
-    }
-
     AscendTensor inputAt(input), outputAt(out);
     updateInputAscendTensorDim(inputAt, training);
     outputAt.view(inputAt.getAclMemShape());
 
+    std::vector<int64_t> batchShapeV{inputAt.shape(1)};
+    diopiSize_t batchShapeSizeT{batchShapeV.data(), static_cast<int64_t>(batchShapeV.size())};
+    diopiTensorHandle_t weightTemp = createTensorIfNullptr(ctx, weight, batchShapeSizeT, inputAt.dtype(), true, 1);
+    diopiTensorHandle_t biasTemp = createTensorIfNullptr(ctx, bias, batchShapeSizeT, inputAt.dtype(), true, 0);
+    diopiTensorHandle_t runningMeanTemp = createTensorIfNullptr(ctx, runningMean, batchShapeSizeT, inputAt.dtype(), true, 0);
+    diopiTensorHandle_t runningVarTemp = createTensorIfNullptr(ctx, runningVar, batchShapeSizeT, inputAt.dtype(), true, 1);
+
     if (!training) {
         AclOpRunner<5, 1>("BNInfer", ctx)
             .addInput(inputAt)
-            .addInput(weight)
-            .addInput(bias)
-            .addInput(runningMean)
-            .addInput(runningVar)
+            .addInput(weightTemp)
+            .addInput(biasTemp)
+            .addInput(runningMeanTemp)
+            .addInput(runningVarTemp)
             .addOutput(outputAt)
             .setAttr("epsilon", static_cast<float>(eps))
             .run();
@@ -93,8 +89,8 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     } else {
         diopiTensorHandle_t sum = nullptr, squareSum = nullptr;
         diopiSize_t shape, stride;
-        diopiGetTensorShape(runningMean, &shape);
-        diopiGetTensorStride(runningMean, &stride);
+        diopiGetTensorShape(runningMeanTemp, &shape);
+        diopiGetTensorStride(runningMeanTemp, &stride);
         diopiRequireTensor(ctx, &sum, &shape, &stride, diopiDtype_t::diopi_dtype_float32, diopi_device);
         diopiRequireTensor(ctx, &squareSum, &shape, &stride, diopiDtype_t::diopi_dtype_float32, diopi_device);
         AclOpRunner<1, 2>("BNTrainingReduce", ctx).addInput(inputAt).addOutput(sum).addOutput(squareSum).run();
@@ -102,15 +98,15 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
             .addInput(inputAt)
             .addInput(sum)
             .addInput(squareSum)
-            .addInput(weight)
-            .addInput(bias)
-            .addInput(runningMean)
-            .addInput(runningVar)
+            .addInput(weightTemp)
+            .addInput(biasTemp)
+            .addInput(runningMeanTemp)
+            .addInput(runningVarTemp)
             .setAttr("epsilon", static_cast<float>(eps))
             .setAttr("factor", static_cast<float>(momentum))
             .addOutput(outputAt)
-            .addOutput(runningMean)
-            .addOutput(runningVar)
+            .addOutput(runningMeanTemp)
+            .addOutput(runningVarTemp)
             .addOutput(saveMean)
             .addOutput(saveInvstd)
             .run();


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

batch_norm on Ascend can cause a segmentation fault when weight or bias is a nullptr.


## Description
<!--- Describe your changes in detail. -->

- Fix the segmentation fault for batch_norm
- Extract the `createTensorIfNullptr` function from the implementation of layer_norm


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

