### PR TITLE
fix: negative dimensions are not allowed

### DIFF
--- a/diopi_test/python/conformance/diopi_runtime.py
+++ b/diopi_test/python/conformance/diopi_runtime.py
@@ -310,7 +310,8 @@ class Tensor(diopiTensor):
         return tr
 
     def numpy(self) -> np.ndarray:
-        if all(x == 0 for x in self.size().data):
+        if all(x == 0 for x in self.size().data) and self.numel == 0:
+            # cases when shape all 0, but not include the scalar tensor
             return np.empty(self.size().data, to_numpy_dtype(self.get_dtype()))
         data = np.empty((1,), to_numpy_dtype(self.get_dtype()))
         element_size = data.itemsize


### PR DESCRIPTION
## Motivation and Context
fix error like: https://github.com/DeepLink-org/DIOPI/actions/runs/7283426328/job/19847556876?pr=763&from_wecom=1
Handling the tensors with shape `[0, 0]`. Cases when `sumsize` will be calculated as `-1`, then numpy complains the negative input.
This pr fixes that error by returning earlier

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

