### PR TITLE
[Ascend] Wx/fix the wrong dtype setting of diopiScalar* other in diopiMulScalar op

### DIFF
--- a/impl/ascend/functions/binary.cpp
+++ b/impl/ascend/functions/binary.cpp
@@ -141,9 +141,11 @@ diopiError_t diopiMul(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
 diopiError_t diopiMulInp(diopiContextHandle_t ctx, diopiTensorHandle_t input, diopiConstTensorHandle_t other) { return diopiMul(ctx, input, input, other); }
 
 diopiError_t diopiMulScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const diopiScalar_t* other) {
-    diopiTensorHandle_t trOther = nullptr;
-    makeTensorFromScalar(ctx, other, &trOther, other->stype, diopiDevice_t::diopi_device);
-    return diopiMul(ctx, out, input, trOther);
+    diopiTensorHandle_t otherTensor = nullptr;
+    diopiDtype_t outDtype;
+    diopiGetTensorDtype(out, &outDtype);
+    makeTensorFromScalar(ctx, other, &otherTensor, outDtype, diopiDevice_t::diopi_device);
+    return diopiMul(ctx, out, input, otherTensor);
 }
 
 diopiError_t diopiMulInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t input, const diopiScalar_t* other) {


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Fix the wrong dtype setting of diopiScalar* other in diopiMulScalar op.

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

