### PR TITLE
Fix batch_norm_backward return values to respect requires_grad settings

### DIFF
--- a/diopi_test/python/codegen/case_template.py
+++ b/diopi_test/python/codegen/case_template.py
@@ -272,6 +272,7 @@ f_bp_out = os.path.join(data_path, '${test_module_name}', 'outputs', '${bp_outpu
 if not isinstance(dev_foward_out, (list, tuple)):
     dev_foward_out = [dev_foward_out]
 requires_backward = function_config['requires_backward']
+requires_grad = function_paras.get("requires_grad", {})
 outputs_for_backward = dev_foward_out if len(requires_backward) == 0 \
     else [dev_foward_out[i] for i in requires_backward]
 backward_para = {}
@@ -283,7 +284,7 @@ for k, v in function_config['saved_args'].items():
 backward_para_origin = CheckResult.to_numpy(backward_para)
 inputs_origin_np = CheckResult.to_numpy(function_kwargs)
 try:
-    dev_bp_out = ${test_diopi_bp_func_name}(**function_kwargs, **backward_para)
+    dev_bp_out = ${test_diopi_bp_func_name}(**function_kwargs, **backward_para, requires_grad=requires_grad)
 except (FunctionNotImplementedError, FunctionNotDefinedError) as e:
     default_context.clear_tensors()
     pytest.xfail(str(e))

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -2943,7 +2943,14 @@ def batch_norm_backward(
         ), "if not trainging, running_mean and running_var must be defined"
     # running_mean = running_mean if running_mean is None else running_mean
     # running_var = running_var if running_var is None else running_var
-    out = {"input": grad_input, "weight": grad_weight, "bias": grad_bias}
+
+    requires_grad = kwargs.get("requires_grad", {})
+    out = {
+        k: v
+        for k, v in zip(["input", "weight", "bias"], [grad_input, grad_weight, grad_bias])
+        if requires_grad.get(k, False)
+    }
+
     func = check_function("diopiBatchNormBackward")
     grad_output = grad_outputs[0]
     ret = func(


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change addresses an issue with the `batch_norm_backward` function where it was returning unnecessary gradients even when `requires_grad` was not set for some parameters. By respecting the `requires_grad` settings, we ensure that only the required gradients are computed and returned.


## Description
<!--- Describe your changes in detail. -->
- Modified the `batch_norm_backward` function to ensure that gradients are only included in the return dictionary if `requires_grad` is set to True for the respective parameters.
- Updated the test template to correctly handle and pass `requires_grad` information from `function_paras`.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

