### PR TITLE
[Ascend] fix cmake build for ascend

### DIFF
--- a/impl/ascend_npu/CMakeLists.txt
+++ b/impl/ascend_npu/CMakeLists.txt
@@ -99,8 +99,8 @@ set(ASCEND_IMPL_DIR
   ${CMAKE_CURRENT_SOURCE_DIR}/torch_npu/csrc/impl/
 )
 
-set(DIOPI_IMPL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/diopi_impl/)
-file(GLOB DIOPI_IMPL_SRC "${DIOPI_IMPL_DIR}/*.cpp" "${DIOPI_IMPL_DIR}/functions_ext/*.cpp")
+set(ASCEND_NPU_DIOPI_IMPL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/diopi_impl/)
+file(GLOB DIOPI_IMPL_SRC "${ASCEND_NPU_DIOPI_IMPL_DIR}/*.cpp" "${ASCEND_NPU_DIOPI_IMPL_DIR}/functions_ext/*.cpp")
 
 add_definitions(-DBUILD_LIBTORCH)
 


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cmake build failed for ascend since commit: https://github.com/DeepLink-org/DIOPI/commit/384d2ea7db6717b1747857b3c34d2c00b75eda5d

The reason is that DIOPI_IMPL_DIR is resetted in `impl/ascend_npu/CMakeLists.txt` in stead of the value in  `impl/CMakeLists.txt`.
See: https://github.com/DeepLink-org/DIOPI/blob/384d2ea7db6717b1747857b3c34d2c00b75eda5d/impl/CMakeLists.txt#L15
https://github.com/DeepLink-org/DIOPI/blob/384d2ea7db6717b1747857b3c34d2c00b75eda5d/impl/ascend_npu/CMakeLists.txt#L102

## Description
<!--- Describe your changes in detail. -->
fix: rename variable `DIOPI_IMPL_DIR` into `ASCEND_NPU_DIOPI_IMPL_DIR` in ascend_npu CMakeLists.txt

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

