### PR TITLE
Fix the use of the stable argument for the sort op on Ascend

### DIFF
--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4180,6 +4180,28 @@ diopi_configs = {
         ),
     ),
 
+    'sort_no_stable': dict(
+        name=["sort"],
+        interface=['torch'],
+        para=dict(
+            dim=[-1, 0, 1, -2, 3, -1, 0, -1, 0, 2],
+            descending=[False, True, False, False, True, False, True, True, False, False],
+        ),
+        dtype=[np.float16, np.float32, np.float64, np.int16,
+               np.int32, np.int64, np.uint8, np.int8],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (11400, ), (12, 8), (8, 12, 9),
+                              (4, 4, 16, 20), (4, 4, 16, 2, 20), (24180,),
+                              (0,), (12, 0), (4, 0, 5)),
+                },
+            ],
+        ),
+    ),
+
     # FIXME topk输入0-d张量，且k为0时，结果精度不一致
     'topk_nonzero': dict(
         name=['topk'],

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -1456,7 +1456,7 @@ def stack(tensors, dim=0) -> Tensor:
     return out
 
 
-def sort(input, dim=-1, descending=False, stable=False):
+def sort(input, dim=-1, descending=False, stable=None):
     vals = raw_like(input)
     sizeI = input.size().data
     indices = Tensor(sizeI, from_numpy_dtype(glob_vars.int_type))

--- a/impl/ascend/functions/sort.cpp
+++ b/impl/ascend/functions/sort.cpp
@@ -12,7 +12,7 @@ namespace impl {
 namespace ascend {
 
 diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t dim,
-                       bool descending, const bool* stable) {
+                       bool descending, const bool* pStable) {
     diopiSize_t inputShape;
     diopiGetTensorShape(input, &inputShape);
 
@@ -39,7 +39,7 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
             .addInput(inputT)
             .setAttr("axis", lastdim)
             .setAttr("descending", descending)
-            .setAttr("stable", nullptr == stable ? false : *stable)
+            .setAttr("stable", nullptr == pStable ? false : *pStable)
             .addOutput(valuesT)
             .addOutput(indicesT)
             .run();
@@ -52,7 +52,7 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
             .addInput(input)
             .setAttr("axis", dim)
             .setAttr("descending", descending)
-            .setAttr("stable", nullptr == stable ? false : *stable)
+            .setAttr("stable", nullptr == pStable ? false : *pStable)
             .addOutput(values)
             .addOutput(indices)
             .run();

--- a/impl/ascend/functions/sort.cpp
+++ b/impl/ascend/functions/sort.cpp
@@ -12,7 +12,7 @@ namespace impl {
 namespace ascend {
 
 diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t dim,
-                       bool descending, const bool *stable) {
+                       bool descending, const bool* stable) {
     diopiSize_t inputShape;
     diopiGetTensorShape(input, &inputShape);
 

--- a/impl/ascend/functions/sort.cpp
+++ b/impl/ascend/functions/sort.cpp
@@ -39,7 +39,7 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
             .addInput(inputT)
             .setAttr("axis", lastdim)
             .setAttr("descending", descending)
-            .setAttr("stable", *stable)
+            .setAttr("stable", nullptr == stable ? false : *stable)
             .addOutput(valuesT)
             .addOutput(indicesT)
             .run();
@@ -52,7 +52,7 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
             .addInput(input)
             .setAttr("axis", dim)
             .setAttr("descending", descending)
-            .setAttr("stable", *stable)
+            .setAttr("stable", nullptr == stable ? false : *stable)
             .addOutput(values)
             .addOutput(indices)
             .run();

--- a/impl/camb/functions/sort.cpp
+++ b/impl/camb/functions/sort.cpp
@@ -11,7 +11,7 @@ namespace impl {
 namespace camb {
 
 diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t dim,
-                       bool descending, const bool* stable) {
+                       bool descending, const bool* pStable) {
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
     auto inputTensor = DiopiTensor(input);
     auto indicesTensor = DiopiTensor(indices);
@@ -68,7 +68,7 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
                                       dim,
                                       descending,
                                       true,
-                                      nullptr == stable ? false : *stable,
+                                      nullptr == pStable ? false : *pStable,
                                       workspace,
                                       workspaceSize,
                                       valuesDesc.get(),

--- a/impl/camb/functions/sort.cpp
+++ b/impl/camb/functions/sort.cpp
@@ -58,7 +58,7 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
                                       dim,
                                       descending,
                                       true,
-                                      stable,
+                                      nullptr == stable ? false : *stable,
                                       workspace,
                                       workspaceSize,
                                       valuesDesc.get(),

--- a/impl/topsrider/device_configs.py
+++ b/impl/topsrider/device_configs.py
@@ -1767,6 +1767,18 @@ device_configs = {
         ),
     ),
 
+    'sort_no_stable': dict(
+        name=['sort'],
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": [Skip(()),Skip((11400,)),Skip((12, 8)),Skip((8, 12, 9)),Skip((4, 4, 16, 20)),Skip((4, 4, 16, 2, 20)),Skip((24180,)),Skip((0,)),Skip((12, 0)),Skip((4, 0, 5)),],
+                },
+            ]
+        ),
+    ),
+
     'topk_nonzero': dict(
         name=['topk'],
         tensor_para=dict(

--- a/impl/topsrider/functions/functions.cpp
+++ b/impl/topsrider/functions/functions.cpp
@@ -432,9 +432,9 @@ DIOPI_API diopiError_t diopiStack(diopiContextHandle_t ctx, diopiTensorHandle_t 
 }
 
 DIOPI_API diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t dim,
-                                 bool descending, const bool *stable) {
+                                 bool descending, const bool *pStable) {
     TOPSOP_LOG();
-    return impl::tops::topsSort(ctx, values, indices, input, dim, descending, stable);
+    return impl::tops::topsSort(ctx, values, indices, input, dim, descending, pStable);
 }
 
 DIOPI_API diopiError_t diopiHardtanhBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,

--- a/impl/topsrider/ops.h
+++ b/impl/topsrider/ops.h
@@ -185,7 +185,7 @@ DIOPI_API diopiError_t topsLayerNormBackward(diopiContextHandle_t ctx, diopiTens
 DIOPI_API diopiError_t topsStack(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t *tensors, int64_t numTensors, int64_t dim);
 
 DIOPI_API diopiError_t topsSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t dim,
-                                bool descending, const bool *stable);
+                                bool descending, const bool *pStable);
 
 DIOPI_API diopiError_t topsHardtanh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const diopiScalar_t *min_val,
                                     const diopiScalar_t *max_val);

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -2190,13 +2190,13 @@ DIOPI_API diopiError_t diopiStack(diopiContextHandle_t ctx, diopiTensorHandle_t 
  * @param[in] input the intput tensor. type = [float16, float32, float64, int16, int32, int64, uint8, int8]
  * @param[in] dim the dimension to sort along. type = [int64].
  * @param[in] descending boolean, controls the sorting order (ascending or descending).
- * @param[in] stable a boolean pointer, selects a stable sorting algorithm to use,
+ * @param[in] pStable a boolean pointer, selects a stable sorting algorithm to use,
  * where stable sorting algorithms guarantee that the order of equal elements remains unchanged.
  * @param[out] values the sorted tensor. type = [float16, float32, float64, int16, int32, int64, uint8, int8].
  * @param[out] indices the index of corresponding element in the sorted tensor. type = [int32, int64].
  */
 DIOPI_API diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t dim,
-                                 bool descending, const bool* stable);
+                                 bool descending, const bool* pStable);
 
 /**
  * @brief Returns the k largest elements of the given input tensor along a given dimension.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `const bool *stable` argument is not properly handled in the implementation of diopiSort on Ascend.


## Description
<!--- Describe your changes in detail. -->

- Fix the sort op with stable being nullptr on Ascend
- ~~Fix the use of stable for the sort op on Camb~~
- Add sort_no_stable tests
- Change the default value of the stable argument from False to None for sort in diopi_test
- Rename the stable argument to pStable for diopiSort


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

