### PR TITLE
zsk/update compare_input in cases

### DIFF
--- a/diopi_test/python/codegen/case_template.py
+++ b/diopi_test/python/codegen/case_template.py
@@ -248,6 +248,7 @@ try:
     CheckResult.compare_input_dict(function_kwargs, np_inputs_orign, ignore_paras_for_input_check, **tol)
     CheckResult.compare_output(dev_foward_out, ref_foward_out, **tol)
 except Exception as e:
+    default_context.clear_tensors()
     assert False, f'Test {function_config["name"]}: {function_config} traceback: {e}'
 """
     )
@@ -267,6 +268,7 @@ try:
     CheckResult.compare_input_dict(function_kwargs, np_inputs_orign, ignore_paras_for_input_check, **tol)
     CheckResult.compare_output(dev_inp_forward_out, ref_foward_out, **tol)
 except Exception as e:
+    default_context.clear_tensors()
     assert False, f'Test {function_config["name"]}  inplace: {function_config} traceback: {e}'
 """
     )
@@ -332,6 +334,7 @@ try:
     CheckResult.compare_input_list(backward_para_compare, backward_para_origin, **tol)
     CheckResult.compare_output(dev_bp_out, ref_bp_out, **tol)
 except Exception as e:
+    default_context.clear_tensors()
     assert False, f'Test {function_config["name"]} backward: {function_config} traceback: {e}'
 """
     )

--- a/diopi_test/python/codegen/case_template.py
+++ b/diopi_test/python/codegen/case_template.py
@@ -93,7 +93,7 @@ np_inputs_orign = deepcopy(function_kwargs)
 
 ${preprocess_parameters}
 
-# output of device: dev_out
+# output of device: dev_foward_out
 ${test_function_forward_call}
 """
     )
@@ -235,18 +235,18 @@ tol = ${test_compare_tol}
 sum_to_compare = True if 'sorted' in function_kwargs and ~function_kwargs['sorted'] else False
 tol['sum_to_compare'] = sum_to_compare
 try:
-    dev_out = ${test_diopi_func_name}(**function_kwargs)
+    dev_foward_out = ${test_diopi_func_name}(**function_kwargs)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
 
-# read ref_out
+# read ref_foward_out
 with open(f_out, 'rb') as f:
-    ref_out = pickle.load(f)
+    ref_foward_out = pickle.load(f)
 
 try:
-    CheckResult.compare_input(function_kwargs, np_inputs_orign, ignore_paras_for_input_check)
-    CheckResult.compare_output(dev_out, ref_out, **tol)
+    CheckResult.compare_input_dict(function_kwargs, np_inputs_orign, ignore_paras_for_input_check, **tol)
+    CheckResult.compare_output(dev_foward_out, ref_foward_out, **tol)
 except Exception as e:
     assert False, f'Test {function_config["name"]}: {function_config} traceback: {e}'
 """
@@ -257,15 +257,15 @@ except Exception as e:
 # inplace call for the function
 ${test_diopi_func_inp_remove_grad_args}
 try:
-    dev_inp_out = ${test_diopi_func_name}(inplace=True, **function_kwargs)
+    dev_inp_forward_out = ${test_diopi_func_name}(inplace=True, **function_kwargs)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
 
 try:
     ignore_paras_for_input_check.add('input')
-    CheckResult.compare_input(function_kwargs, np_inputs_orign, ignore_paras_for_input_check)
-    CheckResult.compare_output(dev_inp_out, ref_out, **tol)
+    CheckResult.compare_input_dict(function_kwargs, np_inputs_orign, ignore_paras_for_input_check, **tol)
+    CheckResult.compare_output(dev_inp_forward_out, ref_foward_out, **tol)
 except Exception as e:
     assert False, f'Test {function_config["name"]}  inplace: {function_config} traceback: {e}'
 """
@@ -280,6 +280,7 @@ function_kwargs = {key: value for key, value in function_kwargs.items() if key n
         r"""
 try:
     ManualTest.test_${test_diopi_func_name}(**function_kwargs)
+    CheckResult.compare_input_dict(function_kwargs, np_inputs_orign, ignore_paras_for_input_check)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
@@ -303,17 +304,19 @@ except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
 # grad_output_path
 f_bp_out = os.path.join(data_path, '${test_module_name}', 'outputs', '${bp_output_data_path}')
 
-if not isinstance(dev_out, (list, tuple)):
-    dev_out = [dev_out]
+if not isinstance(dev_foward_out, (list, tuple)):
+    dev_foward_out = [dev_foward_out]
 requires_backward = function_config['requires_backward']
-outputs_for_backward = dev_out if len(requires_backward) == 0 \
-    else [dev_out[i] for i in requires_backward]
+outputs_for_backward = dev_foward_out if len(requires_backward) == 0 \
+    else [dev_foward_out[i] for i in requires_backward]
 backward_para = {}
 grad_outputs = [ones_like(i) for i in outputs_for_backward]
 backward_para["grad_outputs"] = grad_outputs
 for k, v in function_config['saved_args'].items():
-    backward_para[k] = dev_out[v]
+    backward_para[k] = dev_foward_out[v]
 
+backward_para_compare = [item for value in backward_para.values() for item in (value if isinstance(value, list) else [value])]
+backward_para_origin = deepcopy([item.numpy() for item in backward_para_compare])
 try:
     dev_bp_out = ${test_diopi_bp_func_name}(**function_kwargs, **backward_para)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
@@ -325,7 +328,8 @@ with open(f_bp_out, 'rb') as f:
 
 # checkout
 try:
-    CheckResult.compare_input(function_kwargs, np_inputs_orign, ignore_paras_for_input_check)
+    CheckResult.compare_input_dict(function_kwargs, np_inputs_orign, ignore_paras_for_input_check, **tol)
+    CheckResult.compare_input_list(backward_para_compare, backward_para_origin, **tol)
     CheckResult.compare_output(dev_bp_out, ref_bp_out, **tol)
 except Exception as e:
     assert False, f'Test {function_config["name"]} backward: {function_config} traceback: {e}'

--- a/diopi_test/python/conformance/check_result.py
+++ b/diopi_test/python/conformance/check_result.py
@@ -6,18 +6,40 @@ from conformance.global_settings import glob_vars, default_cfg_dict
 
 
 class CheckResult(object):
+    
     @staticmethod
-    def compare_input(input: dict, input_reference: dict, ignore_paras_for_input_check: list):
+    def compare_input_list(input: list, input_reference: list, **kwargs):
+        input = [t.numpy() if isinstance(t, Tensor) else t for t in input]
+        if len(input) != len(input_reference):
+            raise InputChangedException(f"")
+
+        passed = True
+        mismatch_ratio_threshold = kwargs.get('mismatch_ratio_threshold', 1e-3)
+        for i in range(len(input)):
+            matched = np.isclose(input_reference[i], input[i], equal_nan=True)
+            mismatched_num = matched.size - np.sum(matched)
+            passed = mismatched_num <= mismatch_ratio_threshold * matched.size
+            if not passed:
+                glob_vars.func_status[glob_vars.cur_test_func] = 'failed'
+                debug_level = glob_vars.debug_level
+                error_info = f'Run {glob_vars.cur_test_func} failed, because of input of backward changed'
+                if debug_level > 1:
+                    error_info += (f"\n\texpect input: \n\t\t{input_reference[i]}\n\tbut got input reference \n\t\t{input[i]}")
+                raise InputChangedException(error_info)
+        
+    @staticmethod
+    def compare_input_dict(input: dict, input_reference: dict, ignore_paras_for_input_check: list, **kwargs):    
         input = {key: value.numpy() for key, value in input.items() if key not in ignore_paras_for_input_check and isinstance(value, Tensor)}
         input_reference = {key: value for key, value in input_reference.items() if key not in ignore_paras_for_input_check and isinstance(value, np.ndarray)}
         if input.keys() != input_reference.keys():
             raise InputChangedException(f"input's keys {list(input.keys())} is not equal to input_reference's keys {list(input_reference.keys())}.")
 
+        mismatch_ratio_threshold = kwargs.get('mismatch_ratio_threshold', 1e-3)
         passed = True
         for name, value in input.items():
             matched = np.isclose(input_reference[name], value, equal_nan=True)
             mismatched_num = matched.size - np.sum(matched)
-            passed = mismatched_num <= default_cfg_dict['default_option']['mismatch_ratio_threshold'] * matched.size
+            passed = mismatched_num <= mismatch_ratio_threshold * matched.size
             if not passed:
                 glob_vars.func_status[glob_vars.cur_test_func] = 'failed'
                 debug_level = glob_vars.debug_level

--- a/diopi_test/python/conformance/check_result.py
+++ b/diopi_test/python/conformance/check_result.py
@@ -6,12 +6,12 @@ from conformance.global_settings import glob_vars, default_cfg_dict
 
 
 class CheckResult(object):
-    
+
     @staticmethod
     def compare_input_list(input: list, input_reference: list, **kwargs):
         input = [t.numpy() if isinstance(t, Tensor) else t for t in input]
         if len(input) != len(input_reference):
-            raise InputChangedException(f"")
+            raise InputChangedException(f"expect input list len {len(input_reference)} but {input}")
 
         passed = True
         mismatch_ratio_threshold = kwargs.get('mismatch_ratio_threshold', 1e-3)
@@ -26,9 +26,9 @@ class CheckResult(object):
                 if debug_level > 1:
                     error_info += (f"\n\texpect input: \n\t\t{input_reference[i]}\n\tbut got input reference \n\t\t{input[i]}")
                 raise InputChangedException(error_info)
-        
+
     @staticmethod
-    def compare_input_dict(input: dict, input_reference: dict, ignore_paras_for_input_check: list, **kwargs):    
+    def compare_input_dict(input: dict, input_reference: dict, ignore_paras_for_input_check: list, **kwargs):
         input = {key: value.numpy() for key, value in input.items() if key not in ignore_paras_for_input_check and isinstance(value, Tensor)}
         input_reference = {key: value for key, value in input_reference.items() if key not in ignore_paras_for_input_check and isinstance(value, np.ndarray)}
         if input.keys() != input_reference.keys():

--- a/diopi_test/python/conformance/gen_case.py
+++ b/diopi_test/python/conformance/gen_case.py
@@ -37,6 +37,7 @@ def gen_case(cache_path=".", cur_dir="", model_name="", fname="", impl_folder=""
     os.makedirs(case_output_dir)
 
     if impl_folder != "":
+        cfg_path = device_case_item_path % os.path.basename(impl_folder)
         sys.path.append(impl_folder)
 
         from device_configs import device_configs

--- a/diopi_test/python/conformance/gen_case.py
+++ b/diopi_test/python/conformance/gen_case.py
@@ -37,7 +37,6 @@ def gen_case(cache_path=".", cur_dir="", model_name="", fname="", impl_folder=""
     os.makedirs(case_output_dir)
 
     if impl_folder != "":
-        cfg_path = device_case_item_path % os.path.basename(impl_folder)
         sys.path.append(impl_folder)
 
         from device_configs import device_configs

--- a/diopi_test/python/conformance/global_op_list.py
+++ b/diopi_test/python/conformance/global_op_list.py
@@ -73,5 +73,7 @@ ops_with_states = {"batch_norm": {"running_mean", "running_var"},
                    "token_attention": {"out"},
                    "token_softmax_reducev": {"out"},
                    "random": {"input"},
-                   "uniform": {"input"}
+                   "uniform": {"input"},
+                   "normal_": {"input"},
+                   "bernoulli": {"input"},
                    }

--- a/diopi_test/python/conformance/global_op_list.py
+++ b/diopi_test/python/conformance/global_op_list.py
@@ -71,5 +71,7 @@ ops_with_states = {"batch_norm": {"running_mean", "running_var"},
                    "context_attention": {"out"},
                    "destindex_copy_kv": {"out"},
                    "token_attention": {"out"},
-                   "token_softmax_reducev": {"out"}
+                   "token_softmax_reducev": {"out"},
+                   "random": {"input"},
+                   "uniform": {"input"}
                    }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
修改了一些compare_input 

## Description
<!--- Describe your changes in detail. -->
### compare_input
增加了对forward输出后的参数在backward前后的对比
增加了manual_function前后的对比
mismatch_ratio_threshold不直接使用默认值，从生成的cfg中读

- 跳过测例 : "random": {"input"},"uniform": {"input"},"normal_": {"input"}
- bernuolli的compare_input通不过，疑似test_manual写的有问题，后面会进行修复，目前先跳过了

### bug_fix
测例比较失败后直接raise了，没有释放context，现在在raise前加上clear_tensor

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

