### PR TITLE
add stream lock to avoid use same steam in multithread at same time

### DIFF
--- a/impl/ascend/common/acloprunner.hpp
+++ b/impl/ascend/common/acloprunner.hpp
@@ -24,6 +24,7 @@
 #include "debug.hpp"
 #include "gil_scoped_release.hpp"
 #include "impl_functions.hpp"
+#include "stream_lock.hpp"
 #include "utils.hpp"
 
 namespace impl {
@@ -630,6 +631,7 @@ public:
         diopiGetStream(context_, &stream);
         diopi::GilScopedRelease gilReleaeGuard;
         if (sync_) {
+            diopi::StreamLockGuard streamLockGuard(stream);
             CALL_ACLRT(aclopCompileAndExecuteV2(opname_.data(),
                                                 inputIndex_,
                                                 inputDescs_.data(),
@@ -643,6 +645,7 @@ public:
                                                 nullptr,
                                                 stream));
         } else {
+            diopi::StreamLockGuard streamLockGuard(stream);
             CALL_ACLRT(aclopCompileAndExecute(opname_.data(),
                                               inputIndex_,
                                               inputDescs_.data(),

--- a/impl/ascend/common/stream_lock.cpp
+++ b/impl/ascend/common/stream_lock.cpp
@@ -1,0 +1,31 @@
+#include "stream_lock.hpp"
+
+#include <map>
+#include <mutex>
+#include <thread>
+
+namespace diopi {
+
+using MutexType = std::mutex;
+
+namespace {
+
+MutexType* getLockForStream(void* aclrtStreamHandle) {
+    static std::map<void*, MutexType> streamThreadMutexMap;
+    return &streamThreadMutexMap[aclrtStreamHandle];
+}
+
+}  // namespace
+
+StreamLockGuard::StreamLockGuard(void* aclrtStreamHandle) {
+    MutexType* mutexPtr = getLockForStream(aclrtStreamHandle);
+    mutex_ = mutexPtr;
+    mutexPtr->lock();
+}
+
+StreamLockGuard::~StreamLockGuard() {
+    MutexType* mutexPtr = static_cast<MutexType*>(mutex_);
+    mutexPtr->unlock();
+}
+
+}  // namespace diopi

--- a/impl/ascend/common/stream_lock.hpp
+++ b/impl/ascend/common/stream_lock.hpp
@@ -7,7 +7,7 @@ private:
     void* mutex_ = nullptr;
 
 public:
-    StreamLockGuard(void* aclrtStreamHandle);
+    explicit StreamLockGuard(void* aclrtStreamHandle);
     ~StreamLockGuard();
 };
 

--- a/impl/ascend/common/stream_lock.hpp
+++ b/impl/ascend/common/stream_lock.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace diopi {
+
+class StreamLockGuard {
+private:
+    void* mutex_ = nullptr;
+
+public:
+    StreamLockGuard(void* aclrtStreamHandle);
+    ~StreamLockGuard();
+};
+
+}  // namespace diopi

--- a/impl/ascend_npu/CMakeLists.txt
+++ b/impl/ascend_npu/CMakeLists.txt
@@ -656,6 +656,7 @@ set(OLD_IMPL_SRC
     ${OLD_IMPL_DIR}/common/format_helper.cpp
     ${OLD_IMPL_DIR}/common/debug.cpp
     ${OLD_IMPL_DIR}/common/generator_helper.cpp
+    ${OLD_IMPL_DIR}/common/stream_lock.cpp
     ${OLD_IMPL_DIR}/env_vars.cpp
 )
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. 背景： 多线程场景下，不支持调用aclopCompileAndExecute接口时指定同一个Stream或使用默认Stream，否则可能任务执行异常。（https://www.hiascend.com/document/detail/zh/canncommercial/70RC1/reference/envvar/envref_07_0047.html?sub_id=%2Fzh%2Fcanncommercial%2F70RC1%2Finferapplicationdev%2Faclcppdevg%2Faclcppdevg_03_0632.html）
2. 调用aclopCompileAndExecute前为同一个stream加锁


## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

