### PR TITLE
Update atol, rtol for Ascend conv2d

### DIFF
--- a/diopi_test/python/conformance/check_result.py
+++ b/diopi_test/python/conformance/check_result.py
@@ -98,7 +98,7 @@ class CheckResult(object):
             else:
                 assert tensor1.size == tensor2.size, "tensor1 element num does not equal tensor2's."
                 diff = np.abs(tensor1 - tensor2) * ~matched
-                max_diff = np.abs(tensor1 - tensor2).max()
+                max_diff = diff.max()
                 max_diff_index = np.unravel_index(np.argmax(diff), diff.shape)
                 max_diff_elem = tensor1[max_diff_index]
                 max_diff_elem_ref = tensor2[max_diff_index]

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -101,26 +101,14 @@ device_configs = {
 
     'conv_2d': dict(
         name=['conv2d'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(np.float32), Skip(np.float64)],
-                },
-            ]
-        ),
+        atol=1e-1,
+        rtol=1e-2,
     ),
 
     'conv_2d_no_contiguous': dict(
         name=['conv2d'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "dtype": [Skip(np.float32), Skip(np.float64)],
-                },
-            ]
-        ),
+        atol=1e-1,
+        rtol=1e-2,
     ),
 
     'hardswish': dict(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Conformance tests of conv2d on Ascend are skipped for float32 and float64 due to low accuracy.


## Description
<!--- Describe your changes in detail. -->

Update atol, rtol for Ascend conv2d

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

