### PR TITLE
zzf/fix bugs of nll_loss when input dtype is float16

### DIFF
--- a/impl/ascend/convert_config.yaml
+++ b/impl/ascend/convert_config.yaml
@@ -234,3 +234,11 @@
 - diopiLayerNormBackward:
     dtype: (float64)->float32
     layout: NCHW
+
+- diopiNLLLoss:
+    dtype: (float16)->float64
+    layout: NCHW
+
+- diopiNLLLossBackward:
+    dtype: (float16)->float64
+    layout: NCHW

--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -951,8 +951,8 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    # TODO(someone): fix me! 
-                    "dtype": [Skip(np.float16), Skip(np.float32), Skip(np.float64)],
+                    # TODO(someone): dtype float16 is not supported
+                    "dtype": [Skip(np.float16)],
                 },
             ]
         ),
@@ -964,8 +964,8 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    # TODO(someone): fix me! 
-                    "dtype": [Skip(np.float16), Skip(np.float32), Skip(np.float64)],
+                    # TODO(someone): dtype float16 is not supported
+                    "dtype": [Skip(np.float16)],
                 },
             ]
         ),


### PR DESCRIPTION
## Motivation and Context
fix bug of nll_loss when input dtype is float16


## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

