### PR TITLE
[Ascend] fix diopiEqual for ascend+kunpeng

### DIFF
--- a/impl/ascend_npu/diopi_impl/equal.cpp
+++ b/impl/ascend_npu/diopi_impl/equal.cpp
@@ -13,7 +13,9 @@ diopiError_t diopiEqual(diopiContextHandle_t ctx, bool* out, diopiConstTensorHan
     BEGIN_CALL_ACL_OP(input, other);
     at::Tensor outAt = at_npu::native::empty_npu({1}, inputAt.options().dtype(at::kBool));
     EXEC_NPU_CMD(aclnnEqual, inputAt, otherAt, outAt);
-    *out = outAt.item().toBool();
+    // TODO(chenchiyu): using outAt.item<bool>() directly would cause ACL stream synchronize failed on a+k platform.
+    // We should find a better way to remove the dispatch cost of .cpu().
+    *out = outAt.cpu().item<bool>();
     END_CALL_ACL_OP();
 }
 


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DiopiEqual is used by calling torch.equal from torch_dipu. On ascend+kunpeng platform, when it's called second time, there would be a runtime error 'ACL stream synchronize failed'. 

## Description
<!--- Describe your changes in detail. -->
Fix the implementation of diopiEqual on ascend by adding `.cpu()` after outAt first and then using `.item<bool>()`.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

