### PR TITLE
tyf/change Avg Pool

### DIFF
--- a/impl/camb/convert_config.yaml
+++ b/impl/camb/convert_config.yaml
@@ -52,6 +52,18 @@
     layout: ND
 #---base operation above---#
 
+#---Pooling operation below---#
+- diopiAdaptiveAvgPool2d:
+    layout: NHWC, NDHWC
+
+- diopiAdaptiveAvgPool2dBackward:
+    layout: NHWC, NDHWC
+#---Pooling operation above---#
+
+#---Matrix operation below---#
+
+#---Matrix operation above---#
+
 - diopiUpsampleNearest:
     layout: NHWC, NDHWC
 

--- a/impl/camb/functions/adaptive_pooling.cpp
+++ b/impl/camb/functions/adaptive_pooling.cpp
@@ -15,31 +15,32 @@ diopiError_t diopiAdaptiveAvgPool2d(diopiContextHandle_t ctx, diopiTensorHandle_
     cnnlHandle_t handle = cnnlHandlePool.get(ctx);
     DiopiTensor inputTr(input);
     DiopiTensor outputTr(out);
+    int dim = inputTr.dim();
+    cnnlTensorLayout_t layout;
+    diopiMemoryFormat_t memoryFormat;
 
     /* Some basic check */
-    DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
-
+    // dim == 3, without batch mode will be support in future version
+    DIOPI_CHECK(dim == 4 || dim == 5, "non-empty 4D or 5D tensor expected for input");
     std::vector<DiopiTensor*> pTensors{&inputTr};
     std::set<diopiDtype_t> supportedDtypes{diopi_dtype_float16, diopi_dtype_float32};
     DIOPI_CALL(autoCastTensorType(ctx, pTensors, supportedDtypes));
 
+    if (dim == 4) {
+        layout = CNNL_LAYOUT_NHWC;
+        memoryFormat = diopiMemoryFormat_t::ChannelsLast;
+    } else if (dim == 5) {
+        layout = CNNL_LAYOUT_NDHWC;
+        memoryFormat = diopiMemoryFormat_t::ChannelsLast3d;
+    }
+
     DiopiTensor outputTmpTr = outputTr;
     if (inputTr.dtype() != outputTr.dtype()) {
-        outputTmpTr = requiresTensor(ctx, outputTr.shape(), inputTr.dtype());
+        outputTmpTr = requiresTensor(ctx, outputTr.shape(), inputTr.dtype(), memoryFormat);
     }
 
-    auto memoryFormat = diopiMemoryFormat_t::ChannelsLast;
-    DIOPI_CALL(contiguous(ctx, inputTr, memoryFormat));
-
-    DiopiTensor outputChannelLast = outputTmpTr;
-    if (!outputChannelLast.isContiguous(memoryFormat)) {
-        // for some special case like shape = [2, 2048, 1, 1], it's already been ChannelsLast
-        outputChannelLast = requiresTensor(ctx, outputTmpTr.shape(), outputTmpTr.dtype(), diopiMemoryFormat_t::ChannelsLast);
-    }
-
-    cnnlTensorLayout_t layout = CNNL_LAYOUT_NHWC;
     CnnlTensorDesc inputDesc(inputTr, layout);
-    CnnlTensorDesc outputDesc(outputChannelLast, layout);
+    CnnlTensorDesc outputDesc(outputTmpTr, layout);
 
     cnnlPoolingMode_t mode = CNNL_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
 
@@ -52,13 +53,10 @@ diopiError_t diopiAdaptiveAvgPool2d(diopiContextHandle_t ctx, diopiTensorHandle_
 
     /* call adaptive pooling */
     DIOPI_CALL_CNNL(cnnlAdaptivePoolingForward_v2(
-        handle, inputDesc.get(), inputTr.data(), mode, workspacePtr, workspaceSize, outputDesc.get(), outputChannelLast.data(), nullptr, nullptr));
+        handle, inputDesc.get(), inputTr.data(), mode, workspacePtr, workspaceSize, outputDesc.get(), outputTmpTr.data(), nullptr, nullptr));
 #else
-    DIOPI_CALL_CNNL(cnnlAdaptivePoolingForward(handle, inputDesc.get(), inputTr.data(), mode, outputDesc.get(), outputChannelLast.data(), nullptr, nullptr));
+    DIOPI_CALL_CNNL(cnnlAdaptivePoolingForward(handle, inputDesc.get(), inputTr.data(), mode, outputDesc.get(), outputTmpTr.data(), nullptr, nullptr));
 #endif
-    // NHWC -> NCHW
-    DIOPI_CALL(impl::camb::contiguous(ctx, outputChannelLast, diopiMemoryFormat_t::Contiguous));
-    DIOPI_CALL(impl::camb::diopiCopyInp(ctx, outputChannelLast.tensorHandle(), outputTmpTr.tensorHandle()));
 
     if (outputTmpTr.dtype() != outputTr.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, outputTr, outputTmpTr));
@@ -74,28 +72,33 @@ diopiError_t diopiAdaptiveAvgPool2dBackward(diopiContextHandle_t ctx, diopiTenso
     DiopiTensor inputTr(input);
     DiopiTensor gradOutputTr(gradOutput);
     DiopiTensor gradInputTr(gradInput);
+    int dim = inputTr.dim();
+    cnnlTensorLayout_t layout;
+    diopiMemoryFormat_t memoryFormat;
 
     /* Some basic check */
-    DIOPI_CHECK(inputTr.dim() == 3 || inputTr.dim() == 4, "non-empty 3D or 4D (batch mode) tensor expected for input");
+    DIOPI_CHECK(dim == 4 || dim == 5, "non-empty 4D or 5D tensor expected for input");
 
     std::vector<DiopiTensor*> pTensors{&gradOutputTr, &inputTr};
     std::set<diopiDtype_t> supportedDtypes{diopi_dtype_float16, diopi_dtype_float32};
     DIOPI_CALL(autoCastTensorType(ctx, pTensors, supportedDtypes));
 
-    auto memoryFormat = diopiMemoryFormat_t::ChannelsLast;
-    DIOPI_CALL(contiguous(ctx, gradOutputTr, memoryFormat));
+    if (dim == 4) {
+        layout = CNNL_LAYOUT_NHWC;
+        memoryFormat = diopiMemoryFormat_t::ChannelsLast;
+    } else if (dim == 5) {
+        layout = CNNL_LAYOUT_NDHWC;
+        memoryFormat = diopiMemoryFormat_t::ChannelsLast3d;
+    }
 
     DiopiTensor gradInputTmpTr = gradInputTr;
     if (gradInputTr.dtype() != gradOutputTr.dtype()) {
-        gradInputTmpTr = requiresTensor(ctx, gradInputTr.shape(), gradOutputTr.dtype());
+        gradInputTmpTr = requiresTensor(ctx, gradInputTr.shape(), gradOutputTr.dtype(), memoryFormat);
     }
 
-    DiopiTensor gradInputChannelLast = requiresTensor(ctx, gradInputTmpTr.shape(), gradInputTmpTr.dtype(), diopiMemoryFormat_t::ChannelsLast);
-
     /* generate tensor desc */
-    cnnlTensorLayout_t layout = CNNL_LAYOUT_NHWC;
     CnnlTensorDesc gradOutputDesc(gradOutputTr, layout);
-    CnnlTensorDesc gradInputDesc(gradInputChannelLast, layout);
+    CnnlTensorDesc gradInputDesc(gradInputTmpTr, layout);
 
     /* call adaptive pooling */
     DIOPI_CALL_CNNL(cnnlAdaptivePoolingBackward(handle,
@@ -105,11 +108,7 @@ diopiError_t diopiAdaptiveAvgPool2dBackward(diopiContextHandle_t ctx, diopiTenso
                                                 nullptr,
                                                 CNNL_POOLING_AVERAGE_COUNT_INCLUDE_PADDING,
                                                 gradInputDesc.get(),
-                                                gradInputChannelLast.data()));
-
-    // NHWC -> NCHW
-    DIOPI_CALL(impl::camb::contiguous(ctx, gradInputChannelLast, diopiMemoryFormat_t::Contiguous));
-    DIOPI_CALL(impl::camb::diopiCopyInp(ctx, gradInputChannelLast.tensorHandle(), gradInputTmpTr.tensorHandle()));
+                                                gradInputTmpTr.data()));
 
     if (gradInputTmpTr.dtype() != gradInputTr.dtype()) {
         DIOPI_CALL(dataTypeCast(ctx, gradInputTr, gradInputTmpTr));


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Description
adaptive avg pool实际上只支持了4D和5D，但算法内部却做了多余的转化，本次操作限制了adaptor内转channellast，内部不做转化


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

