### PR TITLE
tyf/change op

### DIFF
--- a/impl/camb/common/basic_op.cpp
+++ b/impl/camb/common/basic_op.cpp
@@ -62,8 +62,8 @@ diopiError_t opBroadcastCast(const DiopiTensor& inputTensor, DiopiTensor& otherT
     //  shape3,4,1 stride4,1,1 ->shape1,3,4,1 stride12,4,1,1 ->shape1,3,4,1,stride12,1,3,3 flag = true
     //  shape32,3,224,224 contiguous order0,1,2,3 reverseOrder0,1,2,3
     // shape3,1,1 contiguous ->shape1,3,1,1 stride3,3,1,1 ->shape1,3,1,1 stride3,3,1,1 ->flag = flase
-    std::vector<int32_t> order(inputTensor.dim(), 0);
-    std::vector<int32_t> reverseOrder(inputTensor.dim(), 0);
+    std::vector<int32_t> order;
+    std::vector<int32_t> reverseOrder;
     getPermuteOrder(inputTensor, order, reverseOrder);
     targetShape = otherTensor.shape();
     std::vector<int64_t> curStride = otherTensor.stride();
@@ -140,8 +140,8 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor& input, DiopiTen
                 DIOPI_CALL(permuteCopy(ctx, other, otherTmp));
                 other = otherTmp;
             }
-            std::vector<int32_t> order(input.dim(), 0);
-            std::vector<int32_t> reverseOrder(input.dim(), 0);
+            std::vector<int32_t> order;
+            std::vector<int32_t> reverseOrder;
             getPermuteOrder(input, order, reverseOrder);
             std::vector<int64_t> cnnlInShape = changeVecAccordingToOrder(input.shape(), reverseOrder);
             std::vector<int64_t> cnnlInStride = changeVecAccordingToOrder(input.stride(), reverseOrder);
@@ -160,8 +160,8 @@ diopiError_t cnnlOpTensor(diopiContextHandle_t ctx, DiopiTensor& input, DiopiTen
                 DIOPI_CALL(permuteCopy(ctx, input, inputTmp));
                 input = inputTmp;
             }
-            std::vector<int32_t> order(other.dim(), 0);
-            std::vector<int32_t> reverseOrder(other.dim(), 0);
+            std::vector<int32_t> order;
+            std::vector<int32_t> reverseOrder;
             getPermuteOrder(other, order, reverseOrder);
             std::vector<int64_t> cnnlInShape = changeVecAccordingToOrder(targetShape, reverseOrder);
             std::vector<int64_t> cnnlInStride = changeVecAccordingToOrder(targetStride, reverseOrder);

--- a/impl/camb/common/common.hpp
+++ b/impl/camb/common/common.hpp
@@ -35,6 +35,10 @@ bool broadcast(DiopiTensor inputTensor, const std::vector<int64_t>& targetShape,
 diopiError_t opBroadcastCast(const DiopiTensor& inputTensor, DiopiTensor& otherTensor, std::vector<int64_t>& targetShape, std::vector<int64_t>& targetStride,
                              bool& toPermuteFlag);
 
+std::vector<int64_t> changeVecAccordingToOrder(const std::vector<int64_t> vec, std::vector<int32_t> order);
+
+bool isContiguousAccordingToOrder(std::vector<int64_t> shape, std::vector<int64_t> stride, std::vector<int> order);
+
 std::vector<int64_t> calContiguousStride(std::vector<int64_t> shape);
 
 diopiError_t contiguous(diopiContextHandle_t ctx, DiopiTensor& src, diopiMemoryFormat_t memoryFormat = diopiMemoryFormat_t::Contiguous);
@@ -66,11 +70,11 @@ bool isSlice(const DiopiTensor& src);
 
 bool isSparse(const DiopiTensor& src);
 
-bool shapeHasZero(std::vector<int64_t> shape);
-
 diopiError_t permuteTensor(DiopiTensor& t, const std::vector<int32_t>& order);
 
 diopiError_t getPermuteOrder(const DiopiTensor& src, std::vector<int32_t>& orderOut, std::vector<int32_t>& reverseOrder);
+
+diopiError_t getPermuteOrder(std::vector<int64_t>& shape, std::vector<int64_t>& stride, std::vector<int32_t>& orderOut, std::vector<int32_t>& reverseOrder);
 
 diopiError_t getDenseStride(const DiopiTensor& src, std::vector<int64_t>& dstStride);
 

--- a/impl/camb/common/common.hpp
+++ b/impl/camb/common/common.hpp
@@ -68,6 +68,8 @@ bool denseCheck(const DiopiTensor& src);
 
 bool isSlice(const DiopiTensor& src);
 
+bool shapeHasZero(std::vector<int64_t> shape);
+
 bool isSparse(const DiopiTensor& src);
 
 diopiError_t permuteTensor(DiopiTensor& t, const std::vector<int32_t>& order);

--- a/impl/camb/common/common.hpp
+++ b/impl/camb/common/common.hpp
@@ -37,8 +37,6 @@ diopiError_t opBroadcastCast(const DiopiTensor& inputTensor, DiopiTensor& otherT
 
 std::vector<int64_t> changeVecAccordingToOrder(const std::vector<int64_t> vec, std::vector<int32_t> order);
 
-bool isContiguousAccordingToOrder(std::vector<int64_t> shape, std::vector<int64_t> stride, std::vector<int> order);
-
 std::vector<int64_t> calContiguousStride(std::vector<int64_t> shape);
 
 diopiError_t contiguous(diopiContextHandle_t ctx, DiopiTensor& src, diopiMemoryFormat_t memoryFormat = diopiMemoryFormat_t::Contiguous);

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -37,6 +37,7 @@ diopiError_t getPermuteOrder(const DiopiTensor& src, std::vector<int32_t>& order
     std::vector<int64_t> stride = src.stride();
     std::vector<int64_t> shape = src.shape();
     getPermuteOrder(shape, stride, orderOut, reverseOrder);
+    return diopiSuccess;
 }
 
 diopiError_t getPermuteOrder(std::vector<int64_t>& shape, std::vector<int64_t>& stride, std::vector<int32_t>& orderOut, std::vector<int32_t>& reverseOrder) {

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -48,7 +48,8 @@ diopiError_t getPermuteOrder(std::vector<int64_t>& shape, std::vector<int64_t>& 
     for (int i = 0; i < dim; ++i) {
         stridesSizes[i] = std::pair<int, int>(inputStrides[i], inputSizes[i]);
     }
-
+    orderOut.resize(dim);
+    reverseOrder.resize(dim);
     // shape:2,3,4,5 stride:60,1,15,3 -> orderOut: 0,3,1,2, reverseOrder: 0,2,3,1
     sort(stridesSizes.begin(), stridesSizes.end(), [](std::pair<int, int> a, std::pair<int, int> b) { return a.first > b.first; });
     for (int i = 0; i < dim; ++i) {

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -184,6 +184,11 @@ diopiError_t permuteCopy(diopiContextHandle_t ctx, DiopiTensor& src, DiopiTensor
     cnnlTensorLayout_t srcLayout = CNNL_LAYOUT_ARRAY;
     cnnlTensorLayout_t destLayout = CNNL_LAYOUT_ARRAY;
 
+    std::vector<int64_t> olderDestStride = dest.stride();
+    std::vector<int64_t> olderDestShape = dest.shape();
+    std::vector<int64_t> olderSrcStride = src.stride();
+    std::vector<int64_t> olderSrcShape = src.shape();
+
     // permute to get contiguous tensor
     if (!destIsContiguous) {
         DIOPI_CALL(permuteTensor(dest, outputBackOrder));
@@ -200,11 +205,11 @@ diopiError_t permuteCopy(diopiContextHandle_t ctx, DiopiTensor& src, DiopiTensor
     DIOPI_CALL(transpose(ctx, src, dest, srcLayout, destLayout, inputToOutputOrder));
 
     // recovery the shape and strides
-    if (!destIsContiguous || reduceOnes) {
+    if (!destIsContiguous) {
         dest.asStrided(olderDestShape, olderDestStride);
     }
 
-    if (!srcIsContiguous || reduceOnes) {
+    if (!srcIsContiguous) {
         src.asStrided(olderSrcShape, olderSrcStride);
     }
     return diopiSuccess;

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -215,17 +215,5 @@ diopiError_t permuteCopy(diopiContextHandle_t ctx, DiopiTensor& src, DiopiTensor
     return diopiSuccess;
 }
 
-bool isContiguousAccordingToOrder(std::vector<int64_t> shape, std::vector<int64_t> stride, std::vector<int> order) {
-    int64_t curStride = 1;
-    for (auto i : order) {
-        if (curStride != stride[i]) {
-            return false;
-        } else {
-            curStride *= shape[i];
-        }
-    }
-    return true;
-}
-
 }  // namespace camb
 }  // namespace impl

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -34,42 +34,9 @@ diopiError_t getPermuteOrder(const DiopiTensor& src, std::vector<int32_t>& order
         return diopiSuccess;
     }
 
-    int dim = src.dim();
-    std::vector<int> inputStrides(dim, 1);
-    std::vector<int> inputSizes(dim, 1);
-
-    for (int i = 0; i < dim; i++) {
-        inputStrides[i] = src.stride()[i];
-        inputSizes[i] = src.shape()[i];
-    }
-    std::vector<std::pair<int, int>> stridesSizes(dim, std::pair<int, int>(1, 1));
-    for (int i = 0; i < dim; ++i) {
-        stridesSizes[i] = std::pair<int, int>(inputStrides[i], inputSizes[i]);
-    }
-
-    // shape:2,3,4,5 stride:60,1,15,3 -> orderOut: 0,3,1,2, reverseOrder: 0,2,3,1
-    sort(stridesSizes.begin(), stridesSizes.end(), [](std::pair<int, int> a, std::pair<int, int> b) { return a.first > b.first; });
-    for (int i = 0; i < dim; ++i) {
-        auto pair = stridesSizes[i];
-        for (int j = 0; j < dim; ++j) {
-            if ((pair.first == inputStrides[j]) && (pair.second == inputSizes[j])) {
-                reverseOrder[i] = j;
-                inputStrides[j] = -1;
-                inputSizes[j] = -1;
-                break;
-            }
-        }
-    }
-
-    // 反推orderOut
-    for (int i = 0; i < dim; i++) {
-        for (int j = 0; j < dim; j++) {
-            if (reverseOrder[j] == i) {
-                orderOut[i] = j;
-            }
-        }
-    }
-    return diopiSuccess;
+    std::vector<int64_t> stride = src.stride();
+    std::vector<int64_t> shape = src.shape();
+    getPermuteOrder(shape, stride, orderOut, reverseOrder);
 }
 
 diopiError_t getPermuteOrder(std::vector<int64_t>& shape, std::vector<int64_t>& stride, std::vector<int32_t>& orderOut, std::vector<int32_t>& reverseOrder) {

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -165,34 +165,34 @@ diopiError_t permuteCopy(diopiContextHandle_t ctx, DiopiTensor& src, DiopiTensor
     // using input permute + output permute + cnnltranspose to copy
     DIOPI_CHECK(src.shape() == dest.shape(), "src's shape should be the same as dest's");
 
-    std::vector<int64_t> olderDestStride = dest.stride();
-    std::vector<int64_t> olderDestShape = dest.shape();
-    std::vector<int64_t> olderSrcStride = src.stride();
-    std::vector<int64_t> olderSrcShape = src.shape();
+    // std::vector<int64_t> olderDestStride = dest.stride();
+    // std::vector<int64_t> olderDestShape = dest.shape();
+    // std::vector<int64_t> olderSrcStride = src.stride();
+    // std::vector<int64_t> olderSrcShape = src.shape();
 
-    // reduce one first, for reducing ambiguity
-    bool reduceOnes = false;
-    for (int i = 0; i < src.dim(); i++) {
-        if (src.shape()[i] == 1) {
-            reduceOnes = true;
-            break;
-        }
-    }
+    // // reduce one first, for reducing ambiguity
+    // bool reduceOnes = false;
+    // for (int i = 0; i < src.dim(); i++) {
+    //     if (src.shape()[i] == 1) {
+    //         reduceOnes = true;
+    //         break;
+    //     }
+    // }
 
-    if (reduceOnes) {
-        std::vector<int64_t> shape;
-        std::vector<int64_t> srcStride;
-        std::vector<int64_t> destStride;
-        for (int i = 0; i < src.dim(); i++) {
-            if (src.shape()[i] != 1) {
-                shape.push_back(olderSrcShape[i]);
-                srcStride.push_back(olderSrcStride[i]);
-                destStride.push_back(olderDestStride[i]);
-            }
-        }
-        src.asStrided(shape, srcStride);
-        dest.asStrided(shape, destStride);
-    }
+    // if (reduceOnes) {
+    //     std::vector<int64_t> shape;
+    //     std::vector<int64_t> srcStride;
+    //     std::vector<int64_t> destStride;
+    //     for (int i = 0; i < src.dim(); i++) {
+    //         if (src.shape()[i] != 1) {
+    //             shape.push_back(olderSrcShape[i]);
+    //             srcStride.push_back(olderSrcStride[i]);
+    //             destStride.push_back(olderDestStride[i]);
+    //         }
+    //     }
+    //     src.asStrided(shape, srcStride);
+    //     dest.asStrided(shape, destStride);
+    // }
 
     int64_t dim = src.dim();
     DIOPI_CHECK(dim <= 8, "only support less than 8d tensor currently");

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -41,13 +41,9 @@ diopiError_t getPermuteOrder(const DiopiTensor& src, std::vector<int32_t>& order
 
 diopiError_t getPermuteOrder(std::vector<int64_t>& shape, std::vector<int64_t>& stride, std::vector<int32_t>& orderOut, std::vector<int32_t>& reverseOrder) {
     int dim = shape.size();
-    std::vector<int> inputStrides(dim, 1);
-    std::vector<int> inputSizes(dim, 1);
+    std::vector<int> inputStrides(stride.begin(), stride.end());
+    std::vector<int> inputSizes(shape.begin(), shape.end());
 
-    for (int i = 0; i < dim; i++) {
-        inputStrides[i] = stride[i];
-        inputSizes[i] = shape[i];
-    }
     std::vector<std::pair<int, int>> stridesSizes(dim, std::pair<int, int>(1, 1));
     for (int i = 0; i < dim; ++i) {
         stridesSizes[i] = std::pair<int, int>(inputStrides[i], inputSizes[i]);

--- a/impl/camb/common/contiguous.cpp
+++ b/impl/camb/common/contiguous.cpp
@@ -164,36 +164,6 @@ diopiError_t contiguous(diopiContextHandle_t ctx, DiopiTensor& src, diopiMemoryF
 diopiError_t permuteCopy(diopiContextHandle_t ctx, DiopiTensor& src, DiopiTensor& dest) {
     // using input permute + output permute + cnnltranspose to copy
     DIOPI_CHECK(src.shape() == dest.shape(), "src's shape should be the same as dest's");
-
-    // std::vector<int64_t> olderDestStride = dest.stride();
-    // std::vector<int64_t> olderDestShape = dest.shape();
-    // std::vector<int64_t> olderSrcStride = src.stride();
-    // std::vector<int64_t> olderSrcShape = src.shape();
-
-    // // reduce one first, for reducing ambiguity
-    // bool reduceOnes = false;
-    // for (int i = 0; i < src.dim(); i++) {
-    //     if (src.shape()[i] == 1) {
-    //         reduceOnes = true;
-    //         break;
-    //     }
-    // }
-
-    // if (reduceOnes) {
-    //     std::vector<int64_t> shape;
-    //     std::vector<int64_t> srcStride;
-    //     std::vector<int64_t> destStride;
-    //     for (int i = 0; i < src.dim(); i++) {
-    //         if (src.shape()[i] != 1) {
-    //             shape.push_back(olderSrcShape[i]);
-    //             srcStride.push_back(olderSrcStride[i]);
-    //             destStride.push_back(olderDestStride[i]);
-    //         }
-    //     }
-    //     src.asStrided(shape, srcStride);
-    //     dest.asStrided(shape, destStride);
-    // }
-
     int64_t dim = src.dim();
     DIOPI_CHECK(dim <= 8, "only support less than 8d tensor currently");
     bool srcIsContiguous = src.isContiguous();


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Description
由于1.23版本cnnl不支持带stride的op broadcast操作：
对于broadcast 用cnnldesc描述成contiguous进行计算(实际内存逻辑是相同的)
例如 shape[2, 4, 4] stride [1, 8, 2] + shape[2, 1, 1] stride [1, 2, 2] 
会变成 shape[4, 4, 2] stride [8, 2, 1] + shape[1, 1, 2] stride [2, 2, 1] 进行计算
结果验证正确且理论上contiguous加法性能最优


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

