### PR TITLE
new diopirt api for storage/deviceindex

### DIFF
--- a/diopi_test/diopi_stub/csrc/litert.cpp
+++ b/diopi_test/diopi_stub/csrc/litert.cpp
@@ -245,6 +245,26 @@ DIOPI_RT_API diopiError_t diopiGetTensorElemSize(diopiConstTensorHandle_t th, in
     return diopiSuccess;
 }
 
+DIOPI_RT_API diopiError_t diopiGetTensorStoragePtr(diopiConstTensorHandle_t th, void** pStoragePtr) {
+    *pStoragePtr = const_cast<void*>th->data();
+    return diopiSuccess;
+}
+
+DIOPI_RT_API diopiError_t diopiGetTensorStorageOffset(diopiConstTensorHandle_t th, int64_t* pOffset) {
+    *pOffset = 0;
+    return diopiSuccess;
+}
+
+DIOPI_RT_API diopiError_t diopiGetTensorStorageNbytes(diopiConstTensorHandle_t th, size_t* pNbytes) {
+    *pNbytes = th->nbytes();
+    return diopiSuccess;
+}
+
+DIOPI_RT_API diopiError_t diopiGetTensorDeviceIndex(diopiConstTensorHandle_t th, diopiDeviceIndex_t* pDevIndex) {
+    *pDevIndex = 0;
+    return diopiSuccess;
+}
+
 diopiError_t diopiGetStream(diopiContextHandle_t ctx, diopiStreamHandle_t* stream) {
     *stream = ctx->getStreamHandle();
     return diopiSuccess;

--- a/diopi_test/diopi_stub/csrc/litert.cpp
+++ b/diopi_test/diopi_stub/csrc/litert.cpp
@@ -246,7 +246,7 @@ DIOPI_RT_API diopiError_t diopiGetTensorElemSize(diopiConstTensorHandle_t th, in
 }
 
 DIOPI_RT_API diopiError_t diopiGetTensorStoragePtr(diopiConstTensorHandle_t th, void** pStoragePtr) {
-    *pStoragePtr = const_cast<void*>th->data();
+    *pStoragePtr = const_cast<void*>(th->data());
     return diopiSuccess;
 }
 

--- a/proto/include/diopi/diopirt.h
+++ b/proto/include/diopi/diopirt.h
@@ -52,6 +52,8 @@ typedef enum {
     diopi_device = 1,
 } diopiDevice_t;
 
+typedef int8_t diopiDeviceIndex_t;
+
 // In order to meet the requirements of common dtype inference in diopi_test, all members in this enumeration should be assigned values in the order of
 // increasing dtype precision
 typedef enum {
@@ -125,6 +127,10 @@ extern DIOPI_RT_API DIOPI_ATTR_WEEK diopiError_t diopiGetTensorDevice(diopiConst
 
 extern DIOPI_RT_API diopiError_t diopiGetTensorNumel(diopiConstTensorHandle_t th, int64_t* numel);
 extern DIOPI_RT_API DIOPI_ATTR_WEEK diopiError_t diopiGetTensorElemSize(diopiConstTensorHandle_t th, int64_t* itemsize);
+extern DIOPI_RT_API DIOPI_ATTR_WEEK diopiError_t diopiGetTensorStoragePtr(diopiConstTensorHandle_t th, void** pStoragePtr);
+extern DIOPI_RT_API DIOPI_ATTR_WEEK diopiError_t diopiGetTensorStorageOffset(diopiConstTensorHandle_t th, int64_t* pOffset);
+extern DIOPI_RT_API DIOPI_ATTR_WEEK diopiError_t diopiGetTensorStorageNbytes(diopiConstTensorHandle_t th, size_t* pNbytes);
+extern DIOPI_RT_API DIOPI_ATTR_WEEK diopiError_t diopiGetTensorDeviceIndex(diopiConstTensorHandle_t th, diopiDeviceIndex_t* pDevIndex);
 
 /**
  * operations to require Stream and Tensor instances from a Context handle


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
为了解决 https://github.com/DeepLink-org/DIPU/issues/334

dipu添加新api支持：https://github.com/DeepLink-org/DIPU/pull/417



## Description
<!--- Describe your changes in detail. -->
添加了几个diopirt的api来获取storag的ptr\nbytes，tensor的offset\device_index


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

