### PR TITLE
[ascend] Optimise diopiFlashAttentionVarLen

### DIFF
--- a/impl/ascend_npu/diopi_impl/functions_ext/flash_attention_varlen.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/flash_attention_varlen.cpp
@@ -174,6 +174,10 @@ diopiError_t diopiFlashAttentionVarLenBackward(diopiContextHandle_t ctx, diopiTe
     int64_t nextTokens = 0;
     int64_t innerPrecise = 0;
     int64_t sparseMode = 0;
+    // Improve performance, ref: https://www.hiascend.com/document/detail/zh/Pytorch/60RC1/apiref/apilist/ptaoplist_000742.html
+    if (maxSeqLenQ > 2048 && maxSeqLenKV > 2048 && attentionMaskAt.defined() && attentionMaskAt.size(0) == 2048 && attentionMaskAt.size(1) == 2048) {
+        sparseMode = 2;
+    }
 
     EXEC_NPU_NO_FORMAT_CHECK_CMD(aclnnFlashAttentionUnpaddingScoreGrad,
                                  qAt,

--- a/impl/ascend_npu/diopi_impl/functions_ext/flash_attention_varlen.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/flash_attention_varlen.cpp
@@ -69,6 +69,8 @@ diopiError_t diopiFlashAttentionVarLen(diopiContextHandle_t ctx, diopiTensorHand
     int64_t sparseMode = 0;
     at::Tensor attentionMaskAt = at::Tensor();
     if (isCausal) {
+        // According to Huawei documentation, when the attentionMask shape is greater than 2048 * 2048, sparseMode=2 can be adjusted to reduce the memory usage:
+        // https://www.hiascend.com/document/detail/zh/Pytorch/60RC1/apiref/apilist/ptaoplist_000742.html
         if (maxSeqLenQ > 2048 && maxSeqLenKV > 2048) {
             maxSeqLenQ = 2048;
             maxSeqLenKV = 2048;

--- a/impl/ascend_npu/diopi_impl/functions_ext/flash_attention_varlen.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/flash_attention_varlen.cpp
@@ -66,8 +66,14 @@ diopiError_t diopiFlashAttentionVarLen(diopiContextHandle_t ctx, diopiTensorHand
         }
     }
 
+    int64_t sparseMode = 0;
     at::Tensor attentionMaskAt = at::Tensor();
     if (isCausal) {
+        if (maxSeqLenQ > 2048 && maxSeqLenKV > 2048) {
+            maxSeqLenQ = 2048;
+            maxSeqLenKV = 2048;
+            sparseMode = 2;
+        }
         attentionMaskAt = npu_preparation::apply_tensor_without_format({maxSeqLenQ, maxSeqLenKV}, qAt.options().dtype(at::kBool));
         EXEC_NPU_CMD(aclnnInplaceOne, attentionMaskAt);
         int64_t diagonal = 1;
@@ -77,7 +83,6 @@ diopiError_t diopiFlashAttentionVarLen(diopiContextHandle_t ctx, diopiTensorHand
     int64_t preTokens = kAt.size(0);
     int64_t nextTokens = 0;
     int64_t innerPrecise = 0;
-    int64_t sparseMode = 0;
 
     at::Tensor softmaxMaxAt;
     at::Tensor softmaxSumAt;

--- a/impl/ascend_npu/diopi_impl/functions_ext/flash_attention_varlen.cpp
+++ b/impl/ascend_npu/diopi_impl/functions_ext/flash_attention_varlen.cpp
@@ -174,7 +174,8 @@ diopiError_t diopiFlashAttentionVarLenBackward(diopiContextHandle_t ctx, diopiTe
     int64_t nextTokens = 0;
     int64_t innerPrecise = 0;
     int64_t sparseMode = 0;
-    // Improve performance, ref: https://www.hiascend.com/document/detail/zh/Pytorch/60RC1/apiref/apilist/ptaoplist_000742.html
+    // According to Huawei documentation, when the attentionMask shape is greater than 2048 * 2048, sparseMode=2 can be adjusted to reduce the memory usage:
+    // https://www.hiascend.com/document/detail/zh/Pytorch/60RC1/apiref/apilist/ptaoplist_000742.html
     if (maxSeqLenQ > 2048 && maxSeqLenKV > 2048 && attentionMaskAt.defined() && attentionMaskAt.size(0) == 2048 && attentionMaskAt.size(1) == 2048) {
         sparseMode = 2;
     }


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Description
<!--- Describe your changes in detail. -->

根据华为[文档](https://www.hiascend.com/document/detail/zh/Pytorch/60RC1/apiref/apilist/ptaoplist_000742.html) 可知，当diopiFlashAttentionVarLen的参数maxSeqLenQ/maxSeqLenKV比较大的时候，可以通过调整sparseMode去优化处理逻辑，降低attentionMask占用显存大小。
现存在attentionMask的shape是(256k, 256k)的任务，attentionMask占用64G*itemsize的空间。因此参考[mindspeed的逻辑](https://gitee.com/ascend/MindSpeed/blob/master/mindspeed/model/transformer.py#L335) ，通过调整sparseMode降低显存占用。

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->
测试：https://aicarrier.feishu.cn/wiki/MiQ0wxCLNiR7vxkZfbAc336Vnuh

## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

