### PR TITLE
zsk/fix adapative_pool_2d

### DIFF
--- a/impl/ascend/device_configs.py
+++ b/impl/ascend/device_configs.py
@@ -233,14 +233,6 @@ device_configs = {
     'adaptive_avg_pool2d': dict(
         name=['adaptive_avg_pool2d'],
         atol=2e-2,
-        tensor_para=dict(
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": [Skip((3,16,8)), Skip((4,16,12)), Skip((2,144,65,65))],
-                },
-            ]
-        ),
     ),
 
     'adaptive_max_pool2d': dict(

--- a/impl/ascend/functions/pool.cpp
+++ b/impl/ascend/functions/pool.cpp
@@ -41,11 +41,7 @@ diopiError_t diopiAdaptiveAvgPool2dBackward(diopiContextHandle_t ctx, diopiTenso
     for (int i = 0; i < shape.len; ++i) {
         shapeVector.push_back(static_cast<int>(shape.data[i]));
     }
-    AclOpRunner<1, 1>("AdaptiveAvgPool2dGrad", ctx)
-        .addInput(gradOutput)
-        .setAttr("orig_input_shape", shapeVector)
-        .addOutput(gradInput)
-        .run();
+    AclOpRunner<1, 1>("AdaptiveAvgPool2dGrad", ctx).addInput(gradOutput).setAttr("orig_input_shape", shapeVector).addOutput(gradInput).run();
     return diopiSuccess;
 }
 

--- a/impl/ascend/functions/pool.cpp
+++ b/impl/ascend/functions/pool.cpp
@@ -43,7 +43,7 @@ diopiError_t diopiAdaptiveAvgPool2dBackward(diopiContextHandle_t ctx, diopiTenso
     }
     AclOpRunner<1, 1>("AdaptiveAvgPool2dGrad", ctx)
         .addInput(gradOutput)
-        .setAttr("orig_input_shape",shapeVector)
+        .setAttr("orig_input_shape", shapeVector)
         .addOutput(gradInput)
         .run();
     return diopiSuccess;

--- a/impl/ascend/functions/pool.cpp
+++ b/impl/ascend/functions/pool.cpp
@@ -5,7 +5,6 @@
  */
 
 #include "../common/acloprunner.hpp"
-#include <iostream>
 namespace impl {
 namespace ascend {
 

--- a/impl/ascend/functions/pool.cpp
+++ b/impl/ascend/functions/pool.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "../common/acloprunner.hpp"
-
+#include <iostream>
 namespace impl {
 namespace ascend {
 
@@ -37,12 +37,14 @@ diopiError_t diopiAdaptiveAvgPool2dBackward(diopiContextHandle_t ctx, diopiTenso
         diopiMulInp(ctx, gradInput, gradOutput);
         return diopiSuccess;
     }
-
+    std::vector<int32_t> shapeVector;
+    shapeVector.reserve(shape.len);
+    for (int i = 0; i < shape.len; ++i) {
+        shapeVector.push_back(static_cast<int>(shape.data[i]));
+    }
     AclOpRunner<1, 1>("AdaptiveAvgPool2dGrad", ctx)
         .addInput(gradOutput)
-        .setAttr("orig_input_shape",
-                 std::vector<int32_t>{
-                     static_cast<int>(shape.data[0]), static_cast<int>(shape.data[1]), static_cast<int>(shape.data[2]), static_cast<int>(shape.data[3])})
+        .setAttr("orig_input_shape",shapeVector)
         .addOutput(gradInput)
         .run();
     return diopiSuccess;


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

修复adapative_pool_2d 问题，原来grad shape默认四维，所以三维的测例过不了
## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

