### PR TITLE
zq/fix token_attention

### DIFF
--- a/impl/ascend_npu/diopi_impl/functions_ext/token_attention_inference.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/token_attention_inference.cpp
@@ -25,9 +25,9 @@ diopiError_t diopiTokenAttentionInference(diopiContextHandle_t ctx, diopiTensorH
     for (int i = 0; i < batch; ++i) {
         int curSeqLen = bSeqLenAt[i].item<int>();
         int curSeqStartLoc = bStartLocAt[i].item<int>();
-        at::Tensor kLoc = at::index_select(bLocAt[i], 0, acl_op::arange(maxInputLen - curSeqLen, maxInputLen, at::kLong, layout, device));
+        at::Tensor kLoc = at::index_select(bLocAt[i], 0, acl_op::arange(maxInputLen - curSeqLen, maxInputLen, at::kInt, layout, device));
         at::Tensor key = at::index(kAt, {kLoc}).view({1, curSeqLen, head, dim}).transpose(1, 2);
-        at::Tensor outLoc = acl_op::arange(curSeqStartLoc, curSeqStartLoc + curSeqLen, at::kLong, layout, device);
+        at::Tensor outLoc = acl_op::arange(curSeqStartLoc, curSeqStartLoc + curSeqLen, at::kInt, layout, device);
         at::Tensor values =
             (at::matmul(at::index(qAt, {torch::scalar_to_tensor(i)}).toType(at::kFloat), key.transpose(2, 3).toType(at::kFloat)) / std::sqrt(dim))
                 .view({head, curSeqLen})

--- a/impl/ascend_npu/diopi_impl/functions_ext/token_softmax_reducev.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/token_softmax_reducev.cpp
@@ -24,11 +24,11 @@ diopiError_t diopiTokenSoftmaxReduceVInference(diopiContextHandle_t ctx, diopiTe
     for (int i = 0; i < batch; ++i) {
         int curSeqLen = bSeqLenAt[i].item<int>();
         int curSeqStartLoc = bStartLocAt[i].item<int>();
-        at::Tensor p = at::index(logicsAt, {at::Tensor(), acl_op::arange(curSeqStartLoc, curSeqStartLoc + curSeqLen, at::kLong, layout, device)})
+        at::Tensor p = at::index(logicsAt, {at::Tensor(), acl_op::arange(curSeqStartLoc, curSeqStartLoc + curSeqLen, at::kInt, layout, device)})
                            .softmax(-1)
                            .reshape({head, 1, 1, curSeqLen})
                            .transpose(0, 1);
-        at::Tensor vLoc = bLocAt[i].index_select(0, acl_op::arange(maxInputLen - curSeqLen, maxInputLen, at::kLong, layout, device));
+        at::Tensor vLoc = bLocAt[i].index_select(0, acl_op::arange(maxInputLen - curSeqLen, maxInputLen, at::kInt, layout, device));
         at::Tensor v = at::index(vAt, {vLoc}).view({1, curSeqLen, head, dim}).transpose(1, 2);
         at::Tensor values = at::matmul(p.toType(at::kFloat), v.toType(at::kFloat)).view({head, dim}).toType(dtype);
         at::index_put_(outAt, {torch::scalar_to_tensor(i)}, values);


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix token_attention and token_softmax_reduceV.


## Description
<!--- Describe your changes in detail. -->
fix token_attention and token_softmax_reduceV.
the bug is: the bSeqLen will be changed uncorrectly after arange OP if bSeqLen is 63

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

