### PR TITLE
[Ascend] fuj / fix rotary_embedding and getDefaultGenerator

### DIFF
--- a/impl/ascend_npu/diopi_impl/functions_ext/rms_norm.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/rms_norm.cpp
@@ -15,7 +15,9 @@ namespace OP_IMPL_NS {
 diopiError_t diopiRMSNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t invRms, diopiConstTensorHandle_t input,
                           diopiSize_t normalizedShape, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, double eps) {
     BEGIN_CALL_ACL_OP(out, invRms, input, weight);
-    TORCH_CHECK(1 == normalizedShape.len && normalizedShape.data[0] == inputAt.size(inputAt.dim() - 1), "normalized shape error!");
+    TORCH_CHECK(
+        1 == normalizedShape.len && normalizedShape.data[0] == inputAt.size(inputAt.dim() - 1) || normalizedShape.len == 0 || normalizedShape.data == nullptr,
+        "normalized shape is not supported on ascend!");
 
     std::tuple<at::Tensor, at::Tensor> result;
     if (false) {
@@ -39,8 +41,9 @@ diopiError_t diopiRMSNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t 
                                   diopiConstTensorHandle_t gradOutput, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
                                   diopiConstTensorHandle_t bias, diopiConstTensorHandle_t invRms, diopiSize_t normalizedShape, double eps) {
     BEGIN_CALL_ACL_OP(gradInput, gradWeight, gradOutput, input, weight, invRms);
-    TORCH_CHECK(1 == normalizedShape.len && normalizedShape.data[0] == inputAt.size(inputAt.dim() - 1), "normalized shape error!");
-
+    TORCH_CHECK(
+        1 == normalizedShape.len && normalizedShape.data[0] == inputAt.size(inputAt.dim() - 1) || normalizedShape.len == 0 || normalizedShape.data == nullptr,
+        "normalized shape is not supported on ascend!");
     at::Tensor invRmsTempAt = invRmsAt;
     if (invRmsAt.scalar_type() != at::kFloat) {
         invRmsTempAt = invRmsAt.to(at::kFloat);

--- a/impl/ascend_npu/diopi_impl/functions_ext/rotary_embedding.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/rotary_embedding.cpp
@@ -24,7 +24,7 @@ at::Tensor viewAs4D(const at::Tensor& input) {
     for (int i = 0; i < dim; ++i) {
         viewShape[i + n - dim] = inputShape[i];
     }
-    return input.view(viewShape);
+    return impl::aten::viewStorage(input, viewShape);
 }
 
 DIOPI_API diopiError_t diopiRotaryEmbedding(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t x, diopiConstTensorHandle_t cos,

--- a/impl/ascend_npu/torch_npu/csrc/DIOPIAdapter.cpp
+++ b/impl/ascend_npu/torch_npu/csrc/DIOPIAdapter.cpp
@@ -2932,7 +2932,12 @@ thread_local static at::Generator gDiopiGenerator[16];
 
 namespace detail {
 
-const at::Generator& getDefaultNPUGenerator(c10::DeviceIndex device_index) { return gDiopiGenerator[device_index]; }
+const at::Generator& getDefaultNPUGenerator(c10::DeviceIndex device_index) {
+    if (device_index == -1) {
+        device_index = current_device();
+    }
+    return gDiopiGenerator[device_index];
+}
 
 }  // namespace detail
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. fix rotary_embedding: using impl::aten::viewStorage instead of .view
2. add getDefaultGenerator

## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

