### PR TITLE
align diopi test to torch2.1

### DIFF
--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -959,6 +959,7 @@ diopi_configs = {
                     "shape": ((), (16,), (72,),
                               (2, 11856), (2, 741, 80), (4, 4, 16, 20),
                               (0,), (4, 0), (9, 0, 16)),
+                    "gen_fn": dict(fn='Genfunc.uniform', low=0, high=1),
                 },
                 {
                     "ins": ['weight'],
@@ -5236,7 +5237,7 @@ diopi_configs = {
                 },
                 {
                     "ins": ['max_exp_avg_sq'],
-                    "shape": [None, None, (4, 8), (12, 4, 8)],
+                    "shape": [(), (16,), (4, 8), (12, 4, 8)],
                     "gen_fn": 'Genfunc.rand',
                 },
             ]
@@ -6020,13 +6021,13 @@ diopi_configs = {
                 {
                     "ins": ['input'],
                     "shape": ((8, 0), (0, 128), (256, 8)),
-                    "dtype": [np.float32, np.float16, np.float64],
+                    "dtype": [np.float16, np.float32, np.float64],
                     "gen_fn": 'Genfunc.randn',
                 },
                 {
                     "ins": ['mat2'],
                     "shape": ((0, 128), (128, 128), (8, 0)),
-                    "dtype": [np.float16, np.float64, np.float32],
+                    "dtype": [np.float16, np.float32, np.float64],
                     "gen_fn": 'Genfunc.randn',
                 },
             ],

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -2915,7 +2915,11 @@ diopiError_t diopiRmsprop(diopiContextHandle_t ctx, diopiTensorHandle_t param, d
     at::Tensor atAvg;
 
     if (centered) {
+#if TORCH_MM_VERSION >= 2010
+        atGradAvg.lerp_(atGrad, 1 - alpha);
+#else
         atGradAvg.mul_(alpha).add_(atGrad, 1 - alpha);
+#endif
         atAvg = atSquareAvg.addcmul(atGradAvg, atGradAvg, -1).sqrt_().add_(eps);
     } else {
         atAvg = atSquareAvg.sqrt().add_(eps);


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
when running diopi test based on torch2.1, there are some ops that have error.
this pr is to fix these errors, to make sure all ops could pass diopi test on torch2.1

## Description
<!--- Describe your changes in detail. -->
1.binary_cross_entropy: the target value must in  the range [0, 1].
>../aten/src/ATen/native/cuda/Loss.cu:95: operator(): block: [0,0,0], thread: [0,0,0] Assertion `target_val >= zero && target_val <= one` failed.

2.adam: the tensor on first param can not be none-type.
>2024-08-08 20:01:11,795 - ConformanceTest - gen_output.py - 66 - ERROR - Generate output data for diopi_functions.adam [adam::adam_0.pth] failed, cause by 
is_complex(): `argument 'input' (position 1) must be Tensor, not NoneType`

3.mm_diff_dtype: generated input_data has different dtype, because corresponding diopi_config is not aligned properly.
>2024-08-08 20:02:10,034 - ConformanceTest - gen_output.py - 66 - ERROR - Generate output data for diopi_functions.mm [mm_diff_dtype::mm_0.pth] failed, cause by 
`expected mat1 and mat2 to have the same dtype, but got: float != c10::Half`

4.rmsprop: precision issue. caused by updated implementation of rmsprop in torch2.1 compared with torch2.0.
>E           AssertionError: Test rmsprop: {'atol': 1e-05, 'rtol': 0.001, 'atol_half': 0.001, 'rtol_half': 0.01, 'mismatch_ratio_threshold': 0.001, 'memory_format': 'NCHW', 'fp16_exact_match': False, 'train': True, 'gen_policy': 'dafault', 'name': 'rmsprop', 'interface': ['CustomizedTest'], 'para': {'lr': 0.01, 'alpha': 0.99, 'eps': 1e-08, 'weight_decay': 0.1, 'momentum': 0.1, 'centered': True}, 'tensor_para': {'dtype': [<class 'numpy.float32'>, <class 'numpy.float16'>, <class 'numpy.float64'>], 'args': [{'ins': 'param', 'shape': (4, 32, 7, 7), 'gen_fn': 'Genfunc.randn', 'requires_grad': [False], 'sparse': [False], 'gen_num_range': [], 'dtype': <class 'numpy.float16'>, 'gen_policy': 'default'}, {'ins': 'param_grad', 'shape': (4, 32, 7, 7), 'gen_fn': 'Genfunc.randn', 'requires_grad': [False], 'sparse': [False], 'gen_num_range': [], 'dtype': <class 'numpy.float16'>, 'gen_policy': 'default'}, {'ins': 'square_avg', 'shape': (4, 32, 7, 7), 'gen_fn': 'Genfunc.randn', 'requires_grad': [False], 'sparse': [False], 'gen_num_range': [], 'dtype': <class 'numpy.float16'>, 'gen_policy': 'default'}, {'ins': 'grad_avg', 'shape': (4, 32, 7, 7), 'gen_fn': 'Genfunc.randn', 'requires_grad': [False], 'sparse': [False], 'gen_num_range': [], 'dtype': <class 'numpy.float16'>, 'gen_policy': 'default'}, {'ins': 'momentum_buffer', 'shape': (4, 32, 7, 7), 'gen_fn': 'Genfunc.randn', 'requires_grad': [False], 'sparse': [False], 'gen_num_range': [], 'dtype': <class 'numpy.float16'>, 'gen_policy': 'default'}], 'seq_name': ''}, 'requires_backward': [], 'tag': [], 'saved_args': {}} traceback: The count of elements that do not meet the accuracy requirement is 11.
E             The dtype of out3 is float16.
E             The shape of out3 is (4, 32, 7, 7).
E             The stride of out3 is [1568   49    7    1].
E             `The max of diff is 5.015625. Specifically, the actual val is 17.671875 and the expected is 22.6875.`
E             
E           assert False

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

