### PR TITLE
tyf/change pooling and relu

### DIFF
--- a/impl/camb/convert_config.yaml
+++ b/impl/camb/convert_config.yaml
@@ -11,16 +11,16 @@
     layout: NCHW
 
 - diopiUpsampleNearest:
-    layout: NHWC
+    layout: NHWC, NDHWC
 
 - diopiUpsampleNearestBackward:
-    layout: NHWC
+    layout: NHWC, NDHWC
 
 - diopiUpsampleLinear:
-    layout: NLC, NHWC
+    layout: NLC, NHWC, NDHWC
 
 - diopiUpsampleLinearBackward:
-    layout: NLC, NHWC
+    layout: NLC, NHWC, NDHWC
 
 - diopiConvolution2d:
     layout: NHWC

--- a/impl/camb/convert_config.yaml
+++ b/impl/camb/convert_config.yaml
@@ -11,16 +11,16 @@
     layout: NCHW
 
 - diopiUpsampleNearest:
-    layout: NHWC, NDHWC
+    layout: NHWC
 
 - diopiUpsampleNearestBackward:
-    layout: NHWC, NDHWC
+    layout: NHWC
 
 - diopiUpsampleLinear:
-    layout: NLC, NHWC, NDHWC
+    layout: NLC, NHWC
 
 - diopiUpsampleLinearBackward:
-    layout: NLC, NHWC, NDHWC
+    layout: NLC, NHWC
 
 - diopiConvolution2d:
     layout: NHWC
@@ -55,13 +55,13 @@
 # Ops below are not neccesary to convert format
 # next version will be changed,it is better to do nothing in adaptor
 - diopiMaxPool2dWithIndices:
-    layout: NHWC, NDHWC
+    layout: NHWC
 
 - diopiMaxPool2d:
-    layout: NHWC, NDHWC
+    layout: NHWC
 
 - diopiMaxPool2dBackward:
-    layout: NHWC, NDHWC
+    layout: NHWC
 
 - diopiReluInp:
     layout: NLC, NHWC, NDHWC

--- a/impl/camb/convert_config.yaml
+++ b/impl/camb/convert_config.yaml
@@ -52,7 +52,7 @@
 - diopiBatchNormStats:
     layout: NLC, NHWC, NDHWC
 
-# Ops below are not neccesary to convert format
+#* Ops below are not neccesary to convert format *#
 # next version will be changed,it is better to do nothing in adaptor
 - diopiMaxPool2dWithIndices:
     layout: NHWC
@@ -68,3 +68,4 @@
 
 - diopiThresholdBackward:
     layout: NLC, NHWC, NDHWC
+#* Ops above are not neccesary to convert format *#

--- a/impl/camb/convert_config.yaml
+++ b/impl/camb/convert_config.yaml
@@ -52,6 +52,8 @@
 - diopiBatchNormStats:
     layout: NLC, NHWC, NDHWC
 
+# Ops below are not neccesary to convert format
+# next version will be changed,it is better to do nothing in adaptor
 - diopiMaxPool2dWithIndices:
     layout: NLC, NHWC, NDHWC
 

--- a/impl/camb/convert_config.yaml
+++ b/impl/camb/convert_config.yaml
@@ -51,3 +51,18 @@
 
 - diopiBatchNormStats:
     layout: NLC, NHWC, NDHWC
+
+- diopiMaxPool2dWithIndices:
+    layout: NLC, NHWC, NDHWC
+
+- diopiMaxPool2d:
+    layout: NLC, NHWC, NDHWC
+
+- diopiMaxPool2dBackward:
+    layout: NLC, NHWC, NDHWC
+
+- diopiReluInp:
+    layout: NLC, NHWC, NDHWC
+
+- diopiThresholdBackward:
+    layout: NLC, NHWC, NDHWC

--- a/impl/camb/convert_config.yaml
+++ b/impl/camb/convert_config.yaml
@@ -55,13 +55,13 @@
 # Ops below are not neccesary to convert format
 # next version will be changed,it is better to do nothing in adaptor
 - diopiMaxPool2dWithIndices:
-    layout: NLC, NHWC, NDHWC
+    layout: NHWC, NDHWC
 
 - diopiMaxPool2d:
-    layout: NLC, NHWC, NDHWC
+    layout: NHWC, NDHWC
 
 - diopiMaxPool2dBackward:
-    layout: NLC, NHWC, NDHWC
+    layout: NHWC, NDHWC
 
 - diopiReluInp:
     layout: NLC, NHWC, NDHWC

--- a/impl/camb/functions/max_pool2d.cpp
+++ b/impl/camb/functions/max_pool2d.cpp
@@ -9,7 +9,6 @@
 
 #include "../cnnl_helper.hpp"
 #include "../common/common.hpp"
-#include "../common/debug.hpp"
 
 namespace impl {
 namespace camb {
@@ -25,6 +24,7 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     std::vector<DiopiTensor*> pTensors{&inputTr};
     DIOPI_CALL(autoCastTensorType(ctx, pTensors, {diopi_dtype_float16, diopi_dtype_float32}));
 
+    int inDim = inputTr.dim();
     if (inputTr.dim() == 3) {
         inputTr.unsqueeze(0);
         outTr.unsqueeze(0);
@@ -38,7 +38,7 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     std::vector<int64_t> outDim = outTmpTr.shape();
 
     cnnlTensorLayout_t layout = CNNL_LAYOUT_NHWC;
-    if (inputTr.dim() == 3) {
+    if (inDim == 3) {
         layout = CNNL_LAYOUT_NCHW;
     }
     CnnlTensorDesc inputDesc(inputTr, layout);
@@ -105,6 +105,7 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
     std::vector<DiopiTensor*> pTensors{&inputTr};
     DIOPI_CALL(autoCastTensorType(ctx, pTensors, {diopi_dtype_float16, diopi_dtype_float32}));
 
+    int inDim = inputTr.dim();
     if (inputTr.dim() == 3) {
         inputTr.unsqueeze(0);
         indicesTr.unsqueeze(0);
@@ -125,7 +126,7 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
     std::vector<int64_t> outDim = outTmpTr.shape();
 
     cnnlTensorLayout_t layout = CNNL_LAYOUT_NHWC;
-    if (inputTr.dim() == 3) {
+    if (inDim == 3) {
         layout = CNNL_LAYOUT_NCHW;
     }
     CnnlTensorDesc inputDesc(inputTr, layout);

--- a/impl/camb/functions/max_pool2d.cpp
+++ b/impl/camb/functions/max_pool2d.cpp
@@ -19,13 +19,15 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     DiopiTensor inputTr(input);
     DiopiTensor outTr(out);
-
-    DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
+    DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "only support 3D or 4D tensor for input");
+    if (inputTr.dim() == 3) {
+        DIOPI_CHECK(inputTr.isContiguous(diopiMemoryFormat_t::Contiguous), "only support contiguous for 3D input");
+    } else {
+        DIOPI_CHECK(inputTr.isContiguous(diopiMemoryFormat_t::ChannelsLast), "only support ChannelsLast for 4D input");
+    }
 
     std::vector<DiopiTensor*> pTensors{&inputTr};
-    if (inputTr.dtype() != diopi_dtype_float16 && inputTr.dtype() != diopi_dtype_float32) {
-        DIOPI_CALL(autoCastTensorType(ctx, pTensors, {diopi_dtype_float16, diopi_dtype_float32}));
-    }
+    DIOPI_CALL(autoCastTensorType(ctx, pTensors, {diopi_dtype_float16, diopi_dtype_float32}));
 
     int inDim = inputTr.dim();
     if (inputTr.dim() == 3) {
@@ -112,9 +114,12 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
     }
     int inDim = inputTr.dim();
     if (inputTr.dim() == 3) {
+        DIOPI_CHECK(inputTr.isContiguous(diopiMemoryFormat_t::Contiguous), "only support contiguous for 3D input");
         inputTr.unsqueeze(0);
         indicesTr.unsqueeze(0);
         outTr.unsqueeze(0);
+    } else {  // dim() == 4
+        DIOPI_CHECK(inputTr.isContiguous(diopiMemoryFormat_t::ChannelsLast), "only support contiguous for 3D input");
     }
 
     DiopiTensor outTmpTr = outTr;
@@ -231,14 +236,28 @@ diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
     DiopiTensor gradInputTr(gradInput);
     DiopiTensor gradOutputTr(gradOutput);
     DiopiTensor indicesTr(indices);
-
-    DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
-
-    if (inputTr.dim() == 3) {
+    DIOPI_CHECK(inputTr.dim() == indicesTr.dim() && inputTr.dim() == gradOutputTr.dim() && inputTr.dim() == gradInputTr.dim(),
+                "the shapes of input(%ld), indices(%ld), gradOutput(%ld) and gradInput(%ld) should be same",
+                inputTr.dim(),
+                indicesTr.dim(),
+                gradOutputTr.dim(),
+                gradInputTr.dim());
+    DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "3D or 4D (batch mode) tensor expected for input");
+    bool is3dim = inputTr.dim() == 3;
+    if (is3dim) {
+        DIOPI_CHECK(inputTr.isContiguous(diopiMemoryFormat_t::Contiguous), "only support contiguous for 3D input");
+        DIOPI_CHECK(indicesTr.isContiguous(diopiMemoryFormat_t::Contiguous), "only support contiguous for 3D indices");
+        DIOPI_CHECK(gradInputTr.isContiguous(diopiMemoryFormat_t::Contiguous), "only support contiguous for 3D gradInputTr");
+        DIOPI_CHECK(gradOutputTr.isContiguous(diopiMemoryFormat_t::Contiguous), "only support contiguous for 3D gradOutput");
         inputTr.unsqueeze(0);
         indicesTr.unsqueeze(0);
         gradInputTr.unsqueeze(0);
         gradOutputTr.unsqueeze(0);
+    } else {  // dim() == 4
+        DIOPI_CHECK(inputTr.isContiguous(diopiMemoryFormat_t::ChannelsLast), "only support ChannelsLast for 4D input");
+        DIOPI_CHECK(indicesTr.isContiguous(diopiMemoryFormat_t::ChannelsLast), "only support ChannelsLast for 4D indices");
+        DIOPI_CHECK(gradInputTr.isContiguous(diopiMemoryFormat_t::ChannelsLast), "only support ChannelsLast for 4D gradInputTr");
+        DIOPI_CHECK(gradOutputTr.isContiguous(diopiMemoryFormat_t::ChannelsLast), "only support ChannelsLast for 4D gradOutput");
     }
 
     std::vector<DiopiTensor*> pTensors{&inputTr, &gradOutputTr};
@@ -252,12 +271,16 @@ diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
         DIOPI_CALL(dataTypeCast(ctx, indicesTr, diopi_dtype_int32));
     }
     diopiMemoryFormat_t memoryFormat = diopiMemoryFormat_t::ChannelsLast;
-    if (inputTr.isContiguous(diopiMemoryFormat_t::Contiguous)) {
+    // for 3 dim input, it is contiguous, and needs to convert to channelslast for camb kernel.
+    if (is3dim) {
         DIOPI_CALL(contiguous(ctx, inputTr, memoryFormat));
         DIOPI_CALL(contiguous(ctx, gradOutputTr, memoryFormat));
         DIOPI_CALL(contiguous(ctx, indicesTr, memoryFormat));
     }
-    DiopiTensor gradInputTmpTr = requiresTensor(ctx, gradInputTr.shape(), inputTr.dtype(), memoryFormat);
+    DiopiTensor gradInputTmpTr = gradInputTr;
+    if (is3dim) {
+        gradInputTmpTr = requiresTensor(ctx, gradInputTr.shape(), inputTr.dtype(), memoryFormat);
+    }
 
     std::vector<int64_t> inputDim = inputTr.shape();
     std::vector<int64_t> gradOutputDim = gradOutputTr.shape();

--- a/impl/camb/functions/max_pool2d.cpp
+++ b/impl/camb/functions/max_pool2d.cpp
@@ -9,6 +9,7 @@
 
 #include "../cnnl_helper.hpp"
 #include "../common/common.hpp"
+#include "../common/debug.hpp"
 
 namespace impl {
 namespace camb {
@@ -19,6 +20,8 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     DiopiTensor inputTr(input);
     DiopiTensor outTr(out);
+    printDevData(ctx, inputTr);
+    printDevData(ctx, outTr);
 
     DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
 
@@ -34,7 +37,6 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     if (inputTr.dtype() != outTr.dtype()) {
         outTmpTr = requiresTensor(ctx, outTr.shape(), inputTr.dtype());
     }
-
     std::vector<int64_t> inputDim = inputTr.shape();
     std::vector<int64_t> outDim = outTmpTr.shape();
     CnnlTensorDesc inputDesc(inputTr, CNNL_LAYOUT_NHWC);
@@ -51,6 +53,7 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
         strideH = stride.data[0];
         strideW = stride.len == 1 ? strideH : stride.data[1];
     }
+
     const int64_t padH = padding.data[0];
     const int64_t padW = padding.len == 1 ? padH : padding.data[1];
     const int64_t dilation0 = dilation.data[0];
@@ -76,7 +79,7 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
         poolDesc, CNNL_POOLING_MAX, CNNL_PROPAGATE_NAN, kernelH, kernelW, padUp, padDown, padLeft, padRight, strideH, strideW, dilation0, dilation1, ceilMode));
 
     size_t workspaceSize = 0;
-    DIOPI_CALL_CNNL(cnnlGetPoolingWorkspaceSize(handle, CNNL_POOLING_MAX, outTr.shape()[3], inputTr.shape()[2], &workspaceSize));
+    DIOPI_CALL_CNNL(cnnlGetPoolingWorkspaceSize(handle, CNNL_POOLING_MAX, inputTr.shape()[3], inputTr.shape()[2], &workspaceSize));
     void* workspacePtr = workspaceSize == 0 ? nullptr : requiresBuffer(ctx, workspaceSize).data();
 
     DIOPI_CALL_CNNL(cnnlPoolingForward_v2(
@@ -86,6 +89,8 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
         DIOPI_CALL(dataTypeCast(ctx, outTr, outTmpTr));
     }
 
+    printDevData(ctx, inputTr);
+    printDevData(ctx, outTr);
     return diopiSuccess;
 }
 
@@ -96,6 +101,7 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
     DiopiTensor inputTr(input);
     DiopiTensor outTr(out);
     DiopiTensor indicesTr(indices);
+    std::cout << "why i am here index" << std::endl;
 
     DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
 
@@ -298,6 +304,7 @@ diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
                                         nullptr,
                                         gradInputDesc.get(),
                                         gradInputTmpTr.data()));
+    // gradInputTr.data()));
 
     // Channels last -> contiguous
     DIOPI_CALL(contiguous(ctx, gradInputTmpTr, diopiMemoryFormat_t::Contiguous));

--- a/impl/camb/functions/max_pool2d.cpp
+++ b/impl/camb/functions/max_pool2d.cpp
@@ -100,8 +100,6 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
     DiopiTensor inputTr(input);
     DiopiTensor outTr(out);
     DiopiTensor indicesTr(indices);
-    std::cout << "why i am here index" << std::endl;
-
     DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
 
     std::vector<DiopiTensor*> pTensors{&inputTr};

--- a/impl/camb/functions/max_pool2d.cpp
+++ b/impl/camb/functions/max_pool2d.cpp
@@ -23,7 +23,7 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
 
     std::vector<DiopiTensor*> pTensors{&inputTr};
-    if (inputTr.dtype() != diopi_dtype_float16 || inputTr.dtype() != diopi_dtype_float32) {
+    if (inputTr.dtype() != diopi_dtype_float16 && inputTr.dtype() != diopi_dtype_float32) {
         DIOPI_CALL(autoCastTensorType(ctx, pTensors, {diopi_dtype_float16, diopi_dtype_float32}));
     }
 
@@ -107,7 +107,7 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
     DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
 
     std::vector<DiopiTensor*> pTensors{&inputTr};
-    if (inputTr.dtype() != diopi_dtype_float16 || inputTr.dtype() != diopi_dtype_float32) {
+    if (inputTr.dtype() != diopi_dtype_float16 && inputTr.dtype() != diopi_dtype_float32) {
         DIOPI_CALL(autoCastTensorType(ctx, pTensors, {diopi_dtype_float16, diopi_dtype_float32}));
     }
     int inDim = inputTr.dim();
@@ -242,7 +242,7 @@ diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
     }
 
     std::vector<DiopiTensor*> pTensors{&inputTr, &gradOutputTr};
-    if (inputTr.dtype() != gradOutputTr.dtype() || inputTr.dtype() != diopi_dtype_float16 || inputTr.dtype() != diopi_dtype_float32) {
+    if (inputTr.dtype() != gradOutputTr.dtype() || (inputTr.dtype() != diopi_dtype_float16 && inputTr.dtype() != diopi_dtype_float32)) {
         DIOPI_CALL(autoCastTensorType(ctx, pTensors, {diopi_dtype_float16, diopi_dtype_float32}));
     }
 
@@ -316,8 +316,6 @@ diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
                                         gradInputDesc.get(),
                                         gradInputTmpTr.data()));
 
-    // Channels last -> contiguous
-    DIOPI_CALL(contiguous(ctx, gradInputTmpTr, diopiMemoryFormat_t::Contiguous));
     DIOPI_CALL(diopiCopyInp(ctx, gradInputTmpTr.tensorHandle(), gradInputTr.tensorHandle()));
 
     return diopiSuccess;

--- a/impl/camb/functions/max_pool2d.cpp
+++ b/impl/camb/functions/max_pool2d.cpp
@@ -37,8 +37,8 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     std::vector<int64_t> inputDim = inputTr.shape();
     std::vector<int64_t> outDim = outTmpTr.shape();
-    CnnlTensorDesc inputDesc(inputTr, CNNL_LAYOUT_NCHW);
-    CnnlTensorDesc outDesc(outTmpTr, CNNL_LAYOUT_NCHW);
+    CnnlTensorDesc inputDesc(inputTr, CNNL_LAYOUT_NHWC);
+    CnnlTensorDesc outDesc(outTmpTr, CNNL_LAYOUT_NHWC);
 
     const int64_t kernelH = kernelSize.data[0];
     const int64_t kernelW = kernelSize.len == 1 ? kernelH : kernelSize.data[1];
@@ -120,9 +120,9 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
 
     std::vector<int64_t> inputDim = inputTr.shape();
     std::vector<int64_t> outDim = outTmpTr.shape();
-    CnnlTensorDesc inputDesc(inputTr, CNNL_LAYOUT_NCHW);
-    CnnlTensorDesc indicesDesc(indicesTmpTr, CNNL_LAYOUT_NCHW);
-    CnnlTensorDesc outDesc(outTmpTr, CNNL_LAYOUT_NCHW);
+    CnnlTensorDesc inputDesc(inputTr, CNNL_LAYOUT_NHWC);
+    CnnlTensorDesc indicesDesc(indicesTmpTr, CNNL_LAYOUT_NHWC);
+    CnnlTensorDesc outDesc(outTmpTr, CNNL_LAYOUT_NHWC);
 
     const int64_t kernelH = kernelSize.data[0];
     const int64_t kernelW = kernelSize.len == 1 ? kernelH : kernelSize.data[1];


### PR DESCRIPTION
## Motivation and Context
* To improve the performance of the model, change the memory format of maxpool2d、 relu、and threshold backward into NHWC, and this will be reconstructed when the diopi adaptor is reconstructed. 
* reconstructed the maxpool2d to make the code more readable.

## Description

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

