### PR TITLE
[optim][nv] speed up `buildATen` ~67%

### DIFF
--- a/impl/torch/helper.cpp
+++ b/impl/torch/helper.cpp
@@ -127,13 +127,14 @@ at::Tensor buildATenImpl(diopiConstTensorHandle_t tensor) {
         return DeviceImpl::empty(atSizes, atDtype, atDevice);
     }
 
-    // NOTE: CUDA allocators may have not been initialized if we were using DIPU allocators
-    //       we have to do this explicitly for potential allocations in op workspaces
+    // NOTE: CUDA allocators may have not been initialized if we were using DIPU allocators.
+    //       We have to do this explicitly for potential allocations in op workspaces.
     DeviceImpl::lazyInitDevice();
 
-    // PERF: it would be faster if we can obtain and reuse the storage from tensor
-    //       however we cannot assume diopiTensorHandle_t to be a wrapper of at::Tensor
-    //       so we have to create a new storage (offset = 0)
+    // PERF: It would be faster if we can obtain and reuse the storage from tensor.
+    //       However we cannot assume diopiTensorHandle_t to be a wrapper of at::Tensor.
+    //       So we have to create a new storage (offset = 0) whose data_ptr points to
+    //       the same address but with an empty dtor (to avoid double-free).
 
     diopiSize_t stride;
     diopiGetTensorStride(tensor, &stride);

--- a/impl/torch/helper.hpp
+++ b/impl/torch/helper.hpp
@@ -68,7 +68,7 @@ inline void sync(diopiContextHandle_t ctx) {
 
 caffe2::TypeMeta getATenType(diopiDtype_t dt);
 
-diopiDtype_t getDIOPITensorType(at::Tensor& input);
+diopiDtype_t getDIOPITensorType(const at::Tensor& input);
 
 inline diopiDevice_t getDIOPIDevice(c10::DeviceType device) {
     if (device == c10::DeviceType::CPU) {
@@ -84,8 +84,7 @@ inline c10::DeviceType getATenDevice(diopiDevice_t device) {
     return c10::DeviceType::CUDA;
 }
 
-template <typename T>
-at::Tensor buildATen(T tensor);
+at::Tensor buildATen(diopiConstTensorHandle_t tensor);
 
 inline bool isInt(const diopiScalar_t* scalar) { return scalar->stype <= 7; }
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
在 nv 上，`buildATen` 平均占用模型 ~8% CPU 侧时间，本 PR 大幅优化了其时间开销

## Description
<!--- Describe your changes in detail. -->
resnet18 train bs=1 fwd: 69.8% -> 73.2%
llama7b eval fwd: 67.0% -> 69.9%


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->
~~假定了 `buildATen` 输入一定为 CUDA tensor，不过似乎之前也有相同的假定~~

## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

