### PR TITLE
Remove unnecessary sync

### DIFF
--- a/impl/ascend_npu/torch_npu/csrc/DIOPIAdapter.cpp
+++ b/impl/ascend_npu/torch_npu/csrc/DIOPIAdapter.cpp
@@ -2617,9 +2617,6 @@ void OpCommand::Run() {
     aclCmd->SetEnginePriority();
     const string& op_name = aclCmd->GetName();
     aclCmd->Run(sync, sync_index, outputTensor);
-    if (sync) {
-        Sync();
-    }
     aclCmd->releaseSource();
 }
 

--- a/impl/ascend_npu/torch_npu/csrc/DIOPIAdapter.cpp
+++ b/impl/ascend_npu/torch_npu/csrc/DIOPIAdapter.cpp
@@ -2625,7 +2625,6 @@ OpCommand& OpCommand::Sync(c10::SmallVector<int64_t, N>& index) {
     if (!index.empty()) {
         sync = true;
     }
-    Sync();
     return *this;
 }
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- According to https://github.com/Ascend/pytorch/blob/4233d6a6da519de48380df0a7a9c0d9d2f2a0955/torch_npu/csrc/framework/OpCommand.cpp#L148-L150 , synchronization is required here only if an environment variable for synchronization (ASCEND_LAUNCH_BLOCKING) is specified. Since we don't support such an environment variable, sync here is unnecessary.
- According to https://github.com/Ascend/pytorch/blob/4233d6a6da519de48380df0a7a9c0d9d2f2a0955/torch_npu/csrc/framework/OpCommand.cpp#L156-L162 ，synchronization is not required here since OpCommand::Sync(c10::SmallVector<int64_t, N> &index) is just used to set sync_idx and enable sync but not to do synchronization.


## Description
<!--- Describe your changes in detail. -->

Remove unnecessary sync

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

