### PR TITLE
opt cat op

### DIFF
--- a/impl/ascend_npu/diopi_impl/cat.cpp
+++ b/impl/ascend_npu/diopi_impl/cat.cpp
@@ -29,7 +29,7 @@ diopiError_t diopiCat(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiCo
         if (!tensorAt.defined() || tensorAt.numel() <= 0) {
             continue;
         }
-        tensorsAt.push_back(tensorAt.to(outTempAt.scalar_type()));
+        tensorsAt.push_back(tensorAt);
     }
     if (!tensorsAt.empty()) {
         if (false) {

--- a/impl/ascend_npu/diopi_impl/cat.cpp
+++ b/impl/ascend_npu/diopi_impl/cat.cpp
@@ -14,13 +14,6 @@ namespace OP_IMPL_NS {
 diopiError_t diopiCat(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t* tensors, int64_t numInputs, int64_t dim) {
     BEGIN_CALL_ACL_OP(out);
     at::Tensor outTempAt = outAt;
-    if (false) {
-        if (outAt.scalar_type() == at::kDouble) {
-            outTempAt = outAt.to(at::kFloat);
-        } else if (outAt.scalar_type() == at::kLong) {
-            outTempAt = outAt.to(at::kInt);
-        }
-    }
 
     std::vector<at::Tensor> tensorsAt;
     tensorsAt.reserve(numInputs);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Description
opt cat op: rm useless code
origin:
![image](https://github.com/DeepLink-org/DIOPI/assets/14268623/b5b45147-708e-4966-ad99-cf5ebc5e9f5a)
![image](https://github.com/DeepLink-org/DIOPI/assets/14268623/67f6ead9-d3d1-44b3-a2dd-0144561eec87)

after opt:
![image](https://github.com/DeepLink-org/DIOPI/assets/14268623/067a01ce-ec71-4798-b538-dc9ed50ef673)
![image](https://github.com/DeepLink-org/DIOPI/assets/14268623/ac4fb93f-fb43-4169-8630-24572961e8b9)

Reduce 106 times operator aten::to() in model internLM 1B.


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

