### PR TITLE
Fix backward operator return values to respect requires_grad settings

### DIFF
--- a/diopi_test/diopi_stub/csrc/litert.cpp
+++ b/diopi_test/diopi_stub/csrc/litert.cpp
@@ -121,8 +121,8 @@ const char* deviceToStr(const diopiDevice_t device) {
 }
 
 diopiTensor::diopiTensor(const diopiSize_t* shape, const diopiSize_t* stride, diopiDtype_t dtype, diopiDevice_t device, diopiContextHandle_t context,
-                         const void* src, Layout layout)
-    : dtype_(dtype), device_(device), context_(context), layout_(layout) {
+                         const void* src, diopiLayout layout, bool requires_grad)
+    : dtype_(dtype), device_(device), context_(context), layout_(layout), requires_grad_(requires_grad) {
     assert(shape);
 
     shape_.resize(shape->len);
@@ -272,7 +272,7 @@ DIOPI_RT_API diopiError_t diopiGetCurrentDeviceIndex(diopiDeviceIndex_t* pDevInd
 }
 
 DIOPI_RT_API diopiError_t diopiIsTensorSparse(diopiConstTensorHandle_t th, bool* is_sparse) {
-    *is_sparse = th->is_sparse();
+    *is_sparse = th->isSparse();
     return diopiSuccess;
 }
 
@@ -281,7 +281,7 @@ DIOPI_RT_API diopiError_t diopiGetTensorCrowIndices(diopiConstTensorHandle_t th,
     if (!spTh) {
         return diopiErrorOccurred;
     }
-    *crow_indices = spTh->get_crow_indices();
+    *crow_indices = spTh->getCrowIndices();
     return diopiSuccess;
 }
 
@@ -290,7 +290,7 @@ DIOPI_RT_API diopiError_t diopiGetTensorColIndices(diopiConstTensorHandle_t th, 
     if (!spTh) {
         return diopiErrorOccurred;
     }
-    *col_indices = spTh->get_col_indices();
+    *col_indices = spTh->getColIndices();
     return diopiSuccess;
 }
 
@@ -299,7 +299,7 @@ DIOPI_RT_API diopiError_t diopiGetTensorValues(diopiConstTensorHandle_t th, diop
     if (!spTh) {
         return diopiErrorOccurred;
     }
-    *values = spTh->get_values();
+    *values = spTh->getValues();
     return diopiSuccess;
 }
 

--- a/diopi_test/python/codegen/case_template.py
+++ b/diopi_test/python/codegen/case_template.py
@@ -154,7 +154,8 @@ for para_key, para_val in function_kwargs.items():
     if isinstance(para_val, np.ndarray):
         sparse = is_sparse(para_key, function_config)
         sparse_format = function_config.get('sparse_format', None)
-        function_kwargs[para_key] = Tensor.from_numpy(para_val, is_sparse=sparse, sparse_format=sparse_format) 
+        requires_grad = function_paras.get("requires_grad", {}).get(para_key, [False])[0]
+        function_kwargs[para_key] = Tensor.from_numpy(para_val, is_sparse=sparse, sparse_format=sparse_format, requires_grad=requires_grad) 
     if para_key == 'dtype':
         function_kwargs[para_key] = from_numpy_dtype(para_val)
 """

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -2633,7 +2633,7 @@ def embedding_backward(
         sparse,
     )
     check_returncode(ret)
-    return {"weight": grad_weight} if grad_weight.requires_grad else {}
+    return {"weight": grad_weight} if weight.requires_grad else {}
 
 
 def mse_loss_backward(
@@ -3361,7 +3361,7 @@ def cdist_backward(x1, grad_outputs, output, x2, p, **kwargs):
             grad_x1 = np.sum(grad_x1, axis=index, keepdims=True)
     grad_x1 = Tensor.from_numpy(grad_x1)
     check_returncode(ret)
-    return {"x1": grad_x1} if grad_x1.requires_grad else {}
+    return {"x1": grad_x1} if x1.requires_grad else {}
 
 
 def reciprocal(input, inplace=False) -> Tensor:
@@ -5920,7 +5920,7 @@ def scaled_masked_softmax_backward(
         fixed_triu_mask,
     )
     check_returncode(ret)
-    return {"input": grad_input} if grad_input.requires_grad else {}
+    return {"input": grad_input} if input.requires_grad else {}
 
 
 def apply_penalty(

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -5174,10 +5174,14 @@ def rms_norm_backward(grad_outputs, input, weight, bias, normalized_shape, eps):
         eps,
     )
     check_returncode(ret)
-    out = {"input": grad_input, "weight": grad_weight}
-    if bias is not None:
+    out = {}
+    if bias is not None and bias.requires_grad:
         out['bias'] = grad_bias
-    return {k: v for k, v in out.items() if v.requires_grad}
+    if input.requires_grad:
+        out["input"] = grad_input
+    if weight.requires_grad:
+        out["weight"] = grad_weight
+    return out
 
 
 def multihead_attention(

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -382,7 +382,7 @@ def silu_backward(input, grad_outputs, **kwargs) -> Tensor:
     func = check_function("diopiSiluBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def sqrt(input, inplace=False) -> Tensor:
@@ -2204,7 +2204,7 @@ def adaptive_max_pool2d_backward(input, grad_outputs, output_size, **kwargs) -> 
     func = check_function("diopiAdaptiveMaxPool2dBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input, indices)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def slice_op_backward(input, grad_outputs, dim, index, **kwargs) -> Tensor:
@@ -2224,7 +2224,7 @@ def slice_op_backward(input, grad_outputs, dim, index, **kwargs) -> Tensor:
         index.step,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def adaptive_avg_pool2d_backward(input, grad_outputs, **kwargs) -> Tensor:
@@ -2233,7 +2233,7 @@ def adaptive_avg_pool2d_backward(input, grad_outputs, **kwargs) -> Tensor:
     func = check_function("diopiAdaptiveAvgPool2dBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def index_backward(input, grad_outputs, **kwargs) -> Tensor:
@@ -2269,7 +2269,7 @@ def index_backward(input, grad_outputs, **kwargs) -> Tensor:
         grad_outputs[0],
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def leaky_relu_backward(
@@ -2290,7 +2290,7 @@ def leaky_relu_backward(
         input_is_result,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def sigmoid_focal_loss_backward(
@@ -2327,7 +2327,7 @@ def sigmoid_focal_loss_backward(
         reduction,
     )
     check_returncode(ret)
-    return {"inputs": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def roi_align_backward(
@@ -2373,7 +2373,7 @@ def roi_align_backward(
         aligned,
     )
     check_returncode(ret)
-    return {"input": out}
+    return {"input": out} if out.requires_grad else {}
 
 
 def conv2d_backward(
@@ -2405,7 +2405,10 @@ def conv2d_backward(
 
     grad_input = raw_like(input)
     grad_weight = raw_like(weight)
-    out = {"input": grad_input, "weight": grad_weight}
+
+    keys = ["input", "weight"]
+    grads = [grad_input, grad_weight]
+    out = {k: v for k, v in zip(keys, grads) if v.requires_grad}
 
     if bias is None:
         grad_bias = None
@@ -2494,7 +2497,7 @@ def conv_transpose2d_backward(
         groups,
     )
     check_returncode(ret)
-    return out
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 
 def hardtanh_backward(
@@ -2508,7 +2511,7 @@ def hardtanh_backward(
     func = check_function("diopiHardtanhBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input, min_val, max_val)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def hardswish_backward(input, grad_outputs, **kwargs) -> Tensor:
@@ -2517,7 +2520,7 @@ def hardswish_backward(input, grad_outputs, **kwargs) -> Tensor:
     func = check_function("diopiHardswishBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def gelu_backward(input, grad_outputs, approximate="none", **kwargs) -> Tensor:
@@ -2533,7 +2536,7 @@ def gelu_backward(input, grad_outputs, approximate="none", **kwargs) -> Tensor:
         approximate.encode("UTF-8"),
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def avg_pool2d_backward(
@@ -2590,7 +2593,7 @@ def avg_pool2d_backward(
         )
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def embedding_backward(
@@ -2630,7 +2633,7 @@ def embedding_backward(
         sparse,
     )
     check_returncode(ret)
-    return {"weight": grad_weight}
+    return {"weight": grad_weight} if grad_weight.requires_grad else {}
 
 
 def mse_loss_backward(
@@ -2650,7 +2653,7 @@ def mse_loss_backward(
         reduction_mode,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def tanh_backward(input, grad_outputs, output, **kwargs) -> Tensor:
@@ -2660,7 +2663,7 @@ def tanh_backward(input, grad_outputs, output, **kwargs) -> Tensor:
     func = check_function("diopiTanhBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], output)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def index_select_backward(input, grad_outputs, dim, index, **kwargs) -> Tensor:
@@ -2671,7 +2674,7 @@ def index_select_backward(input, grad_outputs, dim, index, **kwargs) -> Tensor:
     func = check_function("diopiIndexSelectBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], inputSize, dim, index)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def select_backward(input, grad_outputs, dim, index, **kwargs) -> Tensor:
@@ -2682,7 +2685,7 @@ def select_backward(input, grad_outputs, dim, index, **kwargs) -> Tensor:
     func = check_function("diopiSelectBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], inputSize, dim, index)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def softmax_backward(input, grad_outputs, output, dim, **kwargs) -> Tensor:
@@ -2692,7 +2695,7 @@ def softmax_backward(input, grad_outputs, output, dim, **kwargs) -> Tensor:
     func = check_function("diopiSoftmaxBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], output, dim)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def log_softmax_backward(input, grad_outputs, output, dim, **kwargs) -> Tensor:
@@ -2702,7 +2705,7 @@ def log_softmax_backward(input, grad_outputs, output, dim, **kwargs) -> Tensor:
     func = check_function("diopiLogSoftmaxBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], output, dim)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def sigmoid_backward(input, grad_outputs, output, **kwargs) -> Tensor:
@@ -2712,7 +2715,7 @@ def sigmoid_backward(input, grad_outputs, output, **kwargs) -> Tensor:
     func = check_function("diopiSigmoidBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], output)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def threshold_backward(input, grad_outputs, threshold, **kwargs) -> Tensor:
@@ -2723,7 +2726,7 @@ def threshold_backward(input, grad_outputs, threshold, **kwargs) -> Tensor:
     func = check_function("diopiThresholdBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input, threshold)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def binary_cross_entropy_backward(
@@ -2755,7 +2758,7 @@ def binary_cross_entropy_backward(
         reduction_mode,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def binary_cross_entropy_with_logits_backward(
@@ -2797,7 +2800,7 @@ def binary_cross_entropy_with_logits_backward(
         reduction_mode,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 # todo: impl for diopiNLLLossV2Backward
@@ -2830,7 +2833,7 @@ def nll_loss_backward(
         ignore_index,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def nll_loss_v2_backward(
@@ -2864,7 +2867,7 @@ def nll_loss_v2_backward(
         ignore_index,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def max_pool2d_backward(
@@ -2915,7 +2918,7 @@ def max_pool2d_backward(
         indices,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def batch_norm_backward(
@@ -3358,7 +3361,7 @@ def cdist_backward(x1, grad_outputs, output, x2, p, **kwargs):
             grad_x1 = np.sum(grad_x1, axis=index, keepdims=True)
     grad_x1 = Tensor.from_numpy(grad_x1)
     check_returncode(ret)
-    return {"x1": grad_x1}
+    return {"x1": grad_x1} if grad_x1.requires_grad else {}
 
 
 def reciprocal(input, inplace=False) -> Tensor:
@@ -3503,7 +3506,7 @@ def smooth_l1_loss_backward(
         beta,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def maximum(input, other) -> Tensor:
@@ -3646,7 +3649,7 @@ def conv3d_backward(
         groups,
     )
     check_returncode(ret)
-    return out
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 
 def expand(input, size) -> Tensor:
@@ -3703,7 +3706,7 @@ def unfold_backward(input, grad_outputs, dimension, size, step, **kwargs):
         step,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def masked_select(input, mask) -> Tensor:
@@ -3724,7 +3727,7 @@ def masked_select_backward(input, grad_outputs, mask) -> Tensor:
     func = check_function("diopiMaskedSelectBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input, mask)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def index_fill(input, dim, index, value, inplace=False) -> Tensor:
@@ -3860,7 +3863,7 @@ def group_norm_backward(
         num_groups,
     )
     check_returncode(ret)
-    return out
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 
 def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-05):
@@ -3940,7 +3943,7 @@ def layer_norm_backward(
         Sizes(normalized_shape),
     )
     check_returncode(ret)
-    return out
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 
 def adaptive_avg_pool3d(input, output_size):
@@ -3978,7 +3981,7 @@ def adaptive_avg_pool3d_backward(input, grad_outputs, **kwargs) -> Tensor:
     func = check_function("diopiAdaptiveAvgPool3dBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def adaptive_max_pool3d(input, output_size, return_indices=False):
@@ -4027,7 +4030,7 @@ def adaptive_max_pool3d_backward(input, grad_outputs, output_size, **kwargs) -> 
     func = check_function("diopiAdaptiveMaxPool3dBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input, indices)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def max_pool3d(
@@ -4153,7 +4156,7 @@ def max_pool3d_backward(
         indices,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def permute(input, dims=None) -> Tensor:
@@ -4200,7 +4203,7 @@ def gather_backward(input, grad_outputs, dim, index, **kwargs):
     func = check_function("diopiGatherBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], input, dim, index)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def remainder(other, input=None, self=None):
@@ -4316,11 +4319,8 @@ def ctc_loss_backward(
         zero_infinity,
     )
     check_returncode(ret)
-    return {
-        "log_probs": log_softmax_backward(log_probs, [grad_input], log_probs_, 2)[
-            "input"
-        ]
-    }
+    grad_log_probs = log_softmax_backward(log_probs, [grad_input], log_probs_, 2).get("input", None)
+    return {"log_probs": grad_log_probs} if grad_log_probs and grad_log_probs.requires_grad else {}
 
 
 def index_put(
@@ -4484,7 +4484,7 @@ def interpolate_backward(
             mode.encode("UTF-8"),
         )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def pad(input, pad, mode="constant", value=None):
@@ -4615,9 +4615,10 @@ def linear_backward(input, grad_outputs, weight, bias=None, **kwargs):
         weight,
     )
     check_returncode(ret)
-    if bias is None:
-        return {"input": grad_input, "weight": grad_weight}
-    return {"input": grad_input, "weight": grad_weight, "bias": grad_bias}
+    out = {"input": grad_input, "weight": grad_weight}
+    if bias is not None:
+        out["bias"] = grad_bias
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 
 def cross_entropy_backward(
@@ -4658,7 +4659,7 @@ def cross_entropy_backward(
         label_smoothing,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def erfinv(input, inplace=False) -> Tensor:
@@ -4769,7 +4770,7 @@ def cholesky_ex_backward(input, grad_outputs, output, upper=False, **kwargs):
     func = check_function("diopiCholeskyBackward")
     ret = func(input.context(), grad_input, grad_outputs[0], output, upper)
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def triangular_solve(input, A, upper=True, transpose=False, unitriangular=False):
@@ -4826,7 +4827,8 @@ def triangular_solve_backward(
         unitriangular,
     )
     check_returncode(ret)
-    return {"input": grad_input, "A": grad_A}
+    out = {"input": grad_input, "A": grad_A}
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 
 def repeat(input, repeats):
@@ -5172,9 +5174,10 @@ def rms_norm_backward(grad_outputs, input, weight, bias, normalized_shape, eps):
         eps,
     )
     check_returncode(ret)
-    if bias is None:
-        return {"input": grad_input, "weight": grad_weight}
-    return {"input": grad_input, "weight": grad_weight, "bias": grad_bias}
+    out = {"input": grad_input, "weight": grad_weight}
+    if bias is not None:
+        out['bias'] = grad_bias
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 
 def multihead_attention(
@@ -5255,7 +5258,8 @@ def multihead_attention_backward(
             raise RuntimeError("execute diopiMultiHeadAttentionBackward failed!")
     else:
         check_returncode(ret)
-        return {"q": grad_q, "k": grad_k, "v": grad_v}
+        out = {"q": grad_q, "k": grad_k, "v": grad_v}
+        return {k: v for k, v in out.items() if v.requires_grad}
 
 
 def multihead_attention_varlen(
@@ -5368,7 +5372,8 @@ def multihead_attention_varlen_backward(
             raise RuntimeError("execute diopiMultiHeadAttentionVarLenBackward failed!")
     else:
         check_returncode(ret)
-        return {"q": grad_q, "k": grad_k, "v": grad_v}
+        out = {"q": grad_q, "k": grad_k, "v": grad_v}
+        return {k: v for k, v in out.items() if v.requires_grad}
 
 def flash_attention(q, k, v, alibi_slopes, p_dropout, softmax_scale, is_causal, window_size_left, window_size_right):
     call = "diopiFlashAttention"
@@ -5452,7 +5457,8 @@ def flash_attention_backward(
         else:
             raise
     check_returncode(ret)
-    return {"q": grad_q, "k": grad_k, "v": grad_v}
+    out = {"q": grad_q, "k": grad_k, "v": grad_v}
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 # diopiCustomizedFlashAttention is designed for ascend, please do not use it with other devices.
 def customized_flash_attention(q, k, v, alibi_slopes, p_dropout, softmax_scale, is_causal, window_size_left, window_size_right, head_num, input_layout):
@@ -5595,7 +5601,8 @@ def customized_flash_attention_backward(
         input_layout,
     )
     check_returncode(ret)
-    return {"q": grad_q, "k": grad_k, "v": grad_v}
+    out = {"q": grad_q, "k": grad_k, "v": grad_v}
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 def flash_attention_varlen(
     q,
@@ -5720,7 +5727,8 @@ def flash_attention_varlen_backward(
         else:
             raise
     check_returncode(ret)
-    return {"q": grad_q, "k": grad_k, "v": grad_v}
+    out = {"q": grad_q, "k": grad_k, "v": grad_v}
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 # diopiCustomizedFlashAttentionVarLen is designed for ascend, please do not use it with other devices.
 def customized_flash_attention_varlen(
@@ -5872,7 +5880,8 @@ def customized_flash_attention_varlen_backward(
         window_size_right,
     )
     check_returncode(ret)
-    return {"q": grad_q, "k": grad_k, "v": grad_v}
+    out = {"q": grad_q, "k": grad_k, "v": grad_v}
+    return {k: v for k, v in out.items() if v.requires_grad}
 
 def scaled_masked_softmax(input, mask, scale, fixed_triu_mask):
     call = "diopiScaledMaskedSoftmax"
@@ -5907,7 +5916,7 @@ def scaled_masked_softmax_backward(
         fixed_triu_mask,
     )
     check_returncode(ret)
-    return {"input": grad_input}
+    return {"input": grad_input} if grad_input.requires_grad else {}
 
 
 def apply_penalty(

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -2327,7 +2327,7 @@ def sigmoid_focal_loss_backward(
         reduction,
     )
     check_returncode(ret)
-    return {"input": grad_input} if grad_input.requires_grad else {}
+    return {"inputs": grad_input} if grad_input.requires_grad else {}
 
 
 def roi_align_backward(

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -2943,7 +2943,10 @@ def batch_norm_backward(
         ), "if not trainging, running_mean and running_var must be defined"
     # running_mean = running_mean if running_mean is None else running_mean
     # running_var = running_var if running_var is None else running_var
-    out = {"input": grad_input, "weight": grad_weight, "bias": grad_bias}
+    keys = ["input", "weight", "bias"]
+    grads = [grad_input, grad_weight, grad_bias]
+    out = {k: v for k, v in zip(keys, grads) if v.requires_grad}
+
     func = check_function("diopiBatchNormBackward")
     grad_output = grad_outputs[0]
     ret = func(

--- a/diopi_test/python/conformance/diopi_runtime.py
+++ b/diopi_test/python/conformance/diopi_runtime.py
@@ -248,6 +248,7 @@ class Tensor(diopiTensor):
         context=default_context,
         data_ptr=None,
         device=Device.AIChip,
+        requires_grad=False,
     ):
         if size is None:
             return diopiTensor.__init__(self)
@@ -259,9 +260,9 @@ class Tensor(diopiTensor):
             stride = Sizes(list(stride))
 
         if data_ptr is None:
-            diopiTensor.__init__(self, size, stride, dtype, device, context)
+            diopiTensor.__init__(self, size, stride, dtype, device, context, requires_grad=requires_grad)
         else:
-            diopiTensor.__init__(self, size, stride, dtype, device, context, data_ptr)
+            diopiTensor.__init__(self, size, stride, dtype, device, context, data_ptr, requires_grad=requires_grad)
 
     def __str__(self):
         # array = self.numpy()
@@ -284,6 +285,7 @@ class Tensor(diopiTensor):
             stride=stride,
             context=self.context(),
             device=self.get_device(),
+            requires_grad=self.requires_grad,
         )
 
     def size(self):
@@ -297,7 +299,15 @@ class Tensor(diopiTensor):
         self.reset_shape(Sizes(list(shape)))
 
     @classmethod
-    def from_numpy(cls, darray, context=None, device=Device.AIChip, is_sparse=False, sparse_format=None):
+    def from_numpy(
+            cls, 
+            darray, 
+            context=None, 
+            device=Device.AIChip, 
+            is_sparse=False, 
+            sparse_format=None,
+            requires_grad=False,
+        ):
         if not isinstance(darray, (np.generic, np.ndarray)):
             raise TypeError(f"expected np.ndarray (got {type(darray)})")
         dtype = from_numpy_dtype(darray.dtype)
@@ -338,6 +348,7 @@ class Tensor(diopiTensor):
             data_ptr=capsule,
             context=context if context else default_context,
             device=device,
+            requires_grad=requires_grad,
         )
 
     def numpy(self) -> np.ndarray:

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -1807,7 +1807,7 @@ diopiError_t diopiDropout(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
             CALL_ATEN_CUDA_FUNC(mul_out, atOut, atInput, atMask);
             atOut.div_(1 - p);
         }
-        impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+        impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
     } else {
         impl::aten::updateATen2Tensor(ctx, atInput, out);
     }
@@ -1830,7 +1830,7 @@ diopiError_t diopiDropoutInp(diopiContextHandle_t ctx, diopiTensorHandle_t input
             CALL_ATEN_CUDA_FUNC(bernoulli_, atMask, 1 - p, gen);
             atInput.mul_(atMask).div_(1 - p);
         }
-        impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+        impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
     }
 
     return diopiSuccess;
@@ -2547,7 +2547,7 @@ diopiError_t diopiRandperm(diopiContextHandle_t ctx, diopiTensorHandle_t out, in
     auto atOut = impl::aten::buildATen(out);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_CUDA_FUNC(randperm_out, atOut, n, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2557,7 +2557,7 @@ diopiError_t diopiUniformInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout
     auto atInOut = impl::aten::buildATen(inout);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     at::native::uniform_(atInOut, from, to, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2568,7 +2568,7 @@ diopiError_t diopiRandomInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout,
     c10::optional<int64_t> atTo = to ? c10::optional<int64_t>(*to) : c10::nullopt;
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     at::native::random_(atInOut, from, atTo, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2578,7 +2578,7 @@ diopiError_t diopiBernoulliInp(diopiContextHandle_t ctx, diopiTensorHandle_t ino
     auto atInOut = impl::aten::buildATen(inout);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_CUDA_FUNC(bernoulli_out, atInOut, atInOut, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2589,7 +2589,7 @@ diopiError_t diopiBernoulli(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     auto atOut = impl::aten::buildATen(out);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_CUDA_FUNC(bernoulli_out, atOut, atInput, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2599,7 +2599,7 @@ diopiError_t diopiBernoulliScalar(diopiContextHandle_t ctx, diopiTensorHandle_t 
     auto atOut = impl::aten::buildATen(out);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_CUDA_FUNC(bernoulli_, atOut, p, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2610,7 +2610,7 @@ diopiError_t diopiNormal(diopiContextHandle_t ctx, diopiTensorHandle_t out, doub
     auto atSize = atOut.sizes();
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_FUNC(normal_out, atOut, mean, std, atSize, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2620,7 +2620,7 @@ diopiError_t diopiNormalInp(diopiContextHandle_t ctx, diopiTensorHandle_t inout,
     auto atInOut = impl::aten::buildATen(inout);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     at::native::normal_(atInOut, mean, std, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
     return diopiSuccess;
 }
 
@@ -2631,7 +2631,7 @@ diopiError_t diopiNormalTensorScalar(diopiContextHandle_t ctx, diopiTensorHandle
     auto atMean = impl::aten::buildATen(mean);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_CUDA_FUNC(normal_out, atOut, atMean, std, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2643,7 +2643,7 @@ diopiError_t diopiNormalScalarTensor(diopiContextHandle_t ctx, diopiTensorHandle
     auto atStd = impl::aten::buildATen(std);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_CUDA_FUNC(normal_out, atOut, mean, atStd, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -2656,7 +2656,7 @@ diopiError_t diopiNormalTensor(diopiContextHandle_t ctx, diopiTensorHandle_t out
     auto atStd = impl::aten::buildATen(std);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_CUDA_FUNC(normal_out, atOut, atMean, atStd, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }
@@ -4135,7 +4135,7 @@ diopiError_t diopiMultinomial(diopiContextHandle_t ctx, diopiTensorHandle_t out,
     auto atOut = impl::aten::buildATen(out);
     at::Generator gen = impl::aten::buildGenerator(ctx, generator);
     CALL_ATEN_CUDA_FUNC(multinomial_out, atOut, atInput, num_samples, replacement, gen);
-    impl::aten::updateGeneratorHandleState(ctx, gen, generator);
+    impl::aten::updateGeneratorHandleSeedAndOffset(ctx, gen, generator);
 
     return diopiSuccess;
 }

--- a/impl/torch/helper.cpp
+++ b/impl/torch/helper.cpp
@@ -125,7 +125,8 @@ at::Generator buildGenerator(diopiContextHandle_t ctx, diopiConstGeneratorHandle
 }
 
 void updateGeneratorHandleSeedAndOffset(diopiContextHandle_t ctx, at::Generator& cuda_gen, diopiGeneratorHandle_t generator) {
-    uint64_t seed, offset;
+    uint64_t seed = 0;
+    uint64_t offset = 0;
     {
         std::lock_guard<std::mutex> lock(cuda_gen.mutex());
 #if TORCH_MM_VERSION >= TORCH_2_1_MM_VERSION

--- a/impl/torch/helper.cpp
+++ b/impl/torch/helper.cpp
@@ -108,12 +108,12 @@ void buildDiopiTensor(diopiContextHandle_t ctx, const at::Tensor& input, diopiTe
 // new cuda generator and pass dipu generator state into cuda generator state
 at::Generator buildGenerator(diopiContextHandle_t ctx, diopiConstGeneratorHandle_t generator) {
     auto gen = at::cuda::detail::createCUDAGenerator();
-    diopiTensorHandle_t state_handle = nullptr;
-    diopiGeneratorGetState(ctx, generator, &state_handle);
-    auto state = impl::aten::buildATen(state_handle);
+    uint64_t seed, offset;
+    diopiGeneratorGetSeedAndOffset(const_cast<diopiGeneratorHandle_t>(generator), &seed, &offset);
     {
         std::lock_guard<std::mutex> lock(gen.mutex());
-        gen.set_state(state);
+        gen.set_current_seed(seed);
+        gen.set_offset(offset);
     }
     return gen;
 }

--- a/impl/torch/helper.hpp
+++ b/impl/torch/helper.hpp
@@ -27,6 +27,7 @@
 #define TORCH_1_10_MM_VERSION 1100
 #define TORCH_1_11_MM_VERSION 1110
 #define TORCH_1_12_MM_VERSION 1120
+#define TORCH_2_1_MM_VERSION 2010
 
 #define ATEN_NOT_IMPLEMENT()                                                                                         \
     std::cerr << __FILE__ << ":" << __LINE__ << ": ";                                                                \
@@ -160,7 +161,7 @@ void buildDiopiTensor(diopiContextHandle_t ctx, const at::Tensor& input, diopiTe
 // new cuda generator and pass dipu generator state into cuda generator state
 at::Generator buildGenerator(diopiContextHandle_t ctx, diopiConstGeneratorHandle_t generator);
 
-void updateGeneratorHandleState(diopiContextHandle_t ctx, at::Generator& cuda_gen, diopiGeneratorHandle_t generator);
+void updateGeneratorHandleSeedAndOffset(diopiContextHandle_t ctx, at::Generator& cuda_gen, diopiGeneratorHandle_t generator);
 
 inline c10::optional<c10::string_view> getRoundingMode(diopiRoundMode_t rounding_mode) {
     switch (rounding_mode) {


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are some error when running resnet50 testcase

![image](https://github.com/user-attachments/assets/484422cc-687c-4062-8247-a4f74e3ef46b)


![image](https://github.com/user-attachments/assets/8bf74b8b-516b-4ee0-9036-166c81433e6c)


This change addresses an issue with the `conv2d_backward` function where it was returning unnecessary gradients even when `requires_grad` was not set for some parameters. By respecting the requires_grad settings, we ensure that only the required gradients are computed and returned. 

## Description
<!--- Describe your changes in detail. -->
- Modified the `backward operator` function to ensure that gradients are only included in the return dictionary if `requires_grad` is set to True for the respective parameters.
- Updated the test template to correctly handle and pass `requires_grad` information from function_paras.
- Updated the `diopiTensor` class definition to include the `requires_grad` attribute.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

