### PR TITLE
[Camb] Wx/fix the bug of sort op on camb

### DIFF
--- a/impl/camb/device_configs.py
+++ b/impl/camb/device_configs.py
@@ -1286,18 +1286,6 @@ device_configs = {
         ),
     ),
 
-    'sort': dict(
-        name=["sort"],
-        interface=['torch'],
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": (Skip(()),),
-                },
-            ],
-        ),
-    ),
     # TODO: ctc_loss of camb could work correctly due to dipu and one_iter, need to fix diopi_test
     'ctc_loss': dict(
         name=["ctc_loss"],

--- a/impl/camb/functions/sort.cpp
+++ b/impl/camb/functions/sort.cpp
@@ -17,7 +17,17 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
     auto indicesTensor = DiopiTensor(indices);
     auto valuesTensor = DiopiTensor(values);
     DiopiTensor valuesTensorTemp = valuesTensor;
-
+    // handle scalar
+    if (inputTensor.dim() == 0 && inputTensor.numel() == 1) {
+        DIOPI_CALL(diopiCopyInp(ctx, input, values));
+        diopiScalar_t zero = constructDiopiScalarT(indicesTensor.dtype(), 0);
+        DIOPI_CALL(diopiFill(ctx, indices, &zero));
+        return diopiSuccess;
+    }
+    // handle empty tensor
+    if (inputTensor.numel() == 0) {
+        return diopiSuccess;
+    }
     // since input can be changed by cnnlTopKTensor_v3 when input_shape is (24180),
     // need to requires a temp Tensor to bypass this bug
     DiopiTensor inputTensorTemp = requiresTensor(ctx, inputTensor.shape(), inputTensor.dtype());
@@ -58,7 +68,7 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
                                       dim,
                                       descending,
                                       true,
-                                      stable,
+                                      nullptr == stable ? false : *stable,
                                       workspace,
                                       workspaceSize,
                                       valuesDesc.get(),


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Fix the bug of sort op on camb when input is a scalar or an empty tensor. 

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

