### PR TITLE
yb/fix fa

### DIFF
--- a/impl/ascend_npu/diopi_impl/functions_ext/flash_attention.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/flash_attention.cpp
@@ -4,10 +4,6 @@
  * @copyright  (c) 2024, DeepLink.
  */
 
-#include <ATen/core/TensorBody.h>
-#include <c10/core/Device.h>
-#include <c10/util/Optional.h>
-
 #include "../helper.hpp"
 #include "op_plugin/OpApiInterface.h"
 #include "op_plugin/utils/op_api_common.h"
@@ -160,8 +156,8 @@ diopiError_t diopiFlashAttentionBackward(diopiContextHandle_t ctx, diopiTensorHa
                                          double pDropout, double softmaxScale, int64_t headNum, const char* inputLayout) {
     BEGIN_CALL_ACL_OP(q, k, v, attentionOut, softmaxMax, softmaxSum, softmaxOut, gradQ, gradK, gradV, gradOut);
 
-    c10::optional<at::Tensor> dropoutMaskAt;
-    c10::optional<at::Tensor> attentionMaskAt;
+    at::Tensor dropoutMaskAt;
+    at::Tensor attentionMaskAt;
     if (dropoutMask) {
         dropoutMaskAt = impl::aten::buildATen(dropoutMask);
     }

--- a/impl/ascend_npu/diopi_impl/functions_ext/flash_attention.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/flash_attention.cpp
@@ -4,6 +4,10 @@
  * @copyright  (c) 2024, DeepLink.
  */
 
+#include <ATen/core/TensorBody.h>
+#include <c10/core/Device.h>
+#include <c10/util/Optional.h>
+
 #include "../helper.hpp"
 #include "op_plugin/OpApiInterface.h"
 #include "op_plugin/utils/op_api_common.h"
@@ -154,8 +158,16 @@ diopiError_t diopiFlashAttentionBackward(diopiContextHandle_t ctx, diopiTensorHa
                                          diopiConstTensorHandle_t attentionOut, diopiConstTensorHandle_t attentionMask, diopiConstTensorHandle_t dropoutMask,
                                          diopiConstTensorHandle_t softmaxMax, diopiConstTensorHandle_t softmaxSum, diopiConstTensorHandle_t softmaxOut,
                                          double pDropout, double softmaxScale, int64_t headNum, const char* inputLayout) {
-    BEGIN_CALL_ACL_OP(q, k, v, attentionOut, attentionMask, dropoutMask, softmaxMax, softmaxSum, softmaxOut, gradQ, gradK, gradV, gradOut);
+    BEGIN_CALL_ACL_OP(q, k, v, attentionOut, softmaxMax, softmaxSum, softmaxOut, gradQ, gradK, gradV, gradOut);
 
+    c10::optional<at::Tensor> dropoutMaskAt;
+    c10::optional<at::Tensor> attentionMaskAt;
+    if (dropoutMask) {
+        dropoutMaskAt = impl::aten::buildATen(dropoutMask);
+    }
+    if (attentionMask) {
+        attentionMaskAt = impl::aten::buildATen(attentionMask);
+    }
     DIOPI_CHECK(qAt.dim() == 3 || qAt.dim() == 4, "The shapes of the input query should be 3-dimensional or 4-dimensional");
     DIOPI_CHECK(kAt.dim() == 3 || kAt.dim() == 4, "The shapes of the input key should be 3-dimensional or 4-dimensional");
     DIOPI_CHECK(vAt.dim() == 3 || vAt.dim() == 4, "The shapes of the input value should be 3-dimensional or 4-dimensional");


### PR DESCRIPTION
## Motivation and Context
fix the issue that we can't pass dropoutMask and attentionMask as nullptr to `diopiFlashAttentionBackward`  

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

