### PR TITLE
Remove unnecessary dtype cast for diopiSqrt, diopiSqrtInp on Ascend

### DIFF
--- a/impl/ascend/convert_config.yaml
+++ b/impl/ascend/convert_config.yaml
@@ -169,12 +169,6 @@
 - diopiGroupNormBackward:
     dtype: (float64)->float32
 
-- diopiSqrt:
-    dtype: (int8, int16, int32, int64, uint8, uint16, uint32, uint64, bool)->float32
-
-- diopiSqrtInp:
-    dtype: (int8, int16, int32, int64, uint8, uint16, uint32, uint64, bool)->float32
-
 - diopiLayerNorm:
     dtype: (float64)->float32
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

aclnnSqrt supports more dtypes than acl_op. So dtype cast is unnecessary for the sqrt op on Ascend.


## Description
<!--- Describe your changes in detail. -->

Remove unnecessary dtype cast for diopiSqrt, diopiSqrtInp on Ascend


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

