### PR TITLE
Wx/optimize conv2d op on camb

### DIFF
--- a/impl/camb/functions/conv_2d.cpp
+++ b/impl/camb/functions/conv_2d.cpp
@@ -154,16 +154,18 @@ diopiError_t convBackwardFilter(diopiContextHandle_t ctx, DiopiTensor gradOutput
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, gradOutput.dtype()));
     DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
+    // To fix: There is currently a problem with the cnnlGetConvolutionBackwardFilterAlgorithm interface. Currently, CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT is
+    // used directly to bypass the bug.
     // prepare conv desc
-    cnnlConvolutionBwdFilterPreference_t preference = CNNL_CONVOLUTION_BWD_FILTER_FASTEST;
-    cnnlConvolutionBwdFilterAlgo_t algo;
-    DIOPI_CALLCNNL(
-        cnnlGetConvolutionBackwardFilterAlgorithm(handle, convDesc.get(), inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), preference, &algo));
+    // cnnlConvolutionBwdFilterPreference_t preference = CNNL_CONVOLUTION_BWD_FILTER_FASTEST;
+    // cnnlConvolutionBwdFilterAlgo_t algo;
+    // DIOPI_CALLCNNL(
+    //     cnnlGetConvolutionBackwardFilterAlgorithm(handle, convDesc.get(), inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), preference, &algo));
 
     // prepare workspace
     size_t workspaceSize = 0;
     DIOPI_CALLCNNL(cnnlGetConvolutionBackwardFilterWorkspaceSize(
-        handle, inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), convDesc.get(), algo, &workspaceSize));
+        handle, inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), convDesc.get(), CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT, &workspaceSize));
 
     void *workspace = nullptr;
     if (workspaceSize != 0) {
@@ -177,7 +179,7 @@ diopiError_t convBackwardFilter(diopiContextHandle_t ctx, DiopiTensor gradOutput
                                                  gradOutputDesc.get(),
                                                  gradOutput.data(),
                                                  convDesc.get(),
-                                                 algo,
+                                                 CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT,
                                                  workspace,
                                                  workspaceSize,
                                                  nullptr,

--- a/impl/camb/functions/conv_2d.cpp
+++ b/impl/camb/functions/conv_2d.cpp
@@ -46,15 +46,15 @@ diopiError_t convForward(diopiContextHandle_t ctx, DiopiTensor input, DiopiTenso
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, input.dtype()));
     DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
-    size_t workspaceSize;
-    DIOPI_CALLCNNL(cnnlGetConvolutionForwardWorkspaceSize(handle,
-                                                          inputDesc.get(),
-                                                          weightDesc.get(),
-                                                          outputDesc.get(),
-                                                          bias.defined() ? biasDesc.get() : nullptr,
-                                                          convDesc.get(),
-                                                          CNNL_CONVOLUTION_FWD_ALGO_DIRECT,
-                                                          &workspaceSize));
+    // prepare conv desc
+    cnnlConvolutionFwdPreference_t preference = CNNL_CONVOLUTION_FWD_FASTEST;
+    cnnlConvolutionForwardAlgo_t algo;
+    DIOPI_CALLCNNL(cnnlGetConvolutionForwardAlgorithm(handle, convDesc.get(), inputDesc.get(), weightDesc.get(), outputDesc.get(), preference, &algo));
+
+    // prepare workspace
+    size_t workspaceSize = 0;
+    DIOPI_CALLCNNL(cnnlGetConvolutionForwardWorkspaceSize(
+        handle, inputDesc.get(), weightDesc.get(), outputDesc.get(), bias.defined() ? biasDesc.get() : nullptr, convDesc.get(), algo, &workspaceSize));
 
     void *workspace = nullptr;
     if (0 != workspaceSize) {
@@ -63,7 +63,7 @@ diopiError_t convForward(diopiContextHandle_t ctx, DiopiTensor input, DiopiTenso
 
     DIOPI_CALLCNNL(cnnlConvolutionForward(handle,
                                           convDesc.get(),
-                                          CNNL_CONVOLUTION_FWD_ALGO_DIRECT,
+                                          algo,
                                           nullptr,
                                           inputDesc.get(),
                                           input.data(),
@@ -101,9 +101,16 @@ diopiError_t convBackwardData(diopiContextHandle_t ctx, DiopiTensor gradOutput, 
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, gradInput.dtype()));
     DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
+    // prepare conv desc
+    cnnlConvolutionBwdDataPreference_t preference = CNNL_CONVOLUTION_BWD_DATA_FASTEST;
+    cnnlConvolutionBwdDataAlgo_t algo;
+    DIOPI_CALLCNNL(
+        cnnlGetConvolutionBackwardDataAlgorithm(handle, weightDesc.get(), gradOutputDesc.get(), convDesc.get(), gradInputDesc.get(), preference, &algo));
+
+    // prepare workspace
     size_t workspaceSize = 0;
-    DIOPI_CALLCNNL(cnnlGetConvolutionBackwardDataWorkspaceSize(
-        handle, weightDesc.get(), gradOutputDesc.get(), convDesc.get(), gradInputDesc.get(), CNNL_CONVOLUTION_BWD_DATA_ALGO_DIRECT, &workspaceSize));
+    DIOPI_CALLCNNL(
+        cnnlGetConvolutionBackwardDataWorkspaceSize(handle, weightDesc.get(), gradOutputDesc.get(), convDesc.get(), gradInputDesc.get(), algo, &workspaceSize));
 
     void *workspace = nullptr;
     if (workspaceSize != 0) {
@@ -116,7 +123,7 @@ diopiError_t convBackwardData(diopiContextHandle_t ctx, DiopiTensor gradOutput, 
                                                gradOutputDesc.get(),
                                                gradOutput.data(),
                                                convDesc.get(),
-                                               CNNL_CONVOLUTION_BWD_DATA_ALGO_DIRECT,
+                                               algo,
                                                workspace,
                                                workspaceSize,
                                                nullptr,
@@ -147,9 +154,16 @@ diopiError_t convBackwardFilter(diopiContextHandle_t ctx, DiopiTensor gradOutput
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, gradOutput.dtype()));
     DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
+    // prepare conv desc
+    cnnlConvolutionBwdFilterPreference_t preference = CNNL_CONVOLUTION_BWD_FILTER_FASTEST;
+    cnnlConvolutionBwdFilterAlgo_t algo;
+    DIOPI_CALLCNNL(
+        cnnlGetConvolutionBackwardFilterAlgorithm(handle, convDesc.get(), inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), preference, &algo));
+
+    // prepare workspace
     size_t workspaceSize = 0;
     DIOPI_CALLCNNL(cnnlGetConvolutionBackwardFilterWorkspaceSize(
-        handle, inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), convDesc.get(), CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT, &workspaceSize));
+        handle, inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), convDesc.get(), algo, &workspaceSize));
 
     void *workspace = nullptr;
     if (workspaceSize != 0) {
@@ -163,7 +177,7 @@ diopiError_t convBackwardFilter(diopiContextHandle_t ctx, DiopiTensor gradOutput
                                                  gradOutputDesc.get(),
                                                  gradOutput.data(),
                                                  convDesc.get(),
-                                                 CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT,
+                                                 algo,
                                                  workspace,
                                                  workspaceSize,
                                                  nullptr,

--- a/impl/camb/functions/conv_2d.cpp
+++ b/impl/camb/functions/conv_2d.cpp
@@ -154,14 +154,7 @@ diopiError_t convBackwardFilter(diopiContextHandle_t ctx, DiopiTensor gradOutput
     DIOPI_CALL(CnnlDataType::convertToCnnlType(&computeType, gradOutput.dtype()));
     DIOPI_CALLCNNL(cnnlSetConvolutionDescriptor(convDesc.get(), dimNb, paddingTmp, strideTmp, dilationTmp, groups, computeType));
 
-    // To fix: There is currently a problem with the cnnlGetConvolutionBackwardFilterAlgorithm interface. Currently, CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT is
-    // used directly to bypass the bug.
-    // prepare conv desc
-    // cnnlConvolutionBwdFilterPreference_t preference = CNNL_CONVOLUTION_BWD_FILTER_FASTEST;
-    // cnnlConvolutionBwdFilterAlgo_t algo;
-    // DIOPI_CALLCNNL(
-    //     cnnlGetConvolutionBackwardFilterAlgorithm(handle, convDesc.get(), inputDesc.get(), gradOutputDesc.get(), gradWeightDesc.get(), preference, &algo));
-
+    // To fix: There is currently a problem with the cnnlGetConvolutionBackwardFilterAlgorithm interface.
     // prepare workspace
     size_t workspaceSize = 0;
     DIOPI_CALLCNNL(cnnlGetConvolutionBackwardFilterWorkspaceSize(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Optimize conv2d op on camb by using the most suited algorithm that can be used in the convolution forward operation, backward filter operation and backward data operation.
*  There is currently a problem with the cnnlGetConvolutionBackwardFilterAlgorithm interface. Currently, CNNL_CONVOLUTION_BWD_FILTER_ALGO_DIRECT is used directly to bypass the bug.
<img width="803" alt="image" src="https://github.com/DeepLink-org/DIOPI/assets/131418410/c02f6006-b162-4db1-8ba8-d63ddaa405d8">

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

