### PR TITLE
[Ascend] Wx/fix redundant dtype cast of pow op

### DIFF
--- a/impl/ascend/convert_config.yaml
+++ b/impl/ascend/convert_config.yaml
@@ -233,16 +233,16 @@
     dtype: (bool, uint8, int8, int16, int32, int64)->float32
 
 - diopiPow:
-    dtype: (bool, uint8, int8, int16, int32, int64)->float32
+    dtype: (uint8)->int16
 
 - diopiPowInp:
-    dtype: (bool, uint8, int8, int16, int32, int64)->float32
+    dtype: (uint8)->int16
 
 - diopiPowTensor:
-    dtype: (bool, uint8, int8, int16, int32, int64)->float32
+    dtype: (uint8)->int16
 
 - diopiPowInpTensor:
-    dtype: (bool, uint8, int8, int16, int32, int64)->float32
+    dtype: (uint8)->int16
 
 - diopiNorm:
     dtype: (bool, uint8, int8, int16, int32, int64, float64)->float32

--- a/impl/ascend/functions/pow.cpp
+++ b/impl/ascend/functions/pow.cpp
@@ -10,11 +10,8 @@ namespace impl {
 namespace ascend {
 
 diopiError_t diopiPowTensor(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t exponent) {
-    AscendTensor inputAt(input), expAt(exponent);
-    auto dtype = promoteTypes(inputAt.dtype(), expAt.dtype());
-    castTensor(ctx, inputAt, dtype);
-    castTensor(ctx, expAt, dtype);
-    AclOpRunner<2, 1>("Pow", ctx).addInput(inputAt).addInput(expAt).addOutput(out).run();
+    AscendTensor outTensor(out);
+    AclOpRunner<2, 1>("Pow", ctx).addInput(input, outTensor.dtype()).addInput(exponent, outTensor.dtype()).addOutput(out).run();
     return diopiSuccess;
 }
 
@@ -23,17 +20,21 @@ diopiError_t diopiPowInpTensor(diopiContextHandle_t ctx, diopiTensorHandle_t inp
 }
 
 diopiError_t diopiPow(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const diopiScalar_t* exponent) {
+    AscendTensor outTensor(out);
     diopiTensorHandle_t exponentTensor;
-    makeTensorFromScalar(ctx, exponent, &exponentTensor, diopi_device);
-    return diopiPowTensor(ctx, out, input, exponentTensor);
+    makeTensorFromScalar(ctx, exponent, &exponentTensor, outTensor.dtype(), diopi_device);
+    AclOpRunner<2, 1>("Pow", ctx).addInput(input, outTensor.dtype()).addInput(exponentTensor).addOutput(out).run();
+    return diopiSuccess;
 }
 
 diopiError_t diopiPowInp(diopiContextHandle_t ctx, diopiTensorHandle_t input, const diopiScalar_t* exponent) { return diopiPow(ctx, input, input, exponent); }
 
 diopiError_t diopiPowScalar(diopiContextHandle_t ctx, diopiTensorHandle_t out, const diopiScalar_t* input, diopiConstTensorHandle_t exponent) {
+    AscendTensor outTensor(out);
     diopiTensorHandle_t inputTensor;
-    makeTensorFromScalar(ctx, input, &inputTensor, diopi_device);
-    return diopiPowTensor(ctx, out, inputTensor, exponent);
+    makeTensorFromScalar(ctx, input, &inputTensor, outTensor.dtype(), diopi_device);
+    AclOpRunner<2, 1>("Pow", ctx).addInput(inputTensor).addInput(exponent, outTensor.dtype()).addOutput(out).run();
+    return diopiSuccess;
 }
 
 }  // namespace ascend


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Fix redundant dtype cast of pow op.
* To avoid overflow，cast dtype from uint8 to int16.

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

