### PR TITLE
Fix the input type requirement of uint64 in Ascend uniform, normal

### DIFF
--- a/impl/ascend/common/utils.cpp
+++ b/impl/ascend/common/utils.cpp
@@ -271,9 +271,6 @@ diopiError_t makeTensorFromScalar(diopiContextHandle_t ctx, const diopiScalar_t*
             case diopiDtype_t::diopi_dtype_int64:
                 *reinterpret_cast<int64_t*>(ptr) = getValue<int64_t>(scalar);
                 break;
-            case diopiDtype_t::diopi_dtype_uint64:
-                *reinterpret_cast<uint64_t*>(ptr) = getValue<uint64_t>(scalar);
-                break;
             case diopiDtype_t::diopi_dtype_uint8:
                 *reinterpret_cast<uint8_t*>(ptr) = getValue<uint8_t>(scalar);
                 break;

--- a/impl/ascend/functions/normal.cpp
+++ b/impl/ascend/functions/normal.cpp
@@ -14,15 +14,15 @@ void stdNormal(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiGenerator
     auto pair = getSeedAndOffset(ctx, generator, 10);
     diopiScalar_t seedScalar = constructDiopiScalarT(diopi_dtype_int64, pair.first);
     diopiTensorHandle_t seedTh;
-    makeTensorFromScalar(ctx, &seedScalar, &seedTh, diopi_dtype_uint64);
+    makeTensorFromScalar(ctx, &seedScalar, &seedTh);
     diopiScalar_t offsetScalar = constructDiopiScalarT(diopi_dtype_int64, pair.second);
     diopiTensorHandle_t offsetTh;
-    makeTensorFromScalar(ctx, &offsetScalar, &offsetTh, diopi_dtype_uint64);
+    makeTensorFromScalar(ctx, &offsetScalar, &offsetTh);
     diopiScalar_t alg = constructDiopiScalarT(diopi_dtype_int64, 1);
     AclOpRunner<4, 1>("StatelessRandomNormalV2", ctx)
         .addConstInput(outputAt.dim() == 0 ? std::vector<int64_t>{1} : outputAt.shape())
-        .addConstInput(seedTh, false)
-        .addConstInput(offsetTh, false)
+        .addConstInput(seedTh, false, ACL_UINT64)
+        .addConstInput(offsetTh, false, ACL_UINT64)
         .addConstInput(alg, diopi_dtype_int32)
         .setAttr("dtype", getAclDataType(out))
         .addOutput(out)

--- a/impl/ascend/functions/uniform.cpp
+++ b/impl/ascend/functions/uniform.cpp
@@ -13,15 +13,15 @@ diopiError_t diopiUniformInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout
     auto pair = getSeedAndOffset(ctx, generator, 10);
     diopiScalar_t seedScalar = constructDiopiScalarT(diopi_dtype_int64, pair.first);
     diopiTensorHandle_t seedTh;
-    makeTensorFromScalar(ctx, &seedScalar, &seedTh, diopi_dtype_uint64);
+    makeTensorFromScalar(ctx, &seedScalar, &seedTh);
     diopiScalar_t offsetScalar = constructDiopiScalarT(diopi_dtype_int64, pair.second);
     diopiTensorHandle_t offsetTh;
-    makeTensorFromScalar(ctx, &offsetScalar, &offsetTh, diopi_dtype_uint64);
+    makeTensorFromScalar(ctx, &offsetScalar, &offsetTh);
     diopiScalar_t alg = constructDiopiScalarT(diopi_dtype_int64, 1);
     AclOpRunner<4, 1>("StatelessRandomUniformV2", ctx)
         .addConstInput(AscendTensor(inout).shape())
-        .addConstInput(seedTh, false)
-        .addConstInput(offsetTh, false)
+        .addConstInput(seedTh, false, ACL_UINT64)
+        .addConstInput(offsetTh, false, ACL_UINT64)
         .addConstInput(alg, diopi_dtype_int32)
         .setAttr("dtype", getAclDataType(inout))
         .addOutput(inout)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Ascend uniform and normal ops cannot pass the tests in dipu/tests/python/unittests/test_generator.py. Because the implementation of these ops depend on some CANN ops that require some input types to be uint64, while uint64 is not a supported dtype of PyTorch.


## Description
<!--- Describe your changes in detail. -->

We add an parameter to support directly passing an aclDataType value (such as ACL_UINT64) to desc. If the new parameter is not provided (default: ACL_DT_UNDEFINED), we will use the traditional way, which is getting the ACL data type from the diopi dtype.

After this fix, uniform and normal can pass the tests in dipu/tests/python/unittests/test_generator.py, and should be able to be used in DIPU.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

