### PR TITLE
Enhance diopiSize export

### DIFF
--- a/diopi_test/diopi_stub/csrc/export_runtime.cpp
+++ b/diopi_test/diopi_stub/csrc/export_runtime.cpp
@@ -108,6 +108,9 @@ PYBIND11_MODULE(export_runtime, m) {
 
     py::class_<diopiSize_t>(m, "diopiSize")
         .def(py::init<>())
+        .def(py::init([](py::none, int64_t nums) {
+            return diopiSize_t{nullptr, nums};
+        }))
         .def(py::init([](py::list& sizeList, int64_t nums) {
             int64_t* sizes = new int64_t[nums];
             for (int i = 0; i < nums; ++i) sizes[i] = sizeList[i].cast<int64_t>();

--- a/diopi_test/python/conformance/diopi_runtime.py
+++ b/diopi_test/python/conformance/diopi_runtime.py
@@ -223,7 +223,7 @@ default_context = Context()
 
 class Sizes(diopiSize):
     def __init__(self, shape=()):
-        super(Sizes, self).__init__(list(shape), len(shape))
+        super(Sizes, self).__init__(list(shape) if shape else None, len(shape))
         self.shape = self.data
 
 


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

diopiSize export in diopi_test doesn't support initialization with (None, 0).

So when input is an empty list, the constructed diopiSize is actually initialized with ([], 0), which has a non-nullptr `data` but a `len` of 0 in C++ code. It may cause misuse and bugs, for example, see https://github.com/DeepLink-org/DIOPI/pull/1277/files#diff-01a5bfe45e300b8d2d104eb75e2facb03b839f086b82d5c01b5b3a5eec9df3b7R21

## Description
<!--- Describe your changes in detail. -->

Enhance diopiSize export to support initializing with (None, 0) for diopi_test

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

