### PR TITLE
opt setCurrentStream function

### DIFF
--- a/impl/torch/helper.hpp
+++ b/impl/torch/helper.hpp
@@ -64,7 +64,7 @@ inline void setCurStream(diopiContextHandle_t ctx) {
     int device_id = c10::cuda::current_device();
     TORCH_CHECK(device_id >= 0 && device_id < MAX_GPU_NUMS, "device_id is out of range");
 
-    // Reduce the number of calls to c10::cuda::setCurrentCUDAStream. Only the current stream for the device is not the same as the stream_handle, set the stream. 
+    // Reduce the number of calls to setCurrentCUDAStream. Only the current stream for the device is not the same as the stream_handle, set the stream.
     if (current_streams[device_id] != stream_handle) {
         c10::cuda::CUDAStream cur_stream = c10::cuda::getStreamFromExternal(static_cast<cudaStream_t>(stream_handle), device_id);
         c10::cuda::setCurrentCUDAStream(cur_stream);

--- a/impl/torch/helper.hpp
+++ b/impl/torch/helper.hpp
@@ -54,16 +54,16 @@ namespace impl {
 namespace aten {
 
 
-static const size_t MAX_NUM_GPUS = 32;
+static const size_t MAX_GPU_NUMS = 32;
 
 inline void setCurStream(diopiContextHandle_t ctx) {
-    static thread_local std::array<diopiStreamHandle_t, MAX_NUM_GPUS> current_streams = {};
+    static thread_local std::array<diopiStreamHandle_t, MAX_GPU_NUMS> current_streams = {};
 
     diopiStreamHandle_t stream_handle;
     diopiGetStream(ctx, &stream_handle);
 
     int device_id = c10::cuda::current_device();
-    TORCH_CHECK(device_id >= 0 && device_id < MAX_NUM_GPUS, "device_id is out of range");
+    TORCH_CHECK(device_id >= 0 && device_id < MAX_GPU_NUMS, "device_id is out of range");
 
     if (!current_streams[device_id] || current_streams[device_id] != stream_handle) {
         c10::cuda::CUDAStream cur_stream = c10::cuda::getStreamFromExternal(static_cast<cudaStream_t>(stream_handle), device_id);

--- a/impl/torch/helper.hpp
+++ b/impl/torch/helper.hpp
@@ -53,8 +53,7 @@ namespace impl {
 
 namespace aten {
 
-
-static const size_t MAX_GPU_NUMS = 32;
+constexpr size_t MAX_GPU_NUMS = 16;
 
 inline void setCurStream(diopiContextHandle_t ctx) {
     static thread_local std::array<diopiStreamHandle_t, MAX_GPU_NUMS> current_streams = {};
@@ -65,7 +64,8 @@ inline void setCurStream(diopiContextHandle_t ctx) {
     int device_id = c10::cuda::current_device();
     TORCH_CHECK(device_id >= 0 && device_id < MAX_GPU_NUMS, "device_id is out of range");
 
-    if (!current_streams[device_id] || current_streams[device_id] != stream_handle) {
+    // Reduce the number of calls to c10::cuda::setCurrentCUDAStream. Only the current stream for the device is not the same as the stream_handle, set the stream. 
+    if (current_streams[device_id] != stream_handle) {
         c10::cuda::CUDAStream cur_stream = c10::cuda::getStreamFromExternal(static_cast<cudaStream_t>(stream_handle), device_id);
         c10::cuda::setCurrentCUDAStream(cur_stream);
         current_streams[device_id] = stream_handle;


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve performance by reducing the number of calls to the setCurStream() function.

ref: #1224

## Description
<!--- Describe your changes in detail. -->

降低函数setCurStream的调用量。在resnet50上进行测试，性能有提升。通过对优化之前的代码和优化之后的代码进行测试，展示优化后的效果，整体进行了两轮测试。
纵坐标Time：模型运行1个step耗时。
横坐标Step。
橙色是优化后的代码，蓝色是优化前的代码。整体趋势上优化后耗时有降低，性能有提升。

![image](https://github.com/DeepLink-org/DIOPI/assets/14268623/ceca722b-9929-4894-8b9f-9f38eb050376)
![image](https://github.com/DeepLink-org/DIOPI/assets/14268623/46ca4e13-3b11-4b06-8cad-e0890b72fa7d)

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

