### PR TITLE
zsk/fix diopi_test bug

### DIFF
--- a/diopi_test/python/codegen/case_template.py
+++ b/diopi_test/python/codegen/case_template.py
@@ -11,11 +11,10 @@ import pickle
 import pytest
 #import psutil
 import numpy as np
-from copy import deepcopy
 
 from conformance.diopi_runtime import Tensor, from_numpy_dtype, default_context
 from conformance.diopi_functions import ones_like, FunctionNotImplementedError, FunctionNotDefinedError
-from conformance.check_result import CheckResult
+from conformance.check_result import CheckResult, CheckInput, CheckOutput
 ${test_diopi_head_import}
 
 data_path = './cache'
@@ -96,7 +95,6 @@ function_paras = data_in['function_paras']
 function_kwargs = function_paras['kwargs']
 function_config = data_in['cfg']
 ignore_paras_for_input_check = ${ignore_paras_for_input_check}
-np_inputs_orign = deepcopy(function_kwargs)
 
 ${preprocess_parameters}
 
@@ -181,6 +179,9 @@ tol = ${test_compare_tol}
 # sum_to_compare
 sum_to_compare = True if 'sorted' in function_kwargs and ~function_kwargs['sorted'] else False
 tol['sum_to_compare'] = sum_to_compare
+
+inputs_origin_np = CheckResult.to_numpy(function_kwargs)
+
 try:
     dev_foward_out = ${test_diopi_func_name}(**function_kwargs)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
@@ -193,9 +194,9 @@ with open(f_out, 'rb') as f:
 
 try:
     function_kwargs_np = CheckResult.to_numpy(function_kwargs)
-    CheckResult.compare_input_dict(function_kwargs_np, np_inputs_orign, ignore_paras_for_input_check, **tol)
+    CheckInput.deep_compare(function_kwargs_np, inputs_origin_np, ignore_paras_for_input_check=ignore_paras_for_input_check, **tol)
     dev_foward_out_np = CheckResult.to_numpy(dev_foward_out)
-    CheckResult.compare_output(dev_foward_out_np, ref_foward_out, **tol)
+    CheckOutput.deep_compare(dev_foward_out_np, ref_foward_out, **tol)
 except Exception as e:
     default_context.clear_tensors()
     assert False, f'Test {function_config["name"]}: {function_config} traceback: {e}'
@@ -206,6 +207,8 @@ except Exception as e:
         r"""
 # inplace call for the function
 ${test_diopi_func_inp_remove_grad_args}
+inputs_origin_np = CheckResult.to_numpy(function_kwargs)
+
 try:
     dev_inp_forward_out = ${test_diopi_func_name}(inplace=True, **function_kwargs)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
@@ -215,9 +218,9 @@ except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
 try:
     ignore_paras_for_input_check.add('input')
     function_kwargs_np = CheckResult.to_numpy(function_kwargs)
-    CheckResult.compare_input_dict(function_kwargs_np, np_inputs_orign, ignore_paras_for_input_check, **tol)
+    CheckInput.deep_compare(function_kwargs_np, inputs_origin_np, ignore_paras_for_input_check=ignore_paras_for_input_check, **tol)
     dev_inp_forward_out_np = CheckResult.to_numpy(dev_inp_forward_out)
-    CheckResult.compare_output(dev_inp_forward_out_np, ref_foward_out, **tol)
+    CheckOutput.deep_compare(dev_inp_forward_out_np, ref_foward_out, **tol)
 except Exception as e:
     default_context.clear_tensors()
     assert False, f'Test {function_config["name"]}  inplace: {function_config} traceback: {e}'
@@ -231,10 +234,13 @@ function_kwargs = {key: value for key, value in function_kwargs.items() if key n
 
     test_manual_function_forward_call = CodeTemplate(
         r"""
+
+inputs_origin_np = CheckResult.to_numpy(function_kwargs)
+
 try:
     ManualTest.test_${test_diopi_func_name}(**function_kwargs)
     function_kwargs_np = CheckResult.to_numpy(function_kwargs)
-    CheckResult.compare_input_dict(function_kwargs_np, np_inputs_orign, ignore_paras_for_input_check)
+    CheckInput.deep_compare(function_kwargs_np, inputs_origin_np, ignore_paras_for_input_check)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))
@@ -244,6 +250,7 @@ except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
         r"""
 ${test_diopi_func_inp_remove_grad_args}
 function_kwargs.update({'inplace': True})
+inputs_origin_np = CheckResult.to_numpy(function_kwargs)
 try:
     ManualTest.test_${test_diopi_func_name}(**function_kwargs)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
@@ -269,8 +276,8 @@ backward_para["grad_outputs"] = grad_outputs
 for k, v in function_config['saved_args'].items():
     backward_para[k] = dev_foward_out[v]
 
-backward_para_compare = [item for value in backward_para.values() for item in (value if isinstance(value, list) else [value])]
-backward_para_origin = deepcopy([item.numpy() for item in backward_para_compare])
+backward_para_origin = CheckResult.to_numpy(backward_para)
+inputs_origin_np = CheckResult.to_numpy(function_kwargs)
 try:
     dev_bp_out = ${test_diopi_bp_func_name}(**function_kwargs, **backward_para)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
@@ -281,13 +288,14 @@ with open(f_bp_out, 'rb') as f:
     ref_bp_out = pickle.load(f)
 
 # checkout
+
 try:
     function_kwargs_np = CheckResult.to_numpy(function_kwargs)
-    CheckResult.compare_input_dict(function_kwargs_np, np_inputs_orign, ignore_paras_for_input_check, **tol)
-    backward_para_compare_np = CheckResult.to_numpy(backward_para_compare)
-    CheckResult.compare_input_list(backward_para_compare_np, backward_para_origin, **tol)
+    CheckInput.deep_compare(function_kwargs_np, inputs_origin_np, ignore_paras_for_input_check, **tol)
+    backward_para_compare_np = CheckResult.to_numpy(backward_para)
+    CheckInput.deep_compare(backward_para_compare_np, backward_para_origin, {}, **tol)
     dev_bp_out_np = CheckResult.to_numpy(dev_bp_out)
-    CheckResult.compare_output(dev_bp_out_np, ref_bp_out, **tol)
+    CheckOutput.deep_compare(dev_bp_out_np, ref_bp_out, **tol)
 except Exception as e:
     default_context.clear_tensors()
     assert False, f'Test {function_config["name"]} backward: {function_config} traceback: {e}'

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4173,7 +4173,7 @@ diopi_configs = {
 
     'sort': dict(
         name=["sort"],
-        interface=['torch'],
+        interface=['CustomizedTest'],
         para=dict(
             dim=[-1, 0, 1, -2, 3, -1, 0, -1, 0, 2],
             descending=[False, True, False, False, True, False, True, True, False, False],
@@ -4196,7 +4196,7 @@ diopi_configs = {
 
     'sort_same_value': dict(
         name=["sort"],
-        interface=['torch'],
+        interface=['CustomizedTest'],
         para=dict(
             dim=[-1, 0, 1],
             descending=[True, False, False],
@@ -4218,7 +4218,7 @@ diopi_configs = {
 
     'sort_no_stable': dict(
         name=["sort"],
-        interface=['torch'],
+        interface=['CustomizedTest'],
         para=dict(
             dim=[-1, 0, 1, -2, 3, -1, 0, -1, 0, 2],
             descending=[False, True, False, False, True, False, True, True, False, False],
@@ -6383,7 +6383,7 @@ diopi_configs = {
                 {
                     "ins": ['log_probs'],
                     "requires_grad": [True],
-                    "shape": ((26, 20, 38), (26, 20, 38), (26, 20, 38), (32, 20, 10)),
+                    "shape": ((26, 20, 38), (26, 20, 38), (26, 20, 38), (32, 20, 50)),
                     # "dtype": [np.float32, np.float64, np.float64, np.float32, np.float32, np.float64],
                     "dtype": [np.float32, np.float64],
                     "gen_fn": 'Genfunc.randn',
@@ -6393,7 +6393,7 @@ diopi_configs = {
                     "shape": ((20, 10), (20, 14), (20, 11), (20, 54)),
                     # "dtype": [np.int64, np.int64, np.int8, np.int16, np.int32, np.uint8],
                     "dtype": [np.int64, np.int64],
-                    "gen_fn": dict(fn='Genfunc.randint', low=1, high=80),
+                    "gen_fn": dict(fn='Genfunc.randint', low=1, high=30),
                 },
                 {
                     "ins": ['input_lengths'],
@@ -6429,7 +6429,7 @@ diopi_configs = {
                 {
                     "ins": ['log_probs'],
                     "requires_grad": [True],
-                    "shape": ((26, 10, 38), (26, 10, 38), (26, 10, 38), (32, 10, 10)),
+                    "shape": ((26, 10, 38), (26, 10, 38), (26, 10, 38), (32, 10, 40)),
                     # "dtype": [np.float32, np.float64, np.float64, np.float32, np.float32, np.float64],
                     "dtype": [np.float32, np.float64],
                     "gen_fn": 'Genfunc.randn',
@@ -6439,7 +6439,7 @@ diopi_configs = {
                     "shape": ((10, ), (10, ), (10, ), (10, )),
                     # "dtype": [np.int64, np.int64, np.int8, np.int16, np.int32, np.uint8],
                     "dtype": [np.int64, np.int64],
-                    "gen_fn": dict(fn='Genfunc.randint', low=1, high=80),
+                    "gen_fn": dict(fn='Genfunc.randint', low=1, high=30),
                 },
                 {
                     "ins": ['input_lengths'],

--- a/diopi_test/python/conformance/check_result.py
+++ b/diopi_test/python/conformance/check_result.py
@@ -1,113 +1,139 @@
 import numpy as np
 
-from conformance.diopi_runtime import Tensor
+from conformance.diopi_runtime import Tensor, is_dtype, to_numpy_dtype
 from conformance.exception import InputChangedException, OutputCheckFailedException
-from conformance.global_settings import glob_vars, default_cfg_dict
-
+from conformance.global_settings import glob_vars
+from copy import deepcopy
 
 class CheckResult(object):
 
     @staticmethod
-    def compare_input_list(input: list, input_reference: list, **kwargs):
-        if len(input) != len(input_reference):
-            raise InputChangedException(f"expect input list len {len(input_reference)} but {input}")
-
-        passed = True
-        mismatch_ratio_threshold = kwargs.get('mismatch_ratio_threshold', 1e-3)
-        for i in range(len(input)):
-            matched = np.isclose(input_reference[i], input[i], equal_nan=True)
-            mismatched_num = matched.size - np.sum(matched)
-            passed = mismatched_num <= mismatch_ratio_threshold * matched.size
-            if not passed:
-                glob_vars.func_status[glob_vars.cur_test_func] = 'failed'
-                debug_level = glob_vars.debug_level
-                error_info = f'Run {glob_vars.cur_test_func} failed, because of input of backward changed'
-                if debug_level > 1:
-                    error_info += (f"\n\texpect input: \n\t\t{input_reference[i]}\n\tbut got input reference \n\t\t{input[i]}")
-                raise InputChangedException(error_info)
-
-    @staticmethod
-    def compare_input_dict(input: dict, input_reference: dict, ignore_paras_for_input_check: list, **kwargs):
-        input = {key: value for key, value in input.items() if key not in ignore_paras_for_input_check and isinstance(value, np.ndarray)}
-        input_reference = {key: value for key, value in input_reference.items() if key not in ignore_paras_for_input_check and isinstance(value, np.ndarray)}
-        if input.keys() != input_reference.keys():
-            raise InputChangedException(f"input's keys {list(input.keys())} is not equal to input_reference's keys {list(input_reference.keys())}.")
-
-        mismatch_ratio_threshold = kwargs.get('mismatch_ratio_threshold', 1e-3)
-        passed = True
-        for name, value in input.items():
-            matched = np.isclose(input_reference[name], value, equal_nan=True)
-            mismatched_num = matched.size - np.sum(matched)
-            passed = mismatched_num <= mismatch_ratio_threshold * matched.size
-            if not passed:
-                glob_vars.func_status[glob_vars.cur_test_func] = 'failed'
-                debug_level = glob_vars.debug_level
-                error_info = f'Run {glob_vars.cur_test_func} failed, because of input\'s args: {name} changed'
-                if debug_level > 1:
-                    error_info += (f"\n\texpect input: \n\t\t{input_reference[name]}\n\tbut got input reference \n\t\t{value}")
-                raise InputChangedException(error_info)
-
-    @staticmethod
-    def compare_output(output, output_reference, **kwargs):
-        if isinstance(output, np.ndarray):
-            compare_fn = CheckResult.compare_tensor
-        elif isinstance(output, (list, tuple)):
-            compare_fn = CheckResult.compare_list
-        elif isinstance(output, dict):
-            compare_fn = CheckResult.compare_dict
-        elif isinstance(output, (int, float)):
-            compare_fn = CheckResult.compare_num
+    def to_numpy(data):
+        r"""
+        Recursively convert the tensor and scalar to numpy.
+        E.g: {"input": Tensor, "other": Tensor, "input_size": 5, "dtype": Dtype.float16} -> {"input": np.ndarray, "other": np.ndarray, "input_size": np.array(5), "dtype": np.float16}
+        """
+        if isinstance(data, Tensor):
+            data_np = data.numpy()
+        elif is_dtype(data):
+            data_np = to_numpy_dtype(data)
+        elif isinstance(data, (int, float)):
+            data_np = np.array(data)
+        elif isinstance(data, list):
+            data_np = [CheckResult.to_numpy(i) for i in data]
+        elif isinstance(data, tuple):
+            data_np = tuple(CheckResult.to_numpy(i) for i in data)
+        elif isinstance(data, dict):
+            data_np = {k: CheckResult.to_numpy(v) for k, v in data.items()}
+        elif isinstance(data, np.ndarray):
+            raise TypeError("Data type should not be ndarray, please check!")
         else:
-            raise TypeError(f'Not support output type {type(output)}')
+            data_np = deepcopy(data)
+        return data_np
+
+
+class CheckInput(CheckResult):
+    @staticmethod
+    def deep_compare(input, input_reference, ignore_paras_for_input_check={}, **kwargs):
+        if isinstance(input, np.ndarray):
+            CheckInput.compare_tensor(input, input_reference, **kwargs)
+        elif isinstance(input, (list, tuple)):
+            CheckInput.compare_list(input, input_reference, **kwargs)
+        elif isinstance(input, dict):
+            CheckInput.compare_dict(input, input_reference, ignore_paras_for_input_check, **kwargs)
+        else:
+            CheckInput.compare_others(input, input_reference, **kwargs)
+
+    @staticmethod
+    def compare_tensor(input, input_reference, **kwargs):
+        CheckInput.allclose(input, input_reference, **kwargs)
+
+    @staticmethod
+    def compare_list(input, input_reference, **kwargs):
+        if not isinstance(input_reference, (list, tuple)):
+            raise InputChangedException(f"There are elements in input that are {type(input)}, but in input_reference, they correspond to {type(input_reference)}")
+        if len(input) != len(input_reference):
+            raise InputChangedException(f"The length of input is {len(input)}, but which in input_reference is {len(input_reference)}")
+        for i in range(len(input)):
+            CheckInput.deep_compare(input[i], input_reference[i], **kwargs)
+
+    @staticmethod
+    def compare_dict(input, input_reference, ignore_paras_for_input_check, **kwargs):
+        if not isinstance(input_reference, dict):
+            raise InputChangedException(f"There are elements in input that are dicts, but in input_reference, they correspond to {type(input_reference)}")
+        if input.keys() != input_reference.keys():
+            raise InputChangedException("Input changed! The keys of input is not equal to input_reference")
+        for k, v in input.items():
+            if k not in ignore_paras_for_input_check:
+                CheckInput.deep_compare(v, input_reference[k], **kwargs)
+
+    @staticmethod
+    def compare_others(input, input_reference, **kwargs):
+        if type(input) is not type(input_reference):
+            raise InputChangedException(f"There are elements in that are {type(input)}. But those in input_reference are {type(input_reference)}")
+        if input != input_reference:
+            raise InputChangedException(f"Input changed! Expected value should be {input_reference} but get {input}")
+
+    @staticmethod
+    def allclose(input, input_reference, **kwargs):
+        passed = True
+        mismatch_ratio_threshold = kwargs.get('mismatch_ratio_threshold', 1e-3)
+        matched = np.isclose(input_reference, input, equal_nan=True)
+        mismatched_num = matched.size - np.sum(matched)
+        passed = mismatched_num <= mismatch_ratio_threshold * matched.size
+        if not passed:
+            glob_vars.func_status[glob_vars.cur_test_func] = 'failed'
+            debug_level = glob_vars.debug_level
+            error_info = f'Run {glob_vars.cur_test_func} failed, because of input changed'
+            if debug_level > 1:
+                error_info += (f"\n\texpect input: \n\t\t{input_reference}\n\tbut got input reference \n\t\t{input}")
+            raise InputChangedException(error_info)
+
+
+class CheckOutput(CheckResult):
+
+    @staticmethod
+    def deep_compare(output, output_reference, **kwargs):
+        if isinstance(output, np.ndarray):
+            compare_fn = CheckOutput.compare_tensor
+        elif isinstance(output, (list, tuple)):
+            compare_fn = CheckOutput.compare_list
+        elif isinstance(output, dict):
+            compare_fn = CheckOutput.compare_dict
+        else:
+            compare_fn = CheckOutput.compare_others
         compare_fn(output, output_reference, **kwargs)
 
     @staticmethod
     def compare_tensor(output, output_reference, **kwargs):
-        CheckResult.allclose(output, output_reference, **kwargs)
+        CheckOutput.allclose(output, output_reference, **kwargs)
 
     @staticmethod
     def compare_list(output, output_reference, **kwargs):
-        assert isinstance(output_reference, (list, tuple))
-        assert len(output) == len(output_reference)
+        if not isinstance(output_reference, (list, tuple)):
+            raise OutputCheckFailedException(f"Exist element in ouput is {type(output)}, while output_reference is {type(output_reference)}")
+        if len(output) != len(output_reference):
+            raise OutputCheckFailedException("Length of output is not equal to output_reference")
         for i in range(len(output)):
-            if isinstance(output[i], Tensor) or isinstance(output[i], np.ndarray):
-                kwargs['name'] = "out" + str(i)
-                CheckResult.allclose(output[i], output_reference[i], **kwargs)
+            kwargs['name'] = "out" + str(i)
+            CheckOutput.deep_compare(output[i], output_reference[i], **kwargs)
 
     @staticmethod
     def compare_dict(output, output_reference, **kwargs):
-        assert isinstance(output_reference, dict)
-        assert len(output) == len(output_reference)
+        if not isinstance(output_reference, dict):
+            raise OutputCheckFailedException(f"Exist element in ouput is dict, while output_reference is {type(output_reference)}")
+        if output.keys() != output_reference.keys():
+            raise OutputCheckFailedException("Key of output is not equal to output_reference")
         for k, v in output.items():
-            if isinstance(v, Tensor) or isinstance(v, np.ndarray):
-                kwargs['name'] = k
-                CheckResult.allclose(v, output_reference[k], **kwargs)
+            kwargs['name'] = k
+            CheckOutput.deep_compare(v, output_reference[k], **kwargs)
 
     @staticmethod
-    def compare_num(output, output_reference, **kwargs):
-        assert isinstance(output_reference, np.ndarray), "output_reference should be type numpy.array"
-        assert output.shape == output_reference.shape, "output and output_reference should be same shape"
-        kwargs['name'] = "scalar"
-        CheckResult.allclose(output, output_reference, **kwargs)
-
-    @staticmethod
-    def to_numpy(input):
-        r"""Switch to numpy. When the input is an iterable object, only tensors within it will be transformed.
-        E.g: {"input": Tensor, "other": Tensor, "input_size": 5} -> {"input": np.ndarray, "other": np.ndarray, "input_size": 5}
-        """
-        if isinstance(input, Tensor):
-            input_np = input.numpy()
-        elif isinstance(input, list):
-            input_np = [i.numpy() if isinstance(i, Tensor) else i for i in input]
-        elif isinstance(input, tuple):
-            input_np = tuple(i.numpy() if isinstance(i, Tensor) else i for i in input)
-        elif isinstance(input, dict):
-            input_np = {k: v.numpy() if isinstance(v, Tensor) else v for k, v in input.items()}
-        elif isinstance(input, (int, float)):
-            input_np = np.array(input)
-        else:
-            raise TypeError(f'Not support output type {type(input)}')
-        return input_np
+    def compare_others(output, output_reference, **kwargs):
+        if type(output) is not type(output_reference):
+            raise OutputCheckFailedException(f"There are elements in that are {type(output)}. But those in output_reference are {type(output_reference)}")
+        if output != output_reference:
+            raise OutputCheckFailedException(f"output changed! Expected value should be {output_reference} but get {output}")
 
     @staticmethod
     def allclose(tensor_dev: np.ndarray, tensor_ref: np.ndarray, **kwargs) -> bool:

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -1491,7 +1491,7 @@ def sort(input, dim=-1, descending=False, stable=None):
             for i in idx:
                 res = res[i]
             temp_vals.append(res)
-        return vals, temp_vals
+        return vals
     return vals, indices
 
 
@@ -4340,7 +4340,7 @@ def ctc_loss_backward(
     return {
         "log_probs": log_softmax_backward(
             log_probs, [grad_input], log_probs_, 2
-        )
+        )["input"]
     }
 
 

--- a/diopi_test/python/conformance/diopi_runtime.py
+++ b/diopi_test/python/conformance/diopi_runtime.py
@@ -134,6 +134,10 @@ def to_numpy_dtype(dtype: Dtype) -> np.dtype:
         return None
 
 
+def is_dtype(dtype) -> bool:
+    return isinstance(dtype, Dtype)
+
+
 def compute_nhwc_stride_2d(sizes, itemsize=1):
     dim = len(sizes)
     strides = [itemsize for i in range(dim)]

--- a/diopi_test/python/conformance/gen_output.py
+++ b/diopi_test/python/conformance/gen_output.py
@@ -218,7 +218,10 @@ class CustomizedTest(object):
 
     def batch_norm_backward_reduce(grad_output, input, mean, invstd, weight, input_g, weight_g, bias_g):
         sum_dy, sum_dy_xmu, grad_weight, grad_bias = torch.batch_norm_backward_reduce(grad_output, input, mean, invstd, weight, input_g, weight_g, bias_g)
-        out = (sum_dy, sum_dy_xmu, grad_weight, grad_bias)
+        if input_g:
+            out = (sum_dy, sum_dy_xmu, grad_weight, grad_bias)
+        else:
+            out = (None, None, grad_weight, grad_bias)
         return out
 
     def batch_norm_backward_elemt(grad_out, input, mean, invstd, weight, sum_dy, sum_dy_xmu, count):
@@ -255,6 +258,15 @@ class CustomizedTest(object):
         out = weight * inp
 
         return (out, inv_rms)
+
+    def sort(input, dim, descending, stable=False):
+        # Skip compare while stable==False
+        sizeI = input.size()
+        sorted, indices = torch.sort(input, dim=dim, descending=descending, stable=stable)
+        if len(sizeI) > 0 and not stable:
+            return sorted
+        else:
+            return sorted, indices
 
     def multihead_attention(q, k, v, dropout_p, is_causal, return_debug_mask, scale):
         # 为了保证精度，因此在test的时候不使用dropout

--- a/impl/camb/device_configs.py
+++ b/impl/camb/device_configs.py
@@ -1292,14 +1292,14 @@ device_configs = {
     'ctc_loss': dict(
         name=["ctc_loss"],
         para=dict(
-            blank=[Skip(0), Skip(9)]
+            blank=[Skip(9)]
         ),
     ),
 
     'ctc_loss_un_padded': dict(
         name=["ctc_loss"],
         para=dict(
-            blank=[Skip(0), Skip(9)]
+            blank=[Skip(9)]
         ),
     ),
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
check_result原来只比较一层，并且只比较其中的tensor，现在用递归重写
## Description
<!--- Describe your changes in detail. -->
### diopi-test修改：

1. 使用递归重写check_result, 并且分离 input 和 output 的比较
出现部分算子问题，[#1035 ](https://github.com/DeepLink-org/DIOPI/pull/1035)中修复一部分，剩下的在这个pr修复

2. 修复check_result_test

### 算子修复：
#### grad_norm_reduce
bug: diopi_functions中 sum_dy, sum_dy_xmu 可能会返回None，但参考值是tensor
fix: inut_g == false 时不应计算input的grad，所以把参考数据相关值也改成None
#### ctc_loss
bug: 这个算子返回的dict多套了一层，但是解开后还是结果不对
fix: 测例有问题，target应该<=classes，已修改
camb目前能解开一部分，但不能完全通过，测试发现是blank!=0时结果不对齐，应该是camb实现存在问题
#### sort
fix: 改成 no stable情况下不进行比较
## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

