### PR TITLE
Add float16 support for dropout on Ascend

### DIFF
--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4447,7 +4447,7 @@ diopi_configs = {
                 {
                     "ins": ['input'],
                     "shape": ((2, 4096), (32, 49, 256), (2, 16, 64, 64), (1, 2304, 1, 1, 1)),
-                    "dtype": [np.float32, np.float64],
+                    "dtype": [np.float16, np.float32, np.float64],
                     "gen_fn": 'Genfunc.positive',
                 },
             ],
@@ -4467,7 +4467,7 @@ diopi_configs = {
                     "ins": ['input'],
                     "shape": ((2, 4096), (32, 49, 256), (2, 16, 64, 64),
                               (1, 2304, 1, 1, 1)),
-                    "dtype": [np.float32, np.float64],
+                    "dtype": [np.float16, np.float32, np.float64],
                     "gen_fn": 'Genfunc.positive',
                 },
             ],
@@ -4512,7 +4512,7 @@ diopi_configs = {
                 {
                     "ins": ['input'],
                     "shape": ((32, 49, 256), (32, 49, 64, 64)),
-                    "dtype": [np.float32, np.float64],
+                    "dtype": [np.float16, np.float32, np.float64],
                     "gen_fn": 'Genfunc.positive',
                 },
             ],

--- a/impl/ascend/functions/dropout.cpp
+++ b/impl/ascend/functions/dropout.cpp
@@ -39,16 +39,21 @@ void dropoutTrainCore(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTe
     float prob = 1. - p;
     AclOpRunner<5, 1, dtypeConvertor>("StatelessDropOutGenMask", ctx)
         .addConstInput(inputSize)
-        .addConstInput(prob, inputAt.dtype())
+        .addConstInput(prob, diopi_dtype_float32)
         .addConstInput(pair.first, diopi_dtype_int32)
         .addConstInput(0, diopi_dtype_int32)
         .addConstInput(offset)
         .addOutput(maskTempTensor)
         .run();
-    AclOpRunner<3, 1, dtypeConvertor>("DropOutDoMask", ctx).addInput(input).addInput(maskTempTensor).addConstInput(1., inputAt.dtype()).addOutput(out).run();
+
+    diopiScalar_t oneScalar = constructDiopiScalarT(diopi_dtype_float64, 1);
+    diopiTensorHandle_t oneTh;
+    makeTensorFromScalar(ctx, &oneScalar, &oneTh, inputAt.dtype(), diopi_device);
+    AclOpRunner<3, 1, dtypeConvertor>("DropOutDoMask", ctx).addInput(input).addInput(maskTempTensor).addInput(oneTh).addOutput(out).run();
+
     diopiEq(ctx, mask, input, out);
-    diopiScalar_t probScalar = constructDiopiScalarT(diopi_dtype_float64, 1. / prob);
-    diopiMulInpScalar(ctx, out, &probScalar);
+    diopiScalar_t probReciprocalScalar = constructDiopiScalarT(diopi_dtype_float64, 1. / prob);
+    diopiMulInpScalar(ctx, out, &probReciprocalScalar);
 }
 
 diopiError_t diopiDropout(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t mask, diopiConstTensorHandle_t input, double p, bool train,

--- a/impl/topsrider/device_configs.py
+++ b/impl/topsrider/device_configs.py
@@ -1845,7 +1845,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(np.float32),Skip(np.float64),],
+                    "dtype": [Skip(np.float16),Skip(np.float32),Skip(np.float64),],
                 },
             ]
         ),
@@ -1857,7 +1857,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(np.float32),Skip(np.float64),],
+                    "dtype": [Skip(np.float16),Skip(np.float32),Skip(np.float64),],
                 },
             ]
         ),
@@ -1869,7 +1869,7 @@ device_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "dtype": [Skip(np.float32),Skip(np.float64),],
+                    "dtype": [Skip(np.float16),Skip(np.float32),Skip(np.float64),],
                 },
             ]
         ),


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

float16 is currently not supported for the dropout op on Ascend. 


## Description
<!--- Describe your changes in detail. -->

- Add float16 support for dropout on Ascend
- Add float16 test cases for dropout in diopi_configs.py

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

