### PR TITLE
Fix the segmentation fault for Ascend all, any with dim being None

### DIFF
--- a/adaptor/csrc/convert.cpp
+++ b/adaptor/csrc/convert.cpp
@@ -105,6 +105,9 @@ bool isContiguous(diopiSize_t size, diopiSize_t strideDiopi, diopiMemoryFormat_t
     if (format == diopiMemoryFormat_t::Contiguous) {
         for (int64_t i = dim - 1; i >= 0; i--) {
             const auto &shapeD = shape[i];
+            if (shapeD == 0) {
+                return true;
+            }
             if (shapeD != 1) {
                 if (strides[i] != stride) {
                     return false;

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -3029,6 +3029,26 @@ diopi_configs = {
         ),
     ),
 
+    'reduce_op_1': dict(
+        name=['any', 'all'],
+        interface=['torch'],
+        atol=1e-4,
+        rtol=1e-5,
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (64, ), (169, 4), (17100, 2), (1, 1, 384),
+                              (4, 133, 128, 128), (2, 64, 3, 3, 3),
+                              (0,), (12, 0), (2, 0, 12)),
+                    "dtype": [np.bool_, np.float16, np.float32, np.float64,
+                              np.int16, np.int32, np.int64, np.uint8, np.int8],
+                    "gen_fn": 'Genfunc.randn',
+                },
+            ],
+        ),
+    ),
+
     'reduce_partial_op': dict(
         name=['mean', 'sum'],
         interface=['torch'],
@@ -3142,7 +3162,7 @@ diopi_configs = {
         name=['any', 'all'],
         interface=['torch'],
         para=dict(
-            dim=[-1, 0, 1, 0, -2, -1, 3, None, 0, -1, 2],
+            dim=[-1, 0, 1, 0, -2, -1, 3, 0, -1, 2],
         ),
         atol=1e-4,
         rtol=1e-5,
@@ -3151,7 +3171,7 @@ diopi_configs = {
                 {
                     "ins": ['input'],
                     "shape": ((), (64, ), (169, 4), (17100, 2), (1, 1, 384),
-                              (4, 133, 128, 128), (2, 64, 3, 3, 3), (2, 64, 3, 3, 3),
+                              (4, 133, 128, 128), (2, 64, 3, 3, 3),
                               (0,), (12, 0), (2, 0, 12)),
                     "dtype": [np.bool_, np.float16, np.float32, np.float64,
                               np.int16, np.int32, np.int64, np.uint8, np.int8],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -3142,7 +3142,7 @@ diopi_configs = {
         name=['any', 'all'],
         interface=['torch'],
         para=dict(
-            dim=[-1, 0, 1, 0, -2, -1, 3, 0, -1, 2],
+            dim=[-1, 0, 1, 0, -2, -1, 3, None, 0, -1, 2],
         ),
         atol=1e-4,
         rtol=1e-5,
@@ -3151,7 +3151,7 @@ diopi_configs = {
                 {
                     "ins": ['input'],
                     "shape": ((), (64, ), (169, 4), (17100, 2), (1, 1, 384),
-                              (4, 133, 128, 128), (2, 64, 3, 3, 3),
+                              (4, 133, 128, 128), (2, 64, 3, 3, 3), (2, 64, 3, 3, 3),
                               (0,), (12, 0), (2, 0, 12)),
                     "dtype": [np.bool_, np.float16, np.float32, np.float64,
                               np.int16, np.int32, np.int64, np.uint8, np.int8],

--- a/impl/ascend/functions/reduce.cpp
+++ b/impl/ascend/functions/reduce.cpp
@@ -113,9 +113,9 @@ diopiError_t diopiMean(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
 
 inline std::vector<int64_t> getDimVectorForTensor(diopiConstTensorHandle_t th) {
     AscendTensor at(th);
-    std::vector<int64_t> dimVector;
-    for (int64_t i = 0; i < at.dim(); ++i) {
-        dimVector.emplace_back(i);
+    std::vector<int64_t> dimVector(at.dim());
+    for (int64_t i = 0; i < dimVector.size(); ++i) {
+        dimVector[i] = i;
     }
     return dimVector;
 }

--- a/impl/ascend/functions/reduce.cpp
+++ b/impl/ascend/functions/reduce.cpp
@@ -111,6 +111,15 @@ diopiError_t diopiMean(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
     return diopiSuccess;
 }
 
+inline std::vector<int64_t> getDimVectorForTensor(diopiConstTensorHandle_t th) {
+    AscendTensor at(th);
+    std::vector<int64_t> dimVector;
+    for (int64_t i = 0; i < at.dim(); ++i) {
+        dimVector.emplace_back(i);
+    }
+    return dimVector;
+}
+
 diopiError_t diopiAll(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const int64_t* dim) {
     int64_t numel = 0;
     diopiGetTensorNumel(input, &numel);
@@ -118,7 +127,8 @@ diopiError_t diopiAll(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
         AclOpRunner<1, 1>("Fills", ctx).addInput(out).setAttr<float>("value", 1).addOutput(out).run();
         return diopiSuccess;
     }
-    AclOpRunner<2, 1>("ReduceAll", ctx).addInput(input).addConstInput({*dim}).setAttr("keep_dims", false).addOutput(out).run();
+    std::vector<int64_t> dimVector = nullptr == dim ? getDimVectorForTensor(input) : std::vector<int64_t>{*dim};
+    AclOpRunner<2, 1>("ReduceAll", ctx).addInput(input).addConstInput(dimVector).setAttr("keep_dims", false).addOutput(out).run();
     return diopiSuccess;
 }
 
@@ -129,7 +139,8 @@ diopiError_t diopiAny(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
         AclOpRunner<1, 1>("Fills", ctx).addInput(out).setAttr<float>("value", 0).addOutput(out).run();
         return diopiSuccess;
     }
-    AclOpRunner<2, 1>("ReduceAny", ctx).addInput(input).addConstInput({*dim}).setAttr("keep_dims", false).addOutput(out).run();
+    std::vector<int64_t> dimVector = nullptr == dim ? getDimVectorForTensor(input) : std::vector<int64_t>{*dim};
+    AclOpRunner<2, 1>("ReduceAny", ctx).addInput(input).addConstInput(dimVector).setAttr("keep_dims", false).addOutput(out).run();
     return diopiSuccess;
 }
 

--- a/impl/camb/device_configs.py
+++ b/impl/camb/device_configs.py
@@ -610,6 +610,18 @@ device_configs = {
         ),
     ),
 
+    'reduce_partial_op_1': dict(
+        name=['std'],
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": (Skip((0,)), Skip((12, 0)), Skip((9, 0, 7))),
+                },
+            ],
+        ),
+    ),
+
     'cross_entropy': dict(
         name=["cross_entropy"],
         para=dict(

--- a/impl/camb/device_configs.py
+++ b/impl/camb/device_configs.py
@@ -610,6 +610,20 @@ device_configs = {
         ),
     ),
 
+    'reduce_partial_op': dict(
+        atol = 0.001,
+        rtol = 0.0001,
+        name=['mean', 'sum'],
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "dtype": [Skip(np.float16)],
+                },
+            ],
+        ),
+    ),
+
     'reduce_partial_op_1': dict(
         name=['std'],
         tensor_para=dict(

--- a/impl/camb/device_configs.py
+++ b/impl/camb/device_configs.py
@@ -610,46 +610,6 @@ device_configs = {
         ),
     ),
 
-    'reduce_op': dict(
-        name=['mean', 'sum'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": (Skip((16, 0, 9)),),
-                    "dtype": [Skip(np.float16)],
-                },
-            ],
-        ),
-    ),
-
-    'reduce_partial_op': dict(
-        atol = 0.001,
-        rtol = 0.0001,
-        name=['mean', 'sum'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": (Skip((16, 0, 9)),),
-                    "dtype": [Skip(np.float16)],
-                },
-            ],
-        ),
-    ),
-
-    'reduce_partial_op_1': dict(
-        name=['std'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": (Skip((0,)), Skip((12, 0)), Skip((9, 0, 7))),
-                },
-            ],
-        ),
-    ),
-
     'cross_entropy': dict(
         name=["cross_entropy"],
         para=dict(
@@ -1551,32 +1511,6 @@ device_configs = {
                     "dtype": [Skip(np.bool_)],
                 },
             ]
-        ),
-    ),
-
-    'reduce_partial_op_2': dict(
-        name=['min', 'max'],
-        interface=['torch'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": (Skip((12, 0)), Skip((2, 0, 12))),
-                },
-            ],
-        ),
-    ),
-
-    'reduce_partial_op_3': dict(
-        name=['any', 'all'],
-        interface=['torch'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": (Skip((0,)), Skip((12, 0)), Skip((2, 0, 12))),
-                },
-            ],
         ),
     ),
 

--- a/impl/camb/diopi_helper.cpp
+++ b/impl/camb/diopi_helper.cpp
@@ -176,6 +176,12 @@ bool DiopiTensor::isContiguous(diopiMemoryFormat_t format) const {
     if (!defined()) {
         return true;
     }
+
+    // Treat a tensors with any dimension of zero as contiguous
+    if (0 == numel()) {
+        return true;
+    }
+
     int64_t stride = 1;
     int64_t dim = this->dim();
     auto strides = this->stride();

--- a/impl/topsrider/device_configs.py
+++ b/impl/topsrider/device_configs.py
@@ -1262,6 +1262,19 @@ device_configs = {
         ),
     ),
 
+    'reduce_op_1': dict(
+        name=['any', 'all'],
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "dtype": [Skip(np.bool_), Skip(np.float16), Skip(np.float32), Skip(np.float64),
+                              Skip(np.int16), Skip(np.int32), Skip(np.int64), Skip(np.uint8), Skip(np.int8),],
+                },
+            ],
+        ),
+    ),
+
     'reduce_partial_op': dict(
         name=['mean', 'sum'],
         tensor_para=dict(


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

all, any on Ascend can cause a segmentation fault when dim is None. This is the root cause of the failure of many unit tests in DIPU, e.g., test_multinomial, test_all, test_any.


## Description
<!--- Describe your changes in detail. -->

- Fix the segmentation fault for all, any.
- Add a new test case for the all, any ops where dim is None 
- Add skip for reduce_op_1 in device_configs.py for topsrider


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

