### PR TITLE
zsk/update bernoulli test

### DIFF
--- a/diopi_test/python/conformance/diopi_manual_functions.py
+++ b/diopi_test/python/conformance/diopi_manual_functions.py
@@ -71,12 +71,16 @@ class ManualTest(object):
                 "failed to execute uniform"
 
     def test_bernoulli(input, inplace=False, p=None):
-        p_numpy = input.numpy()
-        if input.numel() > 0:
-            p = p_numpy.mean() if p is None else p
+        # p_numpy = input.numpy()
+        # if input.numel() > 0:
+        #     p = p_numpy.mean() if p is None else p
         state = build_generator_state(input.context())
         generator = Generator(state)
+        input_origin = np.copy(input.compy())
         out = F.bernoulli(input, inplace, p, generator)
+        if (inplace == False) and p == None:
+            assert np.allclose(input_origin, input) == False, \
+                "input changed"
         out_numpy = out.numpy()
 
         assert np.all((out_numpy == 0) | (out_numpy == 1)), "bernoulli output must be 0 or 1"

--- a/diopi_test/python/conformance/diopi_manual_functions.py
+++ b/diopi_test/python/conformance/diopi_manual_functions.py
@@ -78,8 +78,8 @@ class ManualTest(object):
         generator = Generator(state)
         input_origin = np.copy(input.numpy())
         out = F.bernoulli(input, inplace, p, generator)
-        if inplace == False and p == None:
-            assert np.allclose(input_origin, input) == False, \
+        if inplace is False and p is None:
+            assert np.allclose(input_origin, input) is False, \
                 "input changed"
         out_numpy = out.numpy()
 

--- a/diopi_test/python/conformance/diopi_manual_functions.py
+++ b/diopi_test/python/conformance/diopi_manual_functions.py
@@ -71,14 +71,14 @@ class ManualTest(object):
                 "failed to execute uniform"
 
     def test_bernoulli(input, inplace=False, p=None):
-        # p_numpy = input.numpy()
-        # if input.numel() > 0:
-        #     p = p_numpy.mean() if p is None else p
+        p_numpy = input.numpy()
+        if input.numel() > 0:
+            p = p_numpy.mean() if p is None else p
         state = build_generator_state(input.context())
         generator = Generator(state)
-        input_origin = np.copy(input.compy())
+        input_origin = np.copy(input.numpy())
         out = F.bernoulli(input, inplace, p, generator)
-        if (inplace == False) and p == None:
+        if inplace == False and p == None:
             assert np.allclose(input_origin, input) == False, \
                 "input changed"
         out_numpy = out.numpy()

--- a/diopi_test/python/conformance/diopi_manual_functions.py
+++ b/diopi_test/python/conformance/diopi_manual_functions.py
@@ -79,7 +79,7 @@ class ManualTest(object):
         input_origin = np.copy(input.numpy())
         out = F.bernoulli(input, inplace, p, generator)
         if inplace is False and p is None:
-            assert np.allclose(input_origin, input) is False, \
+            assert np.allclose(input_origin, input.numpy()) is True, \
                 "input changed"
         out_numpy = out.numpy()
 

--- a/diopi_test/python/conformance/global_op_list.py
+++ b/diopi_test/python/conformance/global_op_list.py
@@ -75,5 +75,5 @@ ops_with_states = {"batch_norm": {"running_mean", "running_var"},
                    "random": {"input"},
                    "uniform": {"input"},
                    "normal_": {"input"},
-                   "bernoulli": {"input"},
+                   "bernoulli": {"input"},  # compared in manual_test
                    }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Description
<!--- Describe your changes in detail. -->

在manual_test中加上了对bernoulli input是否改变的比较
只在inplace==false and p==None时比较，p有值时调用diopiBernoulliScalar，input 会作为存结果的tensor
## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

