### PR TITLE
Fix a segmentation fault for Ascend argmax with dim being nullptr 

### DIFF
--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -236,8 +236,8 @@ diopiError_t fillTensor(diopiContextHandle_t ctx, diopiTensorHandle_t out, doubl
     return diopiSuccess;
 }
 
-diopiTensorHandle_t createTensorIfNullptr(diopiContextHandle_t ctx, diopiConstTensorHandle_t in, diopiSize_t& shape, diopiDtype_t dtype, bool isFillingRequired,
-                                          double value) {
+diopiTensorHandle_t createTensorIfNullptrOrConstCast(diopiContextHandle_t ctx, diopiConstTensorHandle_t in, diopiSize_t& shape, diopiDtype_t dtype,
+                                                     bool isFillingRequired, double value) {
     diopiTensorHandle_t out;
     if (nullptr == in) {
         diopiRequireTensor(ctx, &out, &shape, nullptr, dtype, diopi_device);

--- a/impl/ascend/common/utils.hpp
+++ b/impl/ascend/common/utils.hpp
@@ -65,8 +65,8 @@ diopiError_t castTensor(diopiContextHandle_t ctx, const AscendTensor& src, Ascen
 
 diopiError_t castTensor(diopiContextHandle_t ctx, const std::vector<AscendTensor>& src, std::vector<AscendTensor>& dst, diopiDtype_t supportDtype);
 
-diopiTensorHandle_t createTensorIfNullptr(diopiContextHandle_t ctx, diopiConstTensorHandle_t in, diopiSize_t& shape, diopiDtype_t dtype, bool isFillingRequired,
-                                          double value);
+diopiTensorHandle_t createTensorIfNullptrOrConstCast(diopiContextHandle_t ctx, diopiConstTensorHandle_t in, diopiSize_t& shape, diopiDtype_t dtype,
+                                                     bool isFillingRequired, double value);
 
 /**
  * @brief Convert the data type of an AscendTensor src to the specified supported data type dtype.

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -21,7 +21,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(np.float16), Skip(np.float64),],
+                    "dtype": [Skip(np.float16),],
                 },
             ]
         ),
@@ -1437,30 +1437,6 @@ device_configs = {
                 {
                     "ins": ['input'],
                     "dtype": [Skip(np.bool_),Skip(np.int16),Skip(np.int32),Skip(np.int64),Skip(np.int8),],
-                },
-            ]
-        ),
-    ),
-
-    'argmax': dict(
-        name=['argmax'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(np.float64),Skip(np.float16),Skip(np.float32),Skip(np.int32),Skip(np.int16),Skip(np.int64),Skip(np.uint8),Skip(np.int8),],
-                },
-            ]
-        ),
-    ),
-
-    'argmax_same_value': dict(
-        name=['argmax'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(np.float32),],
                 },
             ]
         ),

--- a/impl/ascend/functions/argmax.cpp
+++ b/impl/ascend/functions/argmax.cpp
@@ -10,7 +10,16 @@ namespace impl {
 namespace ascend {
 
 diopiError_t diopiArgmax(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const int64_t* dim, bool keepdim) {
-    AclOpRunner<2, 1>("ArgMaxV2", ctx).addInput(input).addConstInput(*dim, diopi_dtype_int64).setAttr("keep_dims", keepdim).addOutput(out).run();
+    AscendTensor inputAt(input);
+    int64_t dimValue;
+    if (nullptr == dim) {
+        inputAt.view({inputAt.numel()});
+        dimValue = 0;
+        keepdim = false;
+    } else {
+        dimValue = *dim;
+    }
+    AclOpRunner<2, 1>("ArgMaxV2", ctx).addInput(inputAt).addConstInput(dimValue, diopi_dtype_int64).setAttr("keep_dims", keepdim).addOutput(out).run();
     return diopiSuccess;
 }
 

--- a/impl/ascend/functions/batch_norm.cpp
+++ b/impl/ascend/functions/batch_norm.cpp
@@ -62,10 +62,10 @@ diopiError_t diopiBatchNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     std::vector<int64_t> batchShapeV{inputAt.shape(1)};
     diopiSize_t batchShapeSizeT{batchShapeV.data(), static_cast<int64_t>(batchShapeV.size())};
-    diopiTensorHandle_t weightTemp = createTensorIfNullptr(ctx, weight, batchShapeSizeT, inputAt.dtype(), true, 1);
-    diopiTensorHandle_t biasTemp = createTensorIfNullptr(ctx, bias, batchShapeSizeT, inputAt.dtype(), true, 0);
-    diopiTensorHandle_t runningMeanTemp = createTensorIfNullptr(ctx, runningMean, batchShapeSizeT, inputAt.dtype(), true, 0);
-    diopiTensorHandle_t runningVarTemp = createTensorIfNullptr(ctx, runningVar, batchShapeSizeT, inputAt.dtype(), true, 1);
+    diopiTensorHandle_t weightTemp = createTensorIfNullptrOrConstCast(ctx, weight, batchShapeSizeT, inputAt.dtype(), true, 1);
+    diopiTensorHandle_t biasTemp = createTensorIfNullptrOrConstCast(ctx, bias, batchShapeSizeT, inputAt.dtype(), true, 0);
+    diopiTensorHandle_t runningMeanTemp = createTensorIfNullptrOrConstCast(ctx, runningMean, batchShapeSizeT, inputAt.dtype(), true, 0);
+    diopiTensorHandle_t runningVarTemp = createTensorIfNullptrOrConstCast(ctx, runningVar, batchShapeSizeT, inputAt.dtype(), true, 1);
 
     if (!training) {
         AclOpRunner<5, 1>("BNInfer", ctx)

--- a/impl/ascend/functions/layer_norm.cpp
+++ b/impl/ascend/functions/layer_norm.cpp
@@ -18,8 +18,8 @@ diopiError_t diopiLayerNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
         return diopiSuccess;
     }
 
-    diopiTensorHandle_t weightTemp = createTensorIfNullptr(ctx, weight, normalizedShape, inputAt.dtype(), true, 1);
-    diopiTensorHandle_t biasTemp = createTensorIfNullptr(ctx, bias, normalizedShape, inputAt.dtype(), true, 0);
+    diopiTensorHandle_t weightTemp = createTensorIfNullptrOrConstCast(ctx, weight, normalizedShape, inputAt.dtype(), true, 1);
+    diopiTensorHandle_t biasTemp = createTensorIfNullptrOrConstCast(ctx, bias, normalizedShape, inputAt.dtype(), true, 0);
 
     // gen begin normalized dim
     diopiSize_t inShape;
@@ -46,9 +46,9 @@ diopiError_t diopiLayerNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_
                                     diopiConstTensorHandle_t gradOutput, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
                                     diopiConstTensorHandle_t bias, diopiConstTensorHandle_t mean, diopiConstTensorHandle_t rstd, diopiSize_t normalizedShape) {
     AscendTensor inputAt(input);
-    diopiTensorHandle_t weightTemp = createTensorIfNullptr(ctx, weight, normalizedShape, inputAt.dtype(), true, 1);
-    diopiTensorHandle_t gradWeightTemp = createTensorIfNullptr(ctx, gradWeight, normalizedShape, inputAt.dtype(), false, 0);
-    diopiTensorHandle_t gradBiasTemp = createTensorIfNullptr(ctx, gradBias, normalizedShape, inputAt.dtype(), false, 0);
+    diopiTensorHandle_t weightTemp = createTensorIfNullptrOrConstCast(ctx, weight, normalizedShape, inputAt.dtype(), true, 1);
+    diopiTensorHandle_t gradWeightTemp = createTensorIfNullptrOrConstCast(ctx, gradWeight, normalizedShape, inputAt.dtype(), false, 0);
+    diopiTensorHandle_t gradBiasTemp = createTensorIfNullptrOrConstCast(ctx, gradBias, normalizedShape, inputAt.dtype(), false, 0);
 
     // Align the shape of mean and rstd with input
     AscendTensor meanAt(mean), rstdAt(rstd);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

argmax on Ascend can cause a segmentation fault when dim is a nullptr.


## Description
<!--- Describe your changes in detail. -->

- Fix the segmentation fault for argmax
- Add a skipped test back for batch_norm
- Rename the util function `createTensorIfNullptr` to `createTensorIfNullptrOrConstCast` for better readability


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

