### PR TITLE
Fix: Correct backward convolution function call with output mask

### DIFF
--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -2254,8 +2254,11 @@ diopiError_t diopiConvolution2dBackward(diopiContextHandle_t ctx, diopiTensorHan
         at::native::copy_(atGradWeight, std::get<1>(tempOut), true);
         at::native::copy_(atGradBias, std::get<2>(tempOut), true);
     } else {
-        auto results = at::convolution_backward(
-            atGrad, atInput, atWeight, c10::nullopt, atStride, atPadding, atDilation, false, outputPadding, groups, {true, true, false});
+        std::array<bool, 3> output_mask{true, true, false};
+        if (!grad_input) output_mask[0] = false;
+        if (!grad_weight) output_mask[1] = false;
+        auto results = at::native::convolution_backward(
+            atGrad, atInput, atWeight, c10::nullopt, atStride, atPadding, atDilation, false, outputPadding, groups, output_mask);
         impl::aten::updateATen2Tensor(ctx, std::get<0>(results), grad_input);
         impl::aten::updateATen2Tensor(ctx, std::get<1>(results), grad_weight);
         if (bias_sizes && grad_bias) {


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change addresses a performance issue where unnecessary gradients were being computed in the convolution_backward function. Computing gradients that are not needed can be time-consuming. By introducing a dynamic output_mask, this update ensures that only the required gradients are computed, leading to significant time savings and improved overall performance.

## Description
<!--- Describe your changes in detail. -->
- Introduced `std::array<bool, 3> output_mask` to selectively compute only the necessary gradients in the convolution_backward function.
- Modified the function to set `output_mask` based on the presence of `grad_input` and `grad_weight`. If either is not needed, the corresponding gradient computation is skipped.
- Updated the call to `at::native::convolution_backward`.

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [X] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [X] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [X] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

