### PR TITLE
fuj/camb-perf-optim add, sub and mul 

### DIFF
--- a/impl/camb/common/basic_op.cpp
+++ b/impl/camb/common/basic_op.cpp
@@ -72,13 +72,9 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor input, DiopiTens
 template diopiError_t cnnlOpTensor<double, double, double>(diopiContextHandle_t ctx, DiopiTensor input, DiopiTensor other, DiopiTensor out,
                                                            cnnlOpTensorDesc_t op_type, double alpha1, double alpha2, double beta);
 
-template <typename T = double>
+template <typename T>
 diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, T other, T alpha) {
     auto handle = cnnlHandlePool.get(ctx);
-
-    // std::vector<DiopiTensor *> inTensors{&input};
-    // std::set<diopiDtype_t> supDtypes{diopi_dtype_float16, diopi_dtype_float32, diopi_dtype_int32};
-    // DIOPI_CALL(autoCastTensorType(ctx, inTensors, supDtypes));
 
     DiopiTensor outTmp = out;
     if (outTmp.dtype() != input.dtype()) {
@@ -105,9 +101,6 @@ diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, Dio
 }
 
 template diopiError_t cnnlTransformAdaptor<double>(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, double alpha, double beta);
-
-// template
-// diopiError_t cnnlTransformAdaptor<void>(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, void* alpha, void* beta);
 
 }  // namespace camb
 }  // namespace impl

--- a/impl/camb/common/basic_op.cpp
+++ b/impl/camb/common/basic_op.cpp
@@ -73,7 +73,7 @@ template diopiError_t cnnlOpTensor<double, double, double>(diopiContextHandle_t 
                                                            cnnlOpTensorDesc_t op_type, double alpha1, double alpha2, double beta);
 
 template <typename T>
-diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, T other, T alpha) {
+diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, T other, T alpha, T beta) {
     auto handle = cnnlHandlePool.get(ctx);
 
     DiopiTensor outTmp = out;
@@ -84,10 +84,10 @@ diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, Dio
     std::shared_ptr<void> alp = nullptr;
     std::shared_ptr<void> bet = nullptr;
     if (DiopiDataType::isInteger(input.dtype())) {
-        alp = std::make_shared<int32_t>(1);
+        alp = std::make_shared<int32_t>(beta);
         bet = std::make_shared<int32_t>(other * alpha);
     } else {
-        alp = std::make_shared<float>(1);
+        alp = std::make_shared<float>(beta);
         bet = std::make_shared<float>(other * alpha);
     }
 
@@ -100,7 +100,7 @@ diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, Dio
     return diopiSuccess;
 }
 
-template diopiError_t cnnlTransformAdaptor<double>(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, double alpha, double beta);
+template diopiError_t cnnlTransformAdaptor<double>(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, double other, double alpha, double beta);
 
 }  // namespace camb
 }  // namespace impl

--- a/impl/camb/common/basic_op.cpp
+++ b/impl/camb/common/basic_op.cpp
@@ -8,29 +8,28 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor input, DiopiTens
                           T3 beta) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
 
-    DiopiTensor inputCasted = input;
-    DiopiTensor otherCasted = other;
-    DiopiTensor outputCasted = out;
-
-    std::vector<DiopiTensor*> tensors{&inputCasted, &otherCasted, &outputCasted};
+    std::vector<DiopiTensor*> tensors{&input, &other};
     DIOPI_CALL(autoCastTensorType(ctx, tensors, {diopi_dtype_float16, diopi_dtype_float32, diopi_dtype_int32}));
 
+    DiopiTensor outputTmp = out;
+    if (outputTmp.dtype() != input.dtype()) {
+        outputTmp = requiresTensor(ctx, out.shape(), input.dtype());
+    }
+
     cnnlDataType_t compType;
-    DIOPI_CALL(CnnlDataType::convertToCnnlType(&compType, inputCasted.dtype()));
-
+    DIOPI_CALL(CnnlDataType::convertToCnnlType(&compType, input.dtype()));
     CnnlResourceGuard<cnnlOpTensorDescriptor_t, cnnlCreateOpTensorDescriptor, cnnlDestroyOpTensorDescriptor> opDesc;
-
     DIOPI_CALL_CNNL(cnnlSetOpTensorDescriptor(opDesc.get(), opType, compType, CNNL_NOT_PROPAGATE_NAN));
 
     std::shared_ptr<void> alpha1Value = nullptr;
     std::shared_ptr<void> alpha2Value = nullptr;
     std::shared_ptr<void> betaValue = nullptr;
 
-    if (DiopiDataType::isInteger(inputCasted.dtype())) {
+    if (DiopiDataType::isInteger(input.dtype())) {
         alpha1Value = std::make_shared<int32_t>(alpha1);
         alpha2Value = std::make_shared<int32_t>(alpha2);
         betaValue = std::make_shared<int32_t>(beta);
-    } else if (DiopiDataType::isFloatPoint(inputCasted.dtype())) {
+    } else if (DiopiDataType::isFloatPoint(input.dtype())) {
         alpha1Value = std::make_shared<float>(alpha1);
         alpha2Value = std::make_shared<float>(alpha2);
         betaValue = std::make_shared<float>(beta);
@@ -38,9 +37,10 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor input, DiopiTens
         setLastErrorString("%s", "cnnl op tensor only support int or float type.\n");
         return diopiDtypeNotSupported;
     }
-    CnnlTensorDesc inputDesc(inputCasted, CNNL_LAYOUT_ARRAY);
-    CnnlTensorDesc otherDesc(otherCasted, CNNL_LAYOUT_ARRAY);
-    CnnlTensorDesc outputDesc(outputCasted, CNNL_LAYOUT_ARRAY);
+
+    CnnlTensorDesc inputDesc(input, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc otherDesc(other, CNNL_LAYOUT_ARRAY);
+    CnnlTensorDesc outputDesc(outputTmp, CNNL_LAYOUT_ARRAY);
 
     size_t workspaceSize = 0;
     DIOPI_CALL_CNNL(cnnlGetOpTensorWorkspaceSize(handle, inputDesc.get(), otherDesc.get(), outputDesc.get(), &workspaceSize));
@@ -54,17 +54,17 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor input, DiopiTens
                                  opDesc.get(),
                                  alpha1Value.get(),
                                  inputDesc.get(),
-                                 inputCasted.data(),
+                                 input.data(),
                                  alpha2Value.get(),
                                  otherDesc.get(),
-                                 otherCasted.data(),
+                                 other.data(),
                                  workspace,
                                  workspaceSize,
                                  betaValue.get(),
                                  outputDesc.get(),
-                                 outputCasted.data()));
+                                 outputTmp.data()));
 
-    DIOPI_CALL(dataTypeCast(ctx, out, outputCasted));
+    DIOPI_CALL(dataTypeCast(ctx, out, outputTmp));
     return diopiSuccess;
 }
 
@@ -76,9 +76,9 @@ template <typename T = double>
 diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, T other, T alpha) {
     auto handle = cnnlHandlePool.get(ctx);
 
-    std::vector<DiopiTensor *> inTensors{&input};
-    std::set<diopiDtype_t> supDtypes{diopi_dtype_float16, diopi_dtype_float32, diopi_dtype_int32};
-    DIOPI_CALL(autoCastTensorType(ctx, inTensors, supDtypes));
+    // std::vector<DiopiTensor *> inTensors{&input};
+    // std::set<diopiDtype_t> supDtypes{diopi_dtype_float16, diopi_dtype_float32, diopi_dtype_int32};
+    // DIOPI_CALL(autoCastTensorType(ctx, inTensors, supDtypes));
 
     DiopiTensor outTmp = out;
     if (outTmp.dtype() != input.dtype()) {
@@ -89,10 +89,10 @@ diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, Dio
     std::shared_ptr<void> bet = nullptr;
     if (DiopiDataType::isInteger(input.dtype())) {
         alp = std::make_shared<int32_t>(1);
-        bet = std::make_shared<int32_t>( other * alpha);
+        bet = std::make_shared<int32_t>(other * alpha);
     } else {
         alp = std::make_shared<float>(1);
-        bet = std::make_shared<float>( other * alpha);
+        bet = std::make_shared<float>(other * alpha);
     }
 
     CnnlTensorDesc inputDesc(input, CNNL_LAYOUT_ARRAY);
@@ -104,10 +104,9 @@ diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, Dio
     return diopiSuccess;
 }
 
-template 
-diopiError_t cnnlTransformAdaptor<double>(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, double alpha, double beta);
+template diopiError_t cnnlTransformAdaptor<double>(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, double alpha, double beta);
 
-// template 
+// template
 // diopiError_t cnnlTransformAdaptor<void>(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, void* alpha, void* beta);
 
 }  // namespace camb

--- a/impl/camb/common/common.hpp
+++ b/impl/camb/common/common.hpp
@@ -43,6 +43,9 @@ template <typename T1 = double, typename T2 = double, typename T3 = double>
 diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor input, DiopiTensor other, DiopiTensor out, cnnlOpTensorDesc_t opType, T1 alpha1 = 1.0,
                           T2 alpha2 = 1.0, T3 beta = 0.0);
 
+template <typename T = double>
+diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, T other, T alpha);
+
 diopiError_t clone(diopiContextHandle_t ctx, const DiopiTensor& inTensor, DiopiTensor& outTensor,
                    diopiMemoryFormat_t memoryFormat = diopiMemoryFormat_t::Preserve);
 

--- a/impl/camb/common/common.hpp
+++ b/impl/camb/common/common.hpp
@@ -44,7 +44,7 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor input, DiopiTens
                           T2 alpha2 = 1.0, T3 beta = 0.0);
 
 template <typename T = double>
-diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, T other, T alpha);
+diopiError_t cnnlTransformAdaptor(diopiContextHandle_t ctx, DiopiTensor out, DiopiTensor input, T other, T alpha, T beta);
 
 diopiError_t clone(diopiContextHandle_t ctx, const DiopiTensor& inTensor, DiopiTensor& outTensor,
                    diopiMemoryFormat_t memoryFormat = diopiMemoryFormat_t::Preserve);

--- a/impl/camb/functions/add.cpp
+++ b/impl/camb/functions/add.cpp
@@ -33,20 +33,38 @@ diopiError_t diopiAddScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
                             const diopiScalar_t* alpha) {
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(out);
-    DiopiTensor otherTensor;
-    DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
-    DIOPI_CALL(cnnlOpTensor(
-        ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_ADD, 1.0, DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    if (inputTensor.dtype() == diopi_dtype_float16 || inputTensor.dtype() == diopi_dtype_float32 ||
+        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype) && DiopiDataType::isInteger(alpha->stype))) {
+        DIOPI_CALL(cnnlTransformAdaptor(ctx,
+                                        outputTensor,
+                                        inputTensor,
+                                        DiopiDataType::isFloatPoint(other->stype) ? other->fval : other->ival,
+                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    } else {
+        DiopiTensor otherTensor;
+        DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
+        DIOPI_CALL(cnnlOpTensor(
+            ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_ADD, 1.0, DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    }
     return diopiSuccess;
 }
 
 diopiError_t diopiAddInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t input, const diopiScalar_t* other, const diopiScalar_t* alpha) {
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(input);
-    DiopiTensor otherTensor;
-    DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
-    DIOPI_CALL(cnnlOpTensor(
-        ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_ADD, 1.0, DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    if (inputTensor.dtype() == diopi_dtype_float16 || inputTensor.dtype() == diopi_dtype_float32 ||
+        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype) && DiopiDataType::isInteger(alpha->stype))) {
+        DIOPI_CALL(cnnlTransformAdaptor(ctx,
+                                        outputTensor,
+                                        inputTensor,
+                                        DiopiDataType::isFloatPoint(other->stype) ? other->fval : other->ival,
+                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    } else {
+        DiopiTensor otherTensor;
+        DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
+        DIOPI_CALL(cnnlOpTensor(
+            ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_ADD, 1.0, DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    }
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/add.cpp
+++ b/impl/camb/functions/add.cpp
@@ -39,7 +39,8 @@ diopiError_t diopiAddScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
                                         outputTensor,
                                         inputTensor,
                                         DiopiDataType::isFloatPoint(other->stype) ? other->fval : other->ival,
-                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival,
+                                        DiopiDataType::isFloatPoint(inputTensor.dtype()) ? 1.0 : 1));
     } else {
         DiopiTensor otherTensor;
         DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
@@ -58,7 +59,8 @@ diopiError_t diopiAddInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t inp
                                         outputTensor,
                                         inputTensor,
                                         DiopiDataType::isFloatPoint(other->stype) ? other->fval : other->ival,
-                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival,
+                                        DiopiDataType::isFloatPoint(inputTensor.dtype()) ? 1.0 : 1));
     } else {
         DiopiTensor otherTensor;
         DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));

--- a/impl/camb/functions/mul.cpp
+++ b/impl/camb/functions/mul.cpp
@@ -29,18 +29,36 @@ diopiError_t diopiMulInp(diopiContextHandle_t ctx, diopiTensorHandle_t input, di
 diopiError_t diopiMulScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const diopiScalar_t* other) {
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(out);
-    DiopiTensor otherTensor;
-    DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
-    DIOPI_CALL(cnnlOpTensor(ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_MUL));
+    if (inputTensor.dtype() == diopi_dtype_float16 || inputTensor.dtype() == diopi_dtype_float32 ||
+        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype) && DiopiDataType::isInteger(alpha->stype))) {
+        DIOPI_CALL(cnnlTransformAdaptor(ctx,
+                                        outputTensor,
+                                        inputTensor,
+                                        0,
+                                        DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival));
+    } else {
+        DiopiTensor otherTensor;
+        DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
+        DIOPI_CALL(cnnlOpTensor(ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_MUL));
+    }
     return diopiSuccess;
 }
 
 diopiError_t diopiMulInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t input, const diopiScalar_t* other) {
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(input);
-    DiopiTensor otherTensor;
-    DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
-    DIOPI_CALL(cnnlOpTensor(ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_MUL));
+    if (inputTensor.dtype() == diopi_dtype_float16 || inputTensor.dtype() == diopi_dtype_float32 ||
+        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype) && DiopiDataType::isInteger(alpha->stype))) {
+        DIOPI_CALL(cnnlTransformAdaptor(ctx,
+                                        outputTensor,
+                                        inputTensor,
+                                        0,
+                                        DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival));
+    } else {
+        DiopiTensor otherTensor;
+        DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
+        DIOPI_CALL(cnnlOpTensor(ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_MUL));
+    }
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/mul.cpp
+++ b/impl/camb/functions/mul.cpp
@@ -30,11 +30,11 @@ diopiError_t diopiMulScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(out);
     if (inputTensor.dtype() == diopi_dtype_float16 || inputTensor.dtype() == diopi_dtype_float32 ||
-        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype) && DiopiDataType::isInteger(alpha->stype))) {
+        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype))) {
         DIOPI_CALL(cnnlTransformAdaptor(ctx,
                                         outputTensor,
                                         inputTensor,
-                                        0,
+                                        DiopiDataType::isFloatPoint(other->stype) ? 0.0 : 0,
                                         DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival));
     } else {
         DiopiTensor otherTensor;
@@ -48,11 +48,11 @@ diopiError_t diopiMulInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t inp
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(input);
     if (inputTensor.dtype() == diopi_dtype_float16 || inputTensor.dtype() == diopi_dtype_float32 ||
-        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype) && DiopiDataType::isInteger(alpha->stype))) {
+        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype))) {
         DIOPI_CALL(cnnlTransformAdaptor(ctx,
                                         outputTensor,
                                         inputTensor,
-                                        0,
+                                        DiopiDataType::isFloatPoint(other->stype) ? 0.0 : 0,
                                         DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival));
     } else {
         DiopiTensor otherTensor;

--- a/impl/camb/functions/mul.cpp
+++ b/impl/camb/functions/mul.cpp
@@ -35,7 +35,8 @@ diopiError_t diopiMulScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
                                         outputTensor,
                                         inputTensor,
                                         DiopiDataType::isFloatPoint(other->stype) ? 0.0 : 0,
-                                        DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival));
+                                        DiopiDataType::isFloatPoint(other->stype) ? 1.0 : 1,
+                                        DiopiDataType::isFloatPoint(other->stype) ? other->fval : other->ival));
     } else {
         DiopiTensor otherTensor;
         DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
@@ -53,7 +54,8 @@ diopiError_t diopiMulInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t inp
                                         outputTensor,
                                         inputTensor,
                                         DiopiDataType::isFloatPoint(other->stype) ? 0.0 : 0,
-                                        DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival));
+                                        DiopiDataType::isFloatPoint(other->stype) ? 1.0 : 1,
+                                        DiopiDataType::isFloatPoint(other->stype) ? other->fval : other->ival));
     } else {
         DiopiTensor otherTensor;
         DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));

--- a/impl/camb/functions/sub.cpp
+++ b/impl/camb/functions/sub.cpp
@@ -35,20 +35,38 @@ diopiError_t diopiSubScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
                             const diopiScalar_t* alpha) {
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(out);
-    DiopiTensor otherTensor;
-    DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
-    DIOPI_CALL(cnnlOpTensor(
-        ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_SUB, 1.0, DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    if (inputTensor.dtype() == diopi_dtype_float16 || inputTensor.dtype() == diopi_dtype_float32 ||
+        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype) && DiopiDataType::isInteger(alpha->stype))) {
+        DIOPI_CALL(cnnlTransformAdaptor(ctx,
+                                        outputTensor,
+                                        inputTensor,
+                                        DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival,
+                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    } else {
+        DiopiTensor otherTensor;
+        DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
+        DIOPI_CALL(cnnlOpTensor(
+            ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_SUB, 1.0, DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    }
     return diopiSuccess;
 }
 
 diopiError_t diopiSubInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t input, const diopiScalar_t* other, const diopiScalar_t* alpha) {
     DiopiTensor inputTensor(input);
     DiopiTensor outputTensor(input);
-    DiopiTensor otherTensor;
-    DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
-    DIOPI_CALL(cnnlOpTensor(
-        ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_SUB, 1.0, DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    if (inputTensor.dtype() == diopi_dtype_float16 || inputTensor.dtype() == diopi_dtype_float32 ||
+        (inputTensor.dtype() == diopi_dtype_int32 && DiopiDataType::isInteger(other->stype) && DiopiDataType::isInteger(alpha->stype))) {
+        DIOPI_CALL(cnnlTransformAdaptor(ctx,
+                                        outputTensor,
+                                        inputTensor,
+                                        DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival,
+                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    } else {
+        DiopiTensor otherTensor;
+        DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
+        DIOPI_CALL(cnnlOpTensor(
+            ctx, inputTensor, otherTensor, outputTensor, CNNL_OP_TENSOR_SUB, 1.0, DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+    }
     return diopiSuccess;
 }
 

--- a/impl/camb/functions/sub.cpp
+++ b/impl/camb/functions/sub.cpp
@@ -41,7 +41,8 @@ diopiError_t diopiSubScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
                                         outputTensor,
                                         inputTensor,
                                         DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival,
-                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival,
+                                        DiopiDataType::isFloatPoint(inputTensor.dtype()) ? 1.0 : 1));
     } else {
         DiopiTensor otherTensor;
         DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));
@@ -60,7 +61,8 @@ diopiError_t diopiSubInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t inp
                                         outputTensor,
                                         inputTensor,
                                         DiopiDataType::isFloatPoint(other->stype) ? -other->fval : -other->ival,
-                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival));
+                                        DiopiDataType::isFloatPoint(alpha->stype) ? alpha->fval : alpha->ival,
+                                        DiopiDataType::isFloatPoint(inputTensor.dtype()) ? 1.0 : 1));
     } else {
         DiopiTensor otherTensor;
         DIOPI_CALL(makeTensorFromScalar(ctx, other, otherTensor));


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Optimize add, sub, mul functions on camb.

## Description
<!--- Describe your changes in detail. -->
The add, sub and mul were implemented with cnnlOpTensor on camb previously, this pr re implemented these funtions 
with cnnlTransform for the case when an operand is scalar type.

- diopiAddScalar
- diopiAddInpScalar
- diopiSubScalar
- diopiSubInpScalar
- diopiMulScalar
- diopiMulInpScalar

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

