### PR TITLE
fix: remove a leading space when checking compute capability

### DIFF
--- a/impl/torch/functions/functions_ext/flash-attention/CMakeLists.txt
+++ b/impl/torch/functions/functions_ext/flash-attention/CMakeLists.txt
@@ -2,6 +2,8 @@
 CUDA_DETECT_INSTALLED_GPUS(CURRENT_GPU_LIST)
 
 foreach(CC ${CURRENT_GPU_LIST})
+  string(STRIP "${CC}" CC) # remove leading spaces
+
   # See https://developer.nvidia.com/cuda-gpus#compute for Compute Capability
   if(CC VERSION_GREATER_EQUAL 8.0) # Ampere
     set(ENABLE_TORCH_EXT_FLASH_ATTN ON)


### PR DESCRIPTION
## Description

当前 CMakeLists.txt 中 `CUDA_DETECT_INSTALLED_GPUS` 的返回值存在一个前置空格，会影响对 compute capability 的版本判断，这里在判断之前手动移除掉。
