### PR TITLE
feat: add a new diopiError_t enum to fallback to cpu

### DIFF
--- a/proto/include/diopi/diopirt.h
+++ b/proto/include/diopi/diopirt.h
@@ -44,6 +44,7 @@ typedef enum {
     diopiNoRegisteredGetLastErrorFunction = 11,
     diopi5DNotSupported = 12,
     diopiNoImplement = 13,
+    diopiForceFallbackToCPU = 14,
     diopiDtypeNotSupported = 1000,
 } diopiError_t;
 


### PR DESCRIPTION
非常简单的一个修改，给 `diopiError_t` 新增一个 enum，用于满足 s2 那边特定算子回退至 CPU 计算的逻辑。

需要考虑一下 enum 的命名。