### PR TITLE
Fix the add op for Ascend when input and other are different dtypes

### DIFF
--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1726,11 +1726,8 @@ diopi_configs = {
         ),
     ),
 
-    # FIXME add输入int8、uint8结果不一致
     'pointwise_binary_diff_dtype': dict(
-        # name=['add', 'mul', 'eq', 'ne', 'le',
-        #       'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
-        name=['mul', 'eq', 'ne', 'le',
+        name=['add', 'mul', 'eq', 'ne', 'le',
               'lt', 'gt', 'ge', 'logical_and', 'logical_or'],
         interface=['torch'],
         tensor_para=dict(

--- a/impl/ascend/functions/binary.cpp
+++ b/impl/ascend/functions/binary.cpp
@@ -33,9 +33,14 @@ diopiError_t diopiAdd(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
                       const diopiScalar_t* alpha) {
     AscendTensor outTensor(out);
     if (isScalarOne(alpha)) {
-        AclOpRunner<2, 1, dtypeConvertor>("Add", ctx).addInput(input).addInput(other).addOutput(out).run();
+        AclOpRunner<2, 1, dtypeConvertor>("Add", ctx).addInput(input, outTensor.dtype()).addInput(other, outTensor.dtype()).addOutput(out).run();
     } else {
-        AclOpRunner<3, 1>("AxpyV2", ctx).addInput(input).addInput(other).addConstInput(*alpha, outTensor.dtype()).addOutput(out).run();
+        AclOpRunner<3, 1>("AxpyV2", ctx)
+            .addInput(input, outTensor.dtype())
+            .addInput(other, outTensor.dtype())
+            .addConstInput(*alpha, outTensor.dtype())
+            .addOutput(out)
+            .run();
     }
 
     return diopiSuccess;


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

