### PR TITLE
[diopi] fix manul test case generation bug

### DIFF
--- a/diopi_test/python/codegen/case_template.py
+++ b/diopi_test/python/codegen/case_template.py
@@ -12,7 +12,7 @@ import pytest
 #import psutil
 import numpy as np
 from conformance.diopi_runtime import Tensor, from_numpy_dtype, default_context
-from conformance.diopi_functions import ones_like, FunctionNotImplementedError
+from conformance.diopi_functions import ones_like, FunctionNotImplementedError, FunctionNotDefinedError
 from conformance.check_result import CheckResult
 ${test_diopi_head_import}
 
@@ -231,7 +231,7 @@ sum_to_compare = True if 'sorted' in function_kwargs and ~function_kwargs['sorte
 tol['sum_to_compare'] = sum_to_compare
 try:
     dev_out = ${test_diopi_func_name}(**function_kwargs)
-except FunctionNotImplementedError as e:
+except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
 
@@ -253,7 +253,7 @@ ${test_diopi_func_inp_remove_grad_args}
 function_kwargs.update({'inplace': True})
 try:
     dev_inp_out = ${test_diopi_func_name}(**function_kwargs)
-except FunctionNotImplementedError as e:
+except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
 
@@ -273,7 +273,7 @@ function_kwargs = {key: value for key, value in function_kwargs.items() if key n
         r"""
 try:
     ManualTest.test_${test_diopi_func_name}(**function_kwargs)
-except FunctionNotImplementedError as e:
+except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
 """
@@ -284,7 +284,7 @@ ${test_diopi_func_inp_remove_grad_args}
 function_kwargs.update({'inplace': True})
 try:
     ManualTest.test_${test_diopi_func_name}(**function_kwargs)
-except FunctionNotImplementedError as e:
+except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
 """
@@ -310,7 +310,7 @@ function_kwargs.update(backward_para)
 
 try:
     dev_bp_out = ${test_diopi_bp_func_name}(**function_kwargs)
-except FunctionNotImplementedError as e:
+except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
 

--- a/diopi_test/python/codegen/case_template.py
+++ b/diopi_test/python/codegen/case_template.py
@@ -271,14 +271,22 @@ function_kwargs = {key: value for key, value in function_kwargs.items() if key n
 
     test_manual_function_forward_call = CodeTemplate(
         r"""
-ManualTest.test_${test_diopi_func_name}(**function_kwargs)
+try:
+    ManualTest.test_${test_diopi_func_name}(**function_kwargs)
+except FunctionNotImplementedError as e:
+    default_context.clear_tensors()
+    pytest.xfail(str(e))
 """
     )
     test_manual_function_inp_forward_call = CodeTemplate(
         r"""
 ${test_diopi_func_inp_remove_grad_args}
 function_kwargs.update({'inplace': True})
-ManualTest.test_${test_diopi_func_name}(**function_kwargs)
+try:
+    ManualTest.test_${test_diopi_func_name}(**function_kwargs)
+except FunctionNotImplementedError as e:
+    default_context.clear_tensors()
+    pytest.xfail(str(e))
 """
     )
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix diopi test case generation bug

## Description
<!--- Describe your changes in detail. -->
When generating manual test cases, the case should try to detact the error that the function called does not implemented for the device.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

