### PR TITLE
Implement some GB ops

### DIFF
--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -6561,6 +6561,7 @@ diopi_configs = {
                               (0,), (0, 12), (13, 0, 4)),
                     "dtype": [np.float32, np.float64, np.float16],
                     "gen_fn": 'Genfunc.randn',
+                    "requires_grad": [True],
                 },
             ],
         ),
@@ -7649,6 +7650,44 @@ diopi_configs = {
         )
     ),
 
+    'layer_normGB': dict(
+        name=["layer_normGB"],
+        dtype=[np.float32, np.float64, np.float16],
+        atol=1e-5,
+        atol_half=1e-1,
+        rtol_half=1e-2,
+        para=dict(
+            eps=[1e-5, 1e-5, 1e-12, 0, -1e-5, 2],
+            normalized_shape=[(5, 3, 5), (128, ), (64, ), (32,),
+                              (3, 5), (2, 16, 128)],
+        ),
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ["input"],
+                    "requires_grad": [True],
+                    "shape": ((2, 5, 3, 5), (2, 3136, 128), (2, 64), (32,),
+                              (2, 5, 3, 5), (2, 16, 128)),
+                },
+                {
+                    "ins": ["weight"],
+                    "requires_grad": [True],
+                    "shape": (None, (128,), (64,), (32,),
+                              (3, 5), (2, 16, 128)),
+                },
+                {
+                    "ins": ["bias"],
+                    "requires_grad": [True],
+                    "shape": (None, (128,), (64,), (32,),
+                              (3, 5), (2, 16, 128)),
+                },
+            ]
+        )
+    ),
+
+
+
     'layer_norm_empty_tensor': dict(
         name=["layer_norm"],
         dtype=[np.float32, np.float64, np.float16],
@@ -7671,6 +7710,28 @@ diopi_configs = {
                 {
                     "ins": ["bias"],
                     "shape": ((0,), (0, 12), (9,)),
+                },
+            ]
+        )
+    ),
+
+    'normalize': dict(
+        name=["normalize"],
+        interface=['torch.nn.functional'],
+        dtype=[np.float32, np.float64, np.float16],
+        atol=1e-5,
+        para=dict(
+            eps=[1e-2, 1e-8, -3],
+            p=[1, 2, 3],
+            dim=[1, 1, 1],
+        ),
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ["input"],
+                    "shape": ((3, 3), (3, 12), (6, 3, 9)),
+                    "requires_grad": [True],
                 },
             ]
         )

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4384,11 +4384,11 @@ diopi_configs = {
         ),
     ),
 
-    'sort_backward': dict(
+    'sort_stable_for_backward': dict(
         name=["sort"],
         interface=['CustomizedTest'],
         saved_args=dict(indice=1),
-        requires_backward = [0],
+        requires_backward=[0],
         para=dict(
             dim=[-1, 0, 1],
             descending=[True, False, False],
@@ -5428,6 +5428,29 @@ diopi_configs = {
                               (0,), (5, 0), (4, 0, 12)),
                     "dtype": [np.float32, np.float64, np.float16, np.int16, np.int32,
                               np.int64, np.uint8, np.int8, np.bool_],
+                    "gen_fn": 'Genfunc.randn',
+                },
+            ],
+        ),
+    ),
+
+    'cumsum_float_for_backward': dict(
+        name=["cumsum"],
+        interface=['torch'],
+        atol=1e-6,
+        rtol=1e-5,
+        requires_backward=[0],
+        dtype=[np.float32],
+        para=dict(
+            dim=[0, -1, 1],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((), (12,), (2, 22, 33)),
+                    "dtype": [np.float32, np.float64, np.float16],
                     "gen_fn": 'Genfunc.randn',
                 },
             ],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4449,8 +4449,8 @@ diopi_configs = {
         ),
     ),
 
-    'imag': dict(
-        name=["imag"],
+    'real_imag': dict(
+        name=["real", "imag"],
         interface=['torch'],
         dtype=[np.complex64, np.complex128],
         tensor_para=dict(

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1383,6 +1383,44 @@ diopi_configs = {
         ),
     ),
 
+    'atanh': dict(
+        name=['atanh'],
+        interface=['torch'],
+        is_inplace=True,
+        saved_args=dict(output=0),
+        dtype=[np.float16, np.float32, np.float64],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
+    'atanh_not_float': dict(
+        name=['atanh'],
+        interface=['torch'],
+        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
     'sign': dict(
         name=['sign'],
         interface=['torch'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -8202,6 +8202,31 @@ diopi_configs = {
         ),
     ),
 
+    'grid_sample': dict(
+        name=["grid_sample"],
+        interface=['torch.nn.functional'],
+        para=dict(
+            mode=["bilinear", "nearest", "bilinear", "nearest"],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((2, 3, 15, 15), (3, 3, 20, 20, 20), (2, 3, 25, 25), (3, 3, 30, 30, 30)),
+                    "dtype": [np.float16, np.float32, np.float64],
+                    "gen_fn": 'Genfunc.randn',
+                },
+                {
+                    "ins": ['grid'],
+                    "shape": ((2, 5, 5, 2), (3, 10, 10, 10, 3), (2, 20, 20, 2), (3, 60, 60, 60, 3)),
+                    "dtype": [np.float16, np.float32, np.float64],
+                    "gen_fn": 'Genfunc.randn',
+                    "gen_num_range": [1, 19],
+                },                
+            ],
+        ),
+    ),
+
     'multinomial': dict(
         name=["multinomial"],
         interface=['torch'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4409,6 +4409,29 @@ diopi_configs = {
         ),
     ),
 
+    'complex': dict(
+        name=["complex"],
+        interface=['torch'],
+        dtype=[np.float32, np.float64],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['real'],
+                    "shape": ((11400, ),
+                              (4, 4, 16, 20),
+                              (4, 4, 16, 2, 20)),
+                },
+                {
+                    "ins": ['imag'],
+                    "shape": ((11400, ),
+                              (4, 4, 16, 20),
+                              (4, 4, 16, 2, 20)),
+                },
+            ],
+        ),
+    ),
+
     # FIXME topk输入0-d张量，且k为0时，结果精度不一致
     'topk_nonzero': dict(
         name=['topk'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1025,7 +1025,7 @@ diopi_configs = {
     ),
 
     'pointwise_op': dict(
-        name=['abs', 'cos', 'tan', 'erf', 'erfinv', 'exp', 'expm1', 'floor',
+        name=['abs', 'cos', 'acos', 'tan', 'erf', 'erfinv', 'exp', 'expm1', 'floor',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'ceil', 'atan'],
         interface=['torch'],
         is_inplace=True,
@@ -1047,7 +1047,7 @@ diopi_configs = {
     'pointwise_op_int_without_inplace': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp',
         #       'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
-        name=['abs', 'cos', 'tan', 'erf', 'exp', 'expm1',
+        name=['abs', 'cos', 'acos', 'tan', 'erf', 'exp', 'expm1',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
         interface=['torch'],
         dtype=[np.int16, np.int32, np.int64, np.int8],
@@ -1068,7 +1068,7 @@ diopi_configs = {
     'pointwise_op_uint8': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp',
         #       'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
-        name=['abs', 'cos', 'tan', 'erf', 'exp', 'expm1',
+        name=['abs', 'cos', 'acos', 'tan', 'erf', 'exp', 'expm1',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
         interface=['torch'],
         dtype=[np.uint8],
@@ -1103,7 +1103,7 @@ diopi_configs = {
     # FIXME erfinv输入int或bool报错
     'pointwise_op_bool': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
-        name=['abs', 'cos', 'tan', 'erf', 'exp', 'expm1', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
+        name=['abs', 'cos', 'acos', 'tan', 'erf', 'exp', 'expm1', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
         interface=['torch'],
         dtype=[np.bool_],
         tensor_para=dict(

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1192,6 +1192,44 @@ diopi_configs = {
         ),
     ),
 
+    'sinh': dict(
+        name=['sinh'],
+        interface=['torch'],
+        is_inplace=True,
+        saved_args=dict(output=0),
+        dtype=[np.float16, np.float32, np.float64],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
+    'sinh_not_float': dict(
+        name=['sinh'],
+        interface=['torch'],
+        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
     'tanh': dict(
         name=['tanh'],
         interface=['torch'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4432,6 +4432,23 @@ diopi_configs = {
         ),
     ),
 
+    'conj': dict(
+        name=["conj"],
+        interface=['torch'],
+        dtype=[np.float32, np.float64, np.complex64, np.complex128],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((11400, ),
+                              (4, 4, 16, 20),
+                              (4, 4, 16, 2, 20)),
+                },
+            ],
+        ),
+    ),
+
     # FIXME topk输入0-d张量，且k为0时，结果精度不一致
     'topk_nonzero': dict(
         name=['topk'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4449,6 +4449,23 @@ diopi_configs = {
         ),
     ),
 
+    'imag': dict(
+        name=["imag"],
+        interface=['torch'],
+        dtype=[np.complex64, np.complex128],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((11400, ),
+                              (4, 4, 16, 20),
+                              (4, 4, 16, 2, 20)),
+                },
+            ],
+        ),
+    ),
+
     # FIXME topk输入0-d张量，且k为0时，结果精度不一致
     'topk_nonzero': dict(
         name=['topk'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1192,8 +1192,8 @@ diopi_configs = {
         ),
     ),
 
-    'sinh': dict(
-        name=['sinh'],
+    'hyperbolic_trigo_function_without_backward': dict(
+        name=['sinh', 'cosh', 'asinh', 'acosh', 'atanh'],
         interface=['torch'],
         is_inplace=True,
         saved_args=dict(output=0),
@@ -1212,46 +1212,8 @@ diopi_configs = {
         ),
     ),
 
-    'sinh_not_float': dict(
-        name=['sinh'],
-        interface=['torch'],
-        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
-        tensor_para=dict(
-            gen_fn='Genfunc.randn',
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
-                              (256, 128, 3, 3),
-                              (2, 31, 512, 6, 40),
-                              (0,), (16, 0), (1, 0, 6)),
-                },
-            ],
-        ),
-    ),
-
-    'cosh': dict(
-        name=['cosh'],
-        interface=['torch'],
-        is_inplace=True,
-        saved_args=dict(output=0),
-        dtype=[np.float16, np.float32, np.float64],
-        tensor_para=dict(
-            gen_fn='Genfunc.randn',
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
-                              (256, 128, 3, 3),
-                              (2, 31, 512, 6, 40),
-                              (0,), (16, 0), (1, 0, 6)),
-                },
-            ],
-        ),
-    ),
-
-    'cosh_not_float': dict(
-        name=['cosh'],
+    'hyperbolic_trigo_function_without_backward_not_float': dict(
+        name=['sinh', 'cosh', 'asinh', 'acosh', 'atanh'],
         interface=['torch'],
         dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
         tensor_para=dict(
@@ -1291,120 +1253,6 @@ diopi_configs = {
 
     'tanh_not_float': dict(
         name=['tanh'],
-        interface=['torch'],
-        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
-        tensor_para=dict(
-            gen_fn='Genfunc.randn',
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
-                              (256, 128, 3, 3),
-                              (2, 31, 512, 6, 40),
-                              (0,), (16, 0), (1, 0, 6)),
-                },
-            ],
-        ),
-    ),
-
-    'asinh': dict(
-        name=['asinh'],
-        interface=['torch'],
-        is_inplace=True,
-        saved_args=dict(output=0),
-        dtype=[np.float16, np.float32, np.float64],
-        tensor_para=dict(
-            gen_fn='Genfunc.randn',
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
-                              (256, 128, 3, 3),
-                              (2, 31, 512, 6, 40),
-                              (0,), (16, 0), (1, 0, 6)),
-                },
-            ],
-        ),
-    ),
-
-    'asinh_not_float': dict(
-        name=['asinh'],
-        interface=['torch'],
-        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
-        tensor_para=dict(
-            gen_fn='Genfunc.randn',
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
-                              (256, 128, 3, 3),
-                              (2, 31, 512, 6, 40),
-                              (0,), (16, 0), (1, 0, 6)),
-                },
-            ],
-        ),
-    ),
-
-    'acosh': dict(
-        name=['acosh'],
-        interface=['torch'],
-        is_inplace=True,
-        saved_args=dict(output=0),
-        dtype=[np.float16, np.float32, np.float64],
-        tensor_para=dict(
-            gen_fn='Genfunc.randn',
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
-                              (256, 128, 3, 3),
-                              (2, 31, 512, 6, 40),
-                              (0,), (16, 0), (1, 0, 6)),
-                },
-            ],
-        ),
-    ),
-
-    'acosh_not_float': dict(
-        name=['acosh'],
-        interface=['torch'],
-        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
-        tensor_para=dict(
-            gen_fn='Genfunc.randn',
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
-                              (256, 128, 3, 3),
-                              (2, 31, 512, 6, 40),
-                              (0,), (16, 0), (1, 0, 6)),
-                },
-            ],
-        ),
-    ),
-
-    'atanh': dict(
-        name=['atanh'],
-        interface=['torch'],
-        is_inplace=True,
-        saved_args=dict(output=0),
-        dtype=[np.float16, np.float32, np.float64],
-        tensor_para=dict(
-            gen_fn='Genfunc.randn',
-            args=[
-                {
-                    "ins": ['input'],
-                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
-                              (256, 128, 3, 3),
-                              (2, 31, 512, 6, 40),
-                              (0,), (16, 0), (1, 0, 6)),
-                },
-            ],
-        ),
-    ),
-
-    'atanh_not_float': dict(
-        name=['atanh'],
         interface=['torch'],
         dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
         tensor_para=dict(

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -5618,6 +5618,49 @@ diopi_configs = {
         ),
     ),
 
+    'conv_transpose3d': dict(
+        name=["conv_transpose3d"],
+        atol=1e-3,
+        rtol=1e-3,
+        atol_half=1e2,
+        rtol_half=1e2,
+        para=dict(
+            stride=[1, 1, 2, 1, 2, (2, 2, 2), 1],
+            padding=[0, 0, 1, 0, 1, (1, 0, 1), 0],
+            output_padding=[0, 0, 1, 0, 1, (0, 1, 1), 0],
+            groups=[1, 1, 8, 1, 1, 1, 1],
+            dilation=[1, 1, 2, 1, 2, (1, 2, 2), 1],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ["input"],
+                    "requires_grad": [True],
+                    "shape": ((6, 16, 20, 8, 5),
+                              (2, 256, 14, 14, 5), (2, 128, 32, 32, 4),
+                              (2, 64, 160, 160, 5), (2, 64, 320, 320, 5), (2, 64, 320, 320, 5),
+                              (0, 16, 20, 8, 5)),
+                    "dtype": [np.float32, np.float64, np.float16],
+                },
+                {
+                    "ins": ["weight"],
+                    "requires_grad": [True],
+                    "shape": ((16, 2, 12, 2, 2),
+                              (256, 256, 2, 2, 2), (128, 128, 4, 4, 4),
+                              (64, 64, 2, 2, 2), (64, 1, 2, 2, 2), (64, 1, 2, 2, 2),
+                              (16, 2, 12, 2, 2)),
+                    "dtype": [np.float32, np.float64, np.float16],
+                },
+                {
+                    "ins": ["bias"],
+                    "requires_grad": [True],
+                    "shape": (None, (256,), None, (64,), (1,), (1,), None),
+                    "dtype": [np.float32, np.float64, np.float16],
+                },
+            ]
+        ),
+    ),
+
     'unfold': dict(
         name=["unfold"],
         interface=['torch.Tensor'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -4384,6 +4384,31 @@ diopi_configs = {
         ),
     ),
 
+    'sort_backward': dict(
+        name=["sort"],
+        interface=['CustomizedTest'],
+        saved_args=dict(indice=1),
+        requires_backward = [0],
+        para=dict(
+            dim=[-1, 0, 1],
+            descending=[True, False, False],
+            stable=[True, True, True],
+        ),
+        dtype=[np.float16, np.float32],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((11400, ),
+                              (4, 4, 16, 20),
+                              (4, 4, 16, 2, 20)),
+                },
+            ],
+        ),
+    ),
+
     # FIXME topk输入0-d张量，且k为0时，结果精度不一致
     'topk_nonzero': dict(
         name=['topk'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1025,7 +1025,7 @@ diopi_configs = {
     ),
 
     'pointwise_op': dict(
-        name=['abs', 'cos', 'erf', 'erfinv', 'exp', 'expm1', 'floor',
+        name=['abs', 'cos', 'tan', 'erf', 'erfinv', 'exp', 'expm1', 'floor',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'ceil', 'atan'],
         interface=['torch'],
         is_inplace=True,
@@ -1047,7 +1047,7 @@ diopi_configs = {
     'pointwise_op_int_without_inplace': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp',
         #       'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
-        name=['abs', 'cos', 'erf', 'exp', 'expm1',
+        name=['abs', 'cos', 'tan', 'erf', 'exp', 'expm1',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
         interface=['torch'],
         dtype=[np.int16, np.int32, np.int64, np.int8],
@@ -1068,7 +1068,7 @@ diopi_configs = {
     'pointwise_op_uint8': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp',
         #       'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
-        name=['abs', 'cos', 'erf', 'exp', 'expm1',
+        name=['abs', 'cos', 'tan', 'erf', 'exp', 'expm1',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
         interface=['torch'],
         dtype=[np.uint8],
@@ -1103,7 +1103,7 @@ diopi_configs = {
     # FIXME erfinv输入int或bool报错
     'pointwise_op_bool': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
-        name=['abs', 'cos', 'erf', 'exp', 'expm1', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
+        name=['abs', 'cos', 'tan', 'erf', 'exp', 'expm1', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
         interface=['torch'],
         dtype=[np.bool_],
         tensor_para=dict(

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -5595,6 +5595,48 @@ diopi_configs = {
         ),
     ),
 
+    'argsort': dict(
+        name=['argsort'],
+        interface=["torch"],
+        para=dict(
+            dim=[0, -1, 0, 1, -1, 0, 2, 1],
+            stable=[True, False, True, False, False, True, True, False],
+            descending=[True, False, True, False, False, True, True, False],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1,), (1024, 80), (2, 256, 256), (2, 1, 64, 64),
+                              (12, 0), (2, 0, 9), (0, 9, 8, 7)),
+                    "dtype": [np.float64, np.float16, np.float32, np.int32, np.int16,
+                              np.int64, np.uint8, np.int8],
+                    "gen_fn": 'Genfunc.randn',
+                },
+            ],
+        ),
+    ),
+
+    'argsort_same_value': dict(
+        name=['argsort'],
+        interface=["torch"],
+        para=dict(
+            dim=[-1, 0, -1, 1],
+            stable=[True, False, True, False],
+            descending=[True, False, True, False],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((1,), (1024, 80), (2, 256, 256), (2, 1, 64, 64)),
+                    "dtype": [np.float32],
+                    "gen_fn": 'Genfunc.zeros',
+                },
+            ],
+        ),
+    ),
+
     'adadelta': dict(
         name=["adadelta"],
         interface=["CustomizedTest"],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1307,6 +1307,44 @@ diopi_configs = {
         ),
     ),
 
+    'asinh': dict(
+        name=['asinh'],
+        interface=['torch'],
+        is_inplace=True,
+        saved_args=dict(output=0),
+        dtype=[np.float16, np.float32, np.float64],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
+    'asinh_not_float': dict(
+        name=['asinh'],
+        interface=['torch'],
+        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
     'sign': dict(
         name=['sign'],
         interface=['torch'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1230,6 +1230,44 @@ diopi_configs = {
         ),
     ),
 
+    'cosh': dict(
+        name=['cosh'],
+        interface=['torch'],
+        is_inplace=True,
+        saved_args=dict(output=0),
+        dtype=[np.float16, np.float32, np.float64],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
+    'cosh_not_float': dict(
+        name=['cosh'],
+        interface=['torch'],
+        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
     'tanh': dict(
         name=['tanh'],
         interface=['torch'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1196,7 +1196,6 @@ diopi_configs = {
         name=['sinh', 'cosh', 'asinh', 'acosh', 'atanh'],
         interface=['torch'],
         is_inplace=True,
-        saved_args=dict(output=0),
         dtype=[np.float16, np.float32, np.float64],
         tensor_para=dict(
             gen_fn='Genfunc.randn',
@@ -5539,6 +5538,46 @@ diopi_configs = {
 
     'argmax_same_value': dict(
         name=['argmax'],
+        interface=["torch"],
+        para=dict(
+            dim=[-1, 0, None, 1],
+            keepdim=[True, False, True, False],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((1,), (1024, 80), (2, 256, 256), (2, 1, 64, 64)),
+                    "dtype": [np.float32],
+                    "gen_fn": 'Genfunc.zeros',
+                },
+            ],
+        ),
+    ),
+
+    'argmin': dict(
+        name=['argmin'],
+        interface=["torch"],
+        para=dict(
+            dim=[0, -1, 0, 1, None, -2, 2, 1],
+            keepdim=[True, False, True, False, False, True, True, False],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1,), (1024, 80), (2, 256, 256), (2, 1, 64, 64),
+                              (12, 0), (2, 0, 9), (0, 9, 8, 7)),
+                    "dtype": [np.float64, np.float16, np.float32, np.int32, np.int16,
+                              np.int64, np.uint8, np.int8],
+                    "gen_fn": 'Genfunc.randn',
+                },
+            ],
+        ),
+    ),
+
+    'argmin_same_value': dict(
+        name=['argmin'],
         interface=["torch"],
         para=dict(
             dim=[-1, 0, None, 1],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -7986,6 +7986,7 @@ diopi_configs = {
         ),
     ),
 
+    #This test config is for the national standard GB operator version of diopiLayerNorm, which is different from the original interface definition.
     'layer_norm': dict(
         name=["layer_norm"],
         dtype=[np.float32, np.float64, np.float16],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1345,6 +1345,44 @@ diopi_configs = {
         ),
     ),
 
+    'acosh': dict(
+        name=['acosh'],
+        interface=['torch'],
+        is_inplace=True,
+        saved_args=dict(output=0),
+        dtype=[np.float16, np.float32, np.float64],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
+    'acosh_not_float': dict(
+        name=['acosh'],
+        interface=['torch'],
+        dtype=[np.int16, np.int32, np.int64, np.uint8, np.int8, np.bool_],
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((), (1, ), (1024,), (364800, 4), (2, 128, 3072),
+                              (256, 128, 3, 3),
+                              (2, 31, 512, 6, 40),
+                              (0,), (16, 0), (1, 0, 6)),
+                },
+            ],
+        ),
+    ),
+
     'sign': dict(
         name=['sign'],
         interface=['torch'],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -1025,7 +1025,7 @@ diopi_configs = {
     ),
 
     'pointwise_op': dict(
-        name=['abs', 'cos', 'erf', 'erfinv', 'exp', 'floor',
+        name=['abs', 'cos', 'erf', 'erfinv', 'exp', 'expm1', 'floor',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'ceil', 'atan'],
         interface=['torch'],
         is_inplace=True,
@@ -1047,7 +1047,7 @@ diopi_configs = {
     'pointwise_op_int_without_inplace': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp',
         #       'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
-        name=['abs', 'cos', 'erf', 'exp',
+        name=['abs', 'cos', 'erf', 'exp', 'expm1',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
         interface=['torch'],
         dtype=[np.int16, np.int32, np.int64, np.int8],
@@ -1068,7 +1068,7 @@ diopi_configs = {
     'pointwise_op_uint8': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp',
         #       'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
-        name=['abs', 'cos', 'erf', 'exp',
+        name=['abs', 'cos', 'erf', 'exp', 'expm1',
               'neg', 'sin', 'asin', 'sqrt', 'logical_not', 'rsqrt', 'atan'],
         interface=['torch'],
         dtype=[np.uint8],
@@ -1103,7 +1103,7 @@ diopi_configs = {
     # FIXME erfinv输入int或bool报错
     'pointwise_op_bool': dict(
         # name=['abs', 'cos', 'erf', 'erfinv', 'exp', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
-        name=['abs', 'cos', 'erf', 'exp', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
+        name=['abs', 'cos', 'erf', 'exp', 'expm1', 'sin', 'asin', 'sqrt', 'rsqrt', 'atan', 'logical_not'],
         interface=['torch'],
         dtype=[np.bool_],
         tensor_para=dict(
@@ -1250,7 +1250,7 @@ diopi_configs = {
     ),
 
     'pointwise_op_zero': dict(
-        name=['abs', 'exp', 'floor', 'neg', 'sqrt',
+        name=['abs', 'exp', 'expm1', 'floor', 'neg', 'sqrt',
               'logical_not', 'rsqrt', 'ceil'],
         interface=['torch'],
         is_inplace=True,
@@ -1267,7 +1267,7 @@ diopi_configs = {
     ),
 
     'pointwise_op_without_inplace_zero': dict(
-        name=['abs', 'sign', 'exp', 'sqrt',
+        name=['abs', 'sign', 'exp', 'expm1', 'sqrt',
               'logical_not', 'rsqrt'],
         interface=['torch'],
         dtype=[np.float16, np.float32, np.float64, np.int16,

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -743,6 +743,32 @@ diopi_configs = {
         ),
     ),
 
+    'pool1d': dict(
+        name=['pool1d'],
+        interface=['CustomizedTest'],
+        para=dict(
+            kernel_size=[2, 2, 6, 2, 3, 6, 5],
+            stride=[None, None, 3, 1, 2, None, 2],
+            padding=[0, 0, 2, 1, 0, 0, 2],
+            dilation=[0, 0, 0, 0, 0, 1, 3],
+            ceil_mode=[False, True, False, True, False, False, True],
+            count_include_pad=[True, True, False, True, False, False, False],
+            mode=["avg", "avg", "avg", "avg", "avg", "max", "max"],
+            adaptive=[False, False, False, False, False, False, False],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((2, 16), (5, 2, 16), (3, 4, 16),
+                              (2, 1024, 14), (256, 28, 28), (3, 12), (5, 4, 17)),
+                    "dtype": [np.float16, np.float32, np.float64],
+                },
+            ]
+        ),
+    ), 
+
     'avg_pool1d': dict(
         name=["avg_pool1d"],
         para=dict(
@@ -866,12 +892,12 @@ diopi_configs = {
         ),
     ),
 
-    'adaptive_max_pool2d_return_indices': dict(
-        name=["adaptive_max_pool2d"],
+    'adaptive_max_pool1d_return_indices': dict(
+        name=["adaptive_max_pool1d"],
         atol=1e-5,
         rtol=1e-4,
         para=dict(
-            output_size=[5, (26, 40), (None, None), (0, 0)],
+            output_size=[5, 26, 3, 0],
             return_indices=[True, True, True, True]
         ),
         tensor_para=dict(
@@ -879,7 +905,7 @@ diopi_configs = {
             args=[
                 {
                     "ins": ['input'],
-                    "shape": ((3, 16, 8), (4, 7, 27, 39), (4, 16, 12), (4, 16, 12)),
+                    "shape": ((3, 16), (4, 7, 27), (4, 16), (4, 16)),
                     "dtype": [np.float32, np.float16, np.float64],
                 },
             ]

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -747,14 +747,15 @@ diopi_configs = {
         name=['pool1d'],
         interface=['CustomizedTest'],
         para=dict(
-            kernel_size=[2, 2, 6, 2, 3, 6, 5],
-            stride=[None, None, 3, 1, 2, None, 2],
-            padding=[0, 0, 2, 1, 0, 0, 2],
-            dilation=[0, 0, 0, 0, 0, 1, 3],
-            ceil_mode=[False, True, False, True, False, False, True],
-            count_include_pad=[True, True, False, True, False, False, False],
-            mode=["avg", "avg", "avg", "avg", "avg", "max", "max"],
-            adaptive=[False, False, False, False, False, False, False],
+            kernel_size=[2, 2, 6, 2, 3, 6, 5, 0, 0, 0, 0],
+            stride=[None, None, 3, 1, 2, None, 2, 0, 0, 0, 0],
+            padding=[0, 0, 2, 1, 0, 0, 2, 0, 0, 0, 0],
+            dilation=[0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0],
+            ceil_mode=[False, True, False, True, False, False, True, False, False, False, False],
+            count_include_pad=[True, True, False, True, False, False, False, False, False, False, False],
+            mode=["avg", "avg", "avg", "avg", "avg", "max", "max", "avg", "avg", "max", "max"],
+            adaptive=[False, False, False, False, False, False, False, True, True, True, True],
+            output_size=[0, 0, 0, 0, 0, 0, 0, 5, 26, 3, 2]
         ),
         tensor_para=dict(
             args=[
@@ -762,7 +763,7 @@ diopi_configs = {
                     "ins": ['input'],
                     "requires_grad": [True],
                     "shape": ((2, 16), (5, 2, 16), (3, 4, 16),
-                              (2, 1024, 14), (256, 28, 28), (3, 12), (5, 4, 17)),
+                              (2, 1024, 14), (256, 28, 28), (3, 12), (5, 4, 17), (3, 16), (4, 7, 27), (4, 16), (288, 33)),
                     "dtype": [np.float16, np.float32, np.float64],
                 },
             ]
@@ -912,6 +913,32 @@ diopi_configs = {
         ),
     ),
 
+    'pool2d': dict(
+        name=['pool2d'],
+        interface=['CustomizedTest'],
+        para=dict(
+            kernel_size=[2, 2, 6, 2, 3, 6, 5, 0, 0, 0, 0],
+            stride=[None, None, 3, 1, 2, None, 2, 0, 0, 0, 0],
+            padding=[0, 0, 2, 1, 0, 0, 2, 0, 0, 0, 0],
+            dilation=[0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0],
+            ceil_mode=[False, True, False, True, False, False, True, False, False, False, False],
+            count_include_pad=[True, True, False, True, False, False, False, False, False, False, False],
+            mode=["avg", "avg", "avg", "avg", "avg", "max", "max", "avg", "avg", "max", "max"],
+            adaptive=[False, False, False, False, False, False, False, True, True, True, True],
+            output_size=[0, 0, 0, 0, 0, 0, 0, 5, 26, 3, 2]
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((2, 16, 16), (5, 2, 16, 16), (3, 4, 16, 16),
+                              (2, 1024, 14, 16), (256, 28, 28, 16), (3, 12, 12), (5, 4, 17, 17), (3, 16, 16), (4, 7, 27, 27), (4, 16, 17), (288, 33, 33)),
+                    "dtype": [np.float16, np.float32, np.float64],
+                },
+            ]
+        ),
+    ), 
     'avg_pool2d': dict(
         name=["avg_pool2d"],
         para=dict(
@@ -6099,6 +6126,33 @@ diopi_configs = {
             ]
         ),
     ),
+
+    'pool3d': dict(
+        name=['pool3d'],
+        interface=['CustomizedTest'],
+        para=dict(
+            kernel_size=[2, 2, 6, 2, 3, 6, 5, 0, 0, 0, 0],
+            stride=[None, None, 3, 1, 2, None, 2, 0, 0, 0, 0],
+            padding=[0, 0, 2, 1, 0, 0, 2, 0, 0, 0, 0],
+            dilation=[0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0],
+            ceil_mode=[False, True, False, True, False, False, True, False, False, False, False],
+            count_include_pad=[True, True, False, True, False, False, False, False, False, False, False],
+            mode=["avg", "avg", "avg", "avg", "avg", "max", "max", "avg", "avg", "max", "max"],
+            adaptive=[False, False, False, False, False, False, False, True, True, True, True],
+            output_size=[0, 0, 0, 0, 0, 0, 0, 5, 26, 3, 2]
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((2, 16, 16, 16), (5, 2, 16, 16, 17), (3, 4, 16, 16, 18),
+                              (2, 1024, 14, 16, 20), (256, 28, 28, 16, 17), (3, 12, 12, 18), (5, 4, 17, 17, 21), (3, 16, 16, 20), (4, 7, 27, 27, 26), (4, 16, 17, 23), (288, 33, 33, 35)),
+                    "dtype": [np.float16, np.float32, np.float64],
+                },
+            ]
+        ),
+    ), 
 
     'avg_pool3d': dict(
         name=["avg_pool3d"],

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -743,6 +743,149 @@ diopi_configs = {
         ),
     ),
 
+    'avg_pool1d': dict(
+        name=["avg_pool1d"],
+        para=dict(
+            kernel_size=[2, 2, 6, 2, 3],
+            stride=[None, None, 3, 1, 2],
+            padding=[0, 0, 2, 1, 0],
+            ceil_mode=[False, True, False, True, False],
+            count_include_pad=[True, True, False, True, False],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((2, 16), (5, 2, 16), (3, 4, 16),
+                              (2, 1024, 14), (256, 28, 28)),
+                    "dtype": [np.float16, np.float32, np.float64],
+                },
+            ]
+        ),
+    ), 
+
+    'max_pool1d': dict(
+        name=["max_pool1d"],
+        para=dict(
+            kernel_size=[6, 5, 6, 8, 3, 2, 3, 3],
+            stride=[None, 2, 2, 3, 2, 2, 1, 2],
+            padding=[0, 2, 2, 3, 1, 0, 1, 0],
+            dilation=[1, 3, 2, 2, 1, 1, 1, 2],
+            ceil_mode=[False, True, False, True, False, True, False, True],
+            return_indices=[False, False, False, False, False, False, False, False],
+        ),
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((3, 12), (5, 4, 17),
+                              (6, 17), (1, 4, 17),
+                              (2, 64, 352),
+                              (2, 256, 12),
+                              (2, 512, 4),
+                              (3, 4)),
+                    "dtype": [np.float16, np.float32, np.float64],
+                },
+            ]
+        ),
+    ),
+
+    'max_pool1d_return_indices': dict(
+        name=["max_pool1d"],
+        para=dict(
+            kernel_size=[6, 6, 8, 8],
+            stride=[None, 3, 3, 2],
+            padding=[0, 1, 2, 3],
+            dilation=[1, 4, 2, 3],
+            ceil_mode=[False, True, False, True],
+            return_indices=[True, True, True, True],
+        ),
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((3, 12), (5, 4, 17),
+                              (6, 17), (1, 4, 17),),
+                    "dtype": [np.float16, np.float32, np.float64],
+                },
+            ]
+        ),
+        requires_backward=[0],
+    ),
+
+    'adaptive_avg_pool1d': dict(
+        name=["adaptive_avg_pool1d"],
+        atol=1e-5,
+        rtol=1e-4,
+        atol_half=1e-2,
+        rtol_half=1e-2,
+        para=dict(
+            output_size=[5, 26, 3, 1, 2,
+                         1, 3, 7, 10],
+        ),
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((3, 16), (4, 7, 27), (4, 16),
+                              (2, 2048, 8), (2, 288, 33),
+                              (2, 144, 65), (2, 1280, 7),
+                              (2, 265, 7), (2, 265, 7)),
+                    "dtype": [np.float16, np.float32, np.float64],
+                },
+            ]
+        ),
+    ),
+
+    'adaptive_max_pool1d': dict(
+        name=["adaptive_max_pool1d"],
+        atol=1e-5,
+        rtol=1e-4,
+        para=dict(
+            output_size=[5, 26, 3, 2, 1, 3, 33, 40],
+            return_indices=[False, False, False, False, False, False, False, False]
+        ),
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((3, 16), (4, 7, 27), (4, 16),
+                              (288, 33), (2, 144, 33), (2, 16, 130),
+                              (2, 144, 33), (2, 144, 33)),
+                    "dtype": [np.float32, np.float16, np.float64],
+                },
+            ]
+        ),
+    ),
+
+    'adaptive_max_pool2d_return_indices': dict(
+        name=["adaptive_max_pool2d"],
+        atol=1e-5,
+        rtol=1e-4,
+        para=dict(
+            output_size=[5, (26, 40), (None, None), (0, 0)],
+            return_indices=[True, True, True, True]
+        ),
+        tensor_para=dict(
+            gen_fn='Genfunc.randn',
+            args=[
+                {
+                    "ins": ['input'],
+                    "shape": ((3, 16, 8), (4, 7, 27, 39), (4, 16, 12), (4, 16, 12)),
+                    "dtype": [np.float32, np.float16, np.float64],
+                },
+            ]
+        ),
+    ),
+
     'avg_pool2d': dict(
         name=["avg_pool2d"],
         para=dict(
@@ -5926,6 +6069,29 @@ diopi_configs = {
                     "shape": (None, (2, ),
                               None, (16,), (64,), (64,), (2,)),
                     "dtype": [np.float32, np.float64, np.float16],
+                },
+            ]
+        ),
+    ),
+
+    'avg_pool3d': dict(
+        name=["avg_pool3d"],
+        para=dict(
+            kernel_size=[2, (2, 2, 2), (20, 13, 13), (2, 2, 2), 3],
+            stride=[None, None, 3, 1, (1, 2, 2)],
+            padding=[0, (0, 0, 0), (2, 3, 2), (1, 1, 1), 0],
+            ceil_mode=[False, True, False, True, False],
+            count_include_pad=[True, True, False, True, False],
+            divisor_override=[None, None, -3, None, 2],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ['input'],
+                    "requires_grad": [True],
+                    "shape": ((2, 16, 7, 7), (5, 2, 16, 7, 7), (3, 4, 23, 23, 23),
+                              (2, 1024, 14, 14, 14), (256, 28, 28, 28)),
+                    "dtype": [np.float16, np.float32, np.float64],
                 },
             ]
         ),

--- a/diopi_test/python/configs/diopi_configs.py
+++ b/diopi_test/python/configs/diopi_configs.py
@@ -7896,8 +7896,45 @@ diopi_configs = {
         )
     ),
 
+    'instance_norm': dict(
+        name=["instance_norm"],
+        dtype=[np.float32, np.float64],
+        atol=1e-5,
+        atol_half=1e-1,
+        rtol_half=1e-2,
+        para=dict(
+            eps=[1e-5, 1e-5, 1e-12, 0, -1e-5, 2],
+        ),
+        tensor_para=dict(
+            args=[
+                {
+                    "ins": ["input"],
+                    "shape": ((3, 5, 3, 5), (2, 16, 128), (2, 64, 16), (2, 32, 16),
+                              (4, 5, 3, 5), (5, 16, 128)),
+                    'gen_fn':'Genfunc.randn',
+                    'requires_grad': [True],
+                },
+                {
+                    "ins": ["weight"],
+                    "shape": ((5,), (16,), (64,), (32,),
+                              (5,), (16,)),
+                    'gen_fn':'Genfunc.randn',
+                    'requires_grad': [True],
+                },
+                {
+                    "ins": ["bias"],
+                    "shape": ((5,), (16,), (64,), (32,),
+                              (5,), (16,)),
+                    'gen_fn':'Genfunc.randn',
+                    'requires_grad': [True],
+                },
+            ]
+        )
+    ),
+
     'layer_normGB': dict(
         name=["layer_normGB"],
+        interface=['CustomizedTest'],
         dtype=[np.float32, np.float64, np.float16],
         atol=1e-5,
         atol_half=1e-1,

--- a/diopi_test/python/conformance/customized_test.py
+++ b/diopi_test/python/conformance/customized_test.py
@@ -824,3 +824,9 @@ class CustomizedTest(object):
             input, target, weight, None, ignore_index, None, reduction
         )
         return out
+
+    def pool1d(input, kernel_size, stride, padding, dilation, ceil_mode, count_include_pad, mode, adaptive):
+        if mode == "avg" and adaptive == False:
+            return torch.avg_pool1d(input, kernel_size, stride, padding, ceil_mode, count_include_pad)
+        elif mode == "max" and adaptive == False:
+            return torch.max_pool1d(input, kernel_size, stride, padding, dilation, ceil_mode)

--- a/diopi_test/python/conformance/customized_test.py
+++ b/diopi_test/python/conformance/customized_test.py
@@ -854,3 +854,7 @@ class CustomizedTest(object):
             return torch.nn.functional.adaptive_avg_pool3d(input, output_size)
         elif mode == "max" and adaptive == True:
             return torch.nn.functional.adaptive_max_pool3d(input, output_size, return_indices=False)
+
+    def layer_normGB(input, weight, bias, eps, normalized_shape):
+        return torch.nn.functional.layer_norm(input=input, weight=weight, bias=bias, eps=eps, normalized_shape=normalized_shape)
+

--- a/diopi_test/python/conformance/customized_test.py
+++ b/diopi_test/python/conformance/customized_test.py
@@ -825,8 +825,32 @@ class CustomizedTest(object):
         )
         return out
 
-    def pool1d(input, kernel_size, stride, padding, dilation, ceil_mode, count_include_pad, mode, adaptive):
+    def pool1d(input, kernel_size, stride, padding, dilation, ceil_mode, count_include_pad, mode, adaptive, output_size):
         if mode == "avg" and adaptive == False:
-            return torch.avg_pool1d(input, kernel_size, stride, padding, ceil_mode, count_include_pad)
+            return torch.nn.functional.avg_pool1d(input, kernel_size, stride, padding, ceil_mode, count_include_pad)
         elif mode == "max" and adaptive == False:
-            return torch.max_pool1d(input, kernel_size, stride, padding, dilation, ceil_mode)
+            return torch.nn.functional.max_pool1d(input, kernel_size, stride, padding, dilation, ceil_mode, return_indices=False)
+        elif mode == "avg" and adaptive == True:
+            return torch.nn.functional.adaptive_avg_pool1d(input, output_size)
+        elif mode == "max" and adaptive == True:
+            return torch.nn.functional.adaptive_max_pool1d(input, output_size, return_indices=False)
+
+    def pool2d(input, kernel_size, stride, padding, dilation, ceil_mode, count_include_pad, mode, adaptive, output_size):
+        if mode == "avg" and adaptive == False:
+            return torch.nn.functional.avg_pool2d(input, kernel_size, stride, padding, ceil_mode, count_include_pad)
+        elif mode == "max" and adaptive == False:
+            return torch.nn.functional.max_pool2d(input, kernel_size, stride, padding, dilation, ceil_mode, return_indices=False)
+        elif mode == "avg" and adaptive == True:
+            return torch.nn.functional.adaptive_avg_pool2d(input, output_size)
+        elif mode == "max" and adaptive == True:
+            return torch.nn.functional.adaptive_max_pool2d(input, output_size, return_indices=False)
+
+    def pool3d(input, kernel_size, stride, padding, dilation, ceil_mode, count_include_pad, mode, adaptive, output_size):
+        if mode == "avg" and adaptive == False:
+            return torch.nn.functional.avg_pool3d(input, kernel_size, stride, padding, ceil_mode, count_include_pad)
+        elif mode == "max" and adaptive == False:
+            return torch.nn.functional.max_pool3d(input, kernel_size, stride, padding, dilation, ceil_mode, return_indices=False)
+        elif mode == "avg" and adaptive == True:
+            return torch.nn.functional.adaptive_avg_pool3d(input, output_size)
+        elif mode == "max" and adaptive == True:
+            return torch.nn.functional.adaptive_max_pool3d(input, output_size, return_indices=False)

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -1509,6 +1509,16 @@ def sort(input, dim=-1, descending=False, stable=None):
     return vals, indices
 
 
+def sort_backward(input, grad_outputs, dim, indice, **kwargs):
+    grad_outputs = grad_outputs[0]
+    grad_input = raw_like(grad_outputs)
+
+    func = check_function("diopiSortBackward")
+    ret = func(input.context(), grad_input, grad_outputs, dim, indice, input.size(), True)
+    check_returncode(ret)
+    return {"input": grad_input} if grad_input.requires_grad else {}
+
+
 def topk(input, k, dim=-1, largest=True, sorted=True):
     sizeI = input.size().data
     if len(sizeI) > 0:

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -8062,14 +8062,3 @@ def spmm(input, mat2) -> Tensor:
     ret = func(input.context(), out, input, mat2)
     check_returncode(ret)
     return out
-
-
-def layer_norm(input, axis, weight, bias, eps):
-    out = raw_like(input)
-    running_mean = raw_like(input)
-    running_var = raw_like(input)
-    func = check_function("diopiLayerNorm")
-    ret = func(input.context(), out, running_mean, running_var, input, axis, weight, bias, eps)
-    check_returncode(ret)
-    return out, running_mean, running_var
-

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -404,6 +404,8 @@ def sin(input, inplace=False) -> Tensor:
 def cos(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiCos", promote_type(input, Dtype.float32))
 
+def tan(input, inplace=False) -> Tensor:
+    return unary_op(input, inplace, "diopiTan", promote_type(input, Dtype.float32))
 
 def tanh(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiTanh", promote_type(input, Dtype.float32))

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -429,6 +429,10 @@ def atan(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiAtan", promote_type(input, Dtype.float32))
 
 
+def asinh(input, inplace=False) -> Tensor:
+    return unary_op(input, inplace, "diopiAsinh", promote_type(input, Dtype.float32))
+
+
 def exp(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiExp", promote_type(input, Dtype.float32))
 

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -436,6 +436,9 @@ def asinh(input, inplace=False) -> Tensor:
 def acosh(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiAcosh", promote_type(input, Dtype.float32))
 
+def atanh(input, inplace=False) -> Tensor:
+    return unary_op(input, inplace, "diopiAtanh", promote_type(input, Dtype.float32))
+
 
 def exp(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiExp", promote_type(input, Dtype.float32))

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -433,6 +433,10 @@ def asinh(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiAsinh", promote_type(input, Dtype.float32))
 
 
+def acosh(input, inplace=False) -> Tensor:
+    return unary_op(input, inplace, "diopiAcosh", promote_type(input, Dtype.float32))
+
+
 def exp(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiExp", promote_type(input, Dtype.float32))
 

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -1545,6 +1545,14 @@ def imag(input):
     check_returncode(ret)
     return out
 
+def real(input):
+    out = raw_like(input)
+    func = check_function("diopiReal")
+    ret = func(input.context(), out, input)
+
+    check_returncode(ret)
+    return out
+
 def topk(input, k, dim=-1, largest=True, sorted=True):
     sizeI = input.size().data
     if len(sizeI) > 0:

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -5270,6 +5270,8 @@ def layer_normGB(input, normalized_shape, weight=None, bias=None, eps=1e-05):
     bias = None if bias is None else bias
 
     out = raw_like(input)
+
+    # Note that, this is the national standard GB operator version, which is different from the diopiLayerNorm interface definition, normalized_shape has changed to begin_norm_axis.
     func = check_function("diopiLayerNormGB")
     ret = func(
         input.context(),

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -404,6 +404,9 @@ def sin(input, inplace=False) -> Tensor:
 def cos(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiCos", promote_type(input, Dtype.float32))
 
+def acos(input, inplace=False) -> Tensor:
+    return unary_op(input, inplace, "diopiAcos", promote_type(input, Dtype.float32))
+
 def tan(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiTan", promote_type(input, Dtype.float32))
 

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -5097,6 +5097,16 @@ def meshgrid(tensors, shape=None):
     check_returncode(ret)
     return out
 
+def grid_sample(input, grid, mode="bilinear"):
+    if len(input.size().data) == 4:
+        out = Tensor(size=(input.size().data[0], input.size().data[1], grid.size().data[1], grid.size().data[2],), dtype=input.dtype())
+    else:
+        out = Tensor(size=(input.size().data[0], input.size().data[1], grid.size().data[1], grid.size().data[2], grid.size().data[3],), dtype=input.dtype())
+    func = check_function("diopiGridSample")
+    ret = func(input.context(), out, input, grid, mode)
+    check_returncode(ret)
+    return out
+
 
 def cast_dtype(input, out) -> Tensor:
     call = "diopiCastDtype"

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -1526,6 +1526,13 @@ def complex(real, imag):
         out = Tensor(out_shape, Dtype.complex64)
     func = check_function("diopiComplex")
     ret = func(real.context(), out, real, imag)
+    check_returncode(ret)
+    return out
+
+def conj(input):
+    out = raw_like(input)
+    func = check_function("diopiConj")
+    ret = func(input.context(), out, input)
 
     check_returncode(ret)
     return out

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -3382,6 +3382,15 @@ def cumsum(input, dim, dtype=None):
     return out
 
 
+def cumsum_backward(input, grad_outputs, dim, **kwargs):
+    grad_output = grad_outputs[0]
+    grad_input = raw_like(input)
+    func = check_function("diopiCumsumBackward")
+    ret = func(input.context(), grad_input, grad_output, dim)
+    check_returncode(ret)
+    return {"input": grad_input} if grad_input.requires_grad else {}
+
+
 def infer_size(a, b):
     dimsA = len(a)
     dimsB = len(b)

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -1518,6 +1518,17 @@ def sort_backward(input, grad_outputs, dim, indice, **kwargs):
     check_returncode(ret)
     return {"input": grad_input} if grad_input.requires_grad else {}
 
+def complex(real, imag):
+    out_shape = infer_size(real.size().data, imag.size().data)
+    if real.get_dtype() == Dtype.float64:
+        out = Tensor(out_shape, Dtype.complex128)
+    elif real.get_dtype() == Dtype.float32:
+        out = Tensor(out_shape, Dtype.complex64)
+    func = check_function("diopiComplex")
+    ret = func(real.context(), out, real, imag)
+
+    check_returncode(ret)
+    return out
 
 def topk(input, k, dim=-1, largest=True, sorted=True):
     sizeI = input.size().data

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -3586,6 +3586,14 @@ def argmin(input, dim=None, keepdim=False):
 
     return out
 
+def argsort(input, dim=-1, descending=False, stable=False):
+    out = Tensor(input.size().data, from_numpy_dtype(glob_vars.int_type))
+    func = check_function("diopiArgsort")
+    ret = func(input.context(), out, input, stable, dim, descending)
+    check_returncode(ret)
+
+    return out
+
 
 def smooth_l1_loss(input, target, reduction="mean", beta=1.0):
     assert (

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -1075,6 +1075,241 @@ def conv2d(
     check_returncode(ret)
     return out
 
+def pool1d(input, kernel_size=0, stride=None, padding=0, dilation=1, ceil_mode=False, count_include_pad=True, output_size=0, mode="avg", adaptive=False) -> Tensor:
+
+    sizeI = input.size().data
+    assert len(sizeI) == 3 or len(sizeI) == 2, "input must be 2d or 3d tensors"
+    sizeO = []
+    sizeO.append(sizeI[0])
+    if len(sizeI) == 3:
+        sizeO.append(sizeI[1])
+
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size,)
+    if stride is None:
+        stride = kernel_size
+    if isinstance(stride, int):
+        stride = (stride,)
+    if isinstance(padding, int):
+        padding = (padding,)
+    if isinstance(dilation, int):
+        dilation = (dilation,)
+    if isinstance(output_size, int):
+        output_size = (output_size,)
+
+    if mode == "avg" and adaptive == False:
+        for i in range(-1, 0):
+            if ceil_mode:
+                sizeO.append(
+                    math.ceil((sizeI[i] - kernel_size[i] + 2 * padding[i]) / stride[i]) + 1
+                )
+            else:
+                sizeO.append(
+                    math.floor((sizeI[i] - kernel_size[i] + 2 * padding[i]) / stride[i]) + 1
+                )
+    
+        stride = Sizes(list(stride))
+        padding = Sizes(list(padding))
+        kernel_size = Sizes(list(kernel_size))
+        dilation = Sizes(list(dilation))
+        output_size = Sizes(list(output_size))
+        nhwc_stride = compute_nhwc_stride_1d(sizeO) if glob_vars.nhwc else None
+        out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
+    
+        func = check_function("diopiPool1d")
+        ret = func(
+                input.context(),
+                out,
+                input,
+                "avg",
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                ceil_mode,
+                not count_include_pad,
+                False,
+                output_size,
+        )
+        check_returncode(ret)
+        return out
+    elif mode == "max" and adaptive == False:
+        for i in range(-1, 0):
+            tmp_ker_size = kernel_size[i] + (kernel_size[i] - 1) * (dilation[i] - 1)
+            tmp_size = (sizeI[i] - tmp_ker_size + 2 * padding[i]) / stride[i] + 1
+            tmp_size = tmp_size if tmp_size > 1 else 1
+            if ceil_mode:
+                sizeO.append(math.ceil(tmp_size))
+            else:
+                sizeO.append(math.floor(tmp_size))
+    
+        stride = Sizes(list(stride))
+        padding = Sizes(list(padding))
+        kernel_size = Sizes(list(kernel_size))
+        dilation = Sizes(list(dilation))
+        output_size = Sizes(list(output_size))
+        nhwc_stride = compute_nhwc_stride_1d(sizeO) if glob_vars.nhwc else None
+        out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)  
+
+        func = check_function("diopiPool1d")
+        ret = func(
+                input.context(),
+                out,
+                input,
+                "max",
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                ceil_mode,
+                not count_include_pad,
+                False,
+                output_size,
+        )
+        check_returncode(ret)
+        return out
+    elif mode == "avg" and adaptive == True:
+        for i in range(-1, 0):
+            if output_size[i] is None:
+                sizeO.append(sizeI[i])
+            else:
+                sizeO.append(output_size[i])
+    
+        nhwc_stride = compute_nhwc_stride_1d(sizeO) if glob_vars.nhwc else None
+        out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
+        output_size = Sizes(list([sizeO[-1],]))
+    
+        func = check_function("diopiPool1d")
+        ret = func(
+                input.context(),
+                out,
+                input,
+                "avg",
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                ceil_mode,
+                not count_include_pad,
+                True,
+                output_size,
+        )
+ 
+        check_returncode(ret)
+        return out
+    else:
+        for i in range(-1, 0):
+            if output_size[i] is None:
+                sizeO.append(sizeI[i])
+            else:
+                sizeO.append(output_size[i])
+    
+        nhwc_stride = compute_nhwc_stride_1d(sizeO) if glob_vars.nhwc else None
+        out = Tensor(sizeO, input.get_dtype(), stride=nhwc_stride)
+        output_size = Sizes(list([sizeO[-1],]))
+    
+        func = check_function("diopiPool1d")
+        ret = func(
+                input.context(),
+                out,
+                input,
+                "max",
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                ceil_mode,
+                not count_include_pad,
+                True,
+                output_size,
+        )
+ 
+        check_returncode(ret)
+        return out
+    
+        
+def pool1d_backward(input, grad_outputs, kernel_size=0, stride=0, padding=0, dilation=0, ceil_mode=0, count_include_pad=True, mode="avg", adaptive=False, **kwargs,) -> Tensor:
+
+    assert len(grad_outputs) == 1, "only accept 1 gradient to do backward"
+    grad_input = raw_like(input)
+
+    if isinstance(kernel_size, int):
+        kernel_size = (kernel_size,)
+        if stride is None:
+            stride = kernel_size
+        if isinstance(stride, int):
+            stride = (stride,)
+        if isinstance(padding, int):
+            padding = (padding,)
+        if isinstance(dilation, int):
+            dilation = (dilation,)
+
+    
+    if mode == "avg" and adaptive == False:
+       
+        stride = Sizes(list(stride))
+        padding = Sizes(list(padding))
+        kernel_size = Sizes(list(kernel_size))
+        dilation = Sizes(list(dilation))
+        
+        indices = raw_like(input)
+    
+        func = check_function("diopiPool1dBackward")
+        ret = (
+            func(
+                input.context(),
+                grad_input,
+                grad_outputs[0],
+                input,
+                "avg",
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                ceil_mode,
+                not count_include_pad,
+                False,
+                indices, 
+            )
+        )
+        check_returncode(ret)
+        return {"input": grad_input} if grad_input.requires_grad else {}
+    elif mode == "max" and adaptive == False:
+
+        _, indices = max_pool1d(
+           input, kernel_size, stride, padding, dilation, ceil_mode, True
+        )
+        stride = Sizes(list(stride))
+        padding = Sizes(list(padding))
+        kernel_size = Sizes(list(kernel_size))
+        dilation = Sizes(list(dilation))
+    
+        func = check_function("diopiPool1dBackward")
+        ret = (
+            func(
+                input.context(),
+                grad_input,
+                grad_outputs[0],
+                input,
+                "max",
+                kernel_size,
+                stride,
+                padding,
+                dilation,
+                ceil_mode,
+                not count_include_pad,
+                False,
+                indices, 
+            )
+        )
+        check_returncode(ret)
+        return {"input": grad_input} if grad_input.requires_grad else {}
+ 
+        
+          
+  
+
+
 def avg_pool1d(
     input,
     kernel_size,
@@ -1143,13 +1378,13 @@ def avg_pool1d_backward(
     assert len(grad_outputs) == 1, "only accept 1 gradient to do backward"
     grad_input = raw_like(input)
     if isinstance(kernel_size, int):
-        kernel_size = (kernel_size, kernel_size)
+        kernel_size = (kernel_size,)
     if stride is None:
         stride = kernel_size
     if isinstance(stride, int):
-        stride = (stride, stride)
+        stride = (stride,)
     if isinstance(padding, int):
-        padding = (padding, padding)
+        padding = (padding,)
 
     stride = Sizes(list(stride))
     padding = Sizes(list(padding))
@@ -1310,7 +1545,7 @@ def adaptive_avg_pool1d(input, output_size):
         sizeO.append(sizeI[1])
 
     if isinstance(output_size, int):
-        output_size = (output_size, output_size)
+        output_size = (output_size,)
 
     for i in range(-1, 0):
         if output_size[i] is None:
@@ -1338,7 +1573,7 @@ def adaptive_max_pool1d(input, output_size, return_indices=False):
         sizeO.append(sizeI[1])
 
     if isinstance(output_size, int):
-        output_size = (output_size, output_size)
+        output_size = (output_size,)
 
     for i in range(-1, 0):
         if output_size[i] is None:

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -1537,6 +1537,14 @@ def conj(input):
     check_returncode(ret)
     return out
 
+def imag(input):
+    out = raw_like(input)
+    func = check_function("diopiImag")
+    ret = func(input.context(), out, input)
+
+    check_returncode(ret)
+    return out
+
 def topk(input, k, dim=-1, largest=True, sorted=True):
     sizeI = input.size().data
     if len(sizeI) > 0:

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -416,6 +416,9 @@ def atan(input, inplace=False) -> Tensor:
 def exp(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiExp", promote_type(input, Dtype.float32))
 
+def expm1(input, inplace=False) -> Tensor:
+    return unary_op(input, inplace, "diopiExpm1", promote_type(input, Dtype.float32))
+
 
 def log(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiLog", promote_type(input, Dtype.float32))

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -3563,6 +3563,29 @@ def argmax(input, dim=None, keepdim=False):
 
     return out
 
+def argmin(input, dim=None, keepdim=False):
+    sizeO = list(input.size().data)
+    if len(sizeO) > 0 and dim is not None:
+        assert dim < len(sizeO), "dim out of index"
+        if keepdim:
+            sizeO[dim] = 1
+        else:
+            sizeO = sizeO[:dim] + sizeO[dim + 1 :]
+    else:
+        sizeO = [1]
+
+    out = Tensor(sizeO, from_numpy_dtype(glob_vars.int_type))
+    func = check_function("diopiArgmin")
+    # todo: check the reason of using keepdim
+    ret = (
+        func(input.context(), out, input, keepdim)
+        if dim is None
+        else func(input.context(), out, input, dim, keepdim)
+    )
+    check_returncode(ret)
+
+    return out
+
 
 def smooth_l1_loss(input, target, reduction="mean", beta=1.0):
     assert (

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -404,11 +404,18 @@ def sin(input, inplace=False) -> Tensor:
 def cos(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiCos", promote_type(input, Dtype.float32))
 
+
 def acos(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiAcos", promote_type(input, Dtype.float32))
 
+
 def tan(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiTan", promote_type(input, Dtype.float32))
+
+
+def sinh(input, inplace=False) -> Tensor:
+    return unary_op(input, inplace, "diopiSinh", promote_type(input, Dtype.float32))
+
 
 def tanh(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiTanh", promote_type(input, Dtype.float32))
@@ -420,6 +427,7 @@ def atan(input, inplace=False) -> Tensor:
 
 def exp(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiExp", promote_type(input, Dtype.float32))
+
 
 def expm1(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiExpm1", promote_type(input, Dtype.float32))

--- a/diopi_test/python/conformance/diopi_functions.py
+++ b/diopi_test/python/conformance/diopi_functions.py
@@ -417,6 +417,10 @@ def sinh(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiSinh", promote_type(input, Dtype.float32))
 
 
+def cosh(input, inplace=False) -> Tensor:
+    return unary_op(input, inplace, "diopiCosh", promote_type(input, Dtype.float32))
+
+
 def tanh(input, inplace=False) -> Tensor:
     return unary_op(input, inplace, "diopiTanh", promote_type(input, Dtype.float32))
 

--- a/diopi_test/python/conformance/diopi_runtime.py
+++ b/diopi_test/python/conformance/diopi_runtime.py
@@ -138,6 +138,19 @@ def to_numpy_dtype(dtype: Dtype) -> np.dtype:
 def is_dtype(dtype) -> bool:
     return isinstance(dtype, Dtype)
 
+def compute_nhwc_stride_1d(sizes, itemsize=1):
+   dim = len(sizes) 
+   strides = [itemsize for i in range(dim)]
+   assert dim == 2 or dim == 3, "not supported dim"
+   if dim == 2:
+      strides[0] = itemsize
+      strides[1] = strides[0] * sizes[0]
+   elif dim == 3:
+      strides[1] = itemsize
+      strides[2] = strides[0] * sizes[1]
+      strides[0] = strides[2] * sizes[2]
+   return strides
+
 
 def compute_nhwc_stride_2d(sizes, itemsize=1):
     dim = len(sizes)

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -1018,6 +1018,23 @@ diopiError_t diopiExpInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
     return diopiSuccess;
 }
 
+diopiError_t diopiExpm1(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    CALL_ATEN_CUDA_FUNC(expm1_out, atOut, atInput);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiExpm1Inp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    CALL_ATEN_CUDA_FUNC(expm1_, atInput);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiLog(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -133,6 +133,29 @@ diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHand
     return diopiSuccess;
 }
 
+// TODO
+diopiError_t diopiPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t kernel_size,
+                         diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode, bool exclusive, bool adaptive) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    at::IntArrayRef atKernelSize = impl::aten::buildAtIntArray(kernel_size);
+    at::IntArrayRef atStride = impl::aten::buildAtIntArray(stride);
+    at::IntArrayRef atPadding = impl::aten::buildAtIntArray(padding);
+    at::IntArrayRef atDilation = impl::aten::buildAtIntArray(dilation);
+    bool atCeilMode = ceil_mode;
+    at::Tensor atOut = {};
+    if (strcmp(mode, "max") == 0 && adaptive) {
+    }
+    if (strcmp(mode, "max") == 0 && !adaptive) {
+    }
+    if (strcmp(mode, "avg") == 0 && adaptive) {
+    }
+    if (strcmp(mode, "avg") == 0 && !adaptive) {
+    }
+
+    return diopiSuccess;
+}
+
 /**
  * @brief
  * @param rounding_mode supported in pytorch>=1.8
@@ -769,6 +792,7 @@ diopiError_t diopiSortBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gra
 }
 
 diopiError_t diopiComplex(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t real, diopiConstTensorHandle_t imag) {
+    impl::aten::setCurStream(ctx);
     auto atReal = impl::aten::buildATen(real);
     auto atImag = impl::aten::buildATen(imag);
     auto atOut = impl::aten::buildATen(out);
@@ -779,6 +803,7 @@ diopiError_t diopiComplex(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
 }
 
 diopiError_t diopiConj(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);
     auto atOut = impl::aten::buildATen(out);
     atOut = torch::conj(atInput);
@@ -788,6 +813,7 @@ diopiError_t diopiConj(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
 }
 
 diopiError_t diopiImag(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);
     auto atOut = impl::aten::buildATen(out);
     atOut = torch::imag(atInput);
@@ -797,6 +823,7 @@ diopiError_t diopiImag(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
 }
 
 diopiError_t diopiReal(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);
     auto atOut = impl::aten::buildATen(out);
     atOut = torch::real(atInput);
@@ -3014,6 +3041,22 @@ diopiError_t diopiMeshGrid(diopiContextHandle_t ctx, diopiTensorHandle_t* outs, 
     for (int i = 0; i < outsNum; ++i) {
         impl::aten::updateATen2Tensor(ctx, atOuts[i].contiguous(), outs[i]);
     }
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiGridSample(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t grid,
+                             const char* mode) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atGrid = impl::aten::buildATen(grid);
+    auto atOut = impl::aten::buildATen(out);
+    int interpolation_mode = 0;
+    if (strcmp(mode, "bilinear") != 0) {
+        interpolation_mode = 1;
+    }
+    atOut = CALL_ATEN_FUNC(grid_sampler, atInput, atGrid, interpolation_mode, 0, 0);
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
 
     return diopiSuccess;
 }

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -755,6 +755,19 @@ diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t values, dio
     return diopiSuccess;
 }
 
+diopiError_t diopiSortBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, int64_t dim,
+                               diopiConstTensorHandle_t indices, diopiSize_t sizes, bool keepdim = 1) {
+    impl::aten::setCurStream(ctx);
+    auto atGrad_input = impl::aten::buildATen(grad_input);
+    auto atGrad_output = impl::aten::buildATen(grad_output);
+    auto atIndices = impl::aten::buildATen(indices);
+    auto atSizes = impl::aten::buildAtIntArray(sizes);
+    atGrad_input = CALL_ATEN_FUNC(value_selecting_reduction_backward, atGrad_output, dim, atIndices, atSizes, keepdim);
+    impl::aten::updateATen2Tensor(ctx, atGrad_input, grad_input);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiTopk(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t k,
                        int64_t dim, bool largest, bool sorted) {
     impl::aten::setCurStream(ctx);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -830,6 +830,23 @@ diopiError_t diopiCosInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
     return diopiSuccess;
 }
 
+diopiError_t diopiAcos(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    CALL_ATEN_CUDA_FUNC(acos_out, atOut, atInput);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAcosInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    CALL_ATEN_CUDA_FUNC(acos_, atInput);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiTan(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -1060,6 +1060,23 @@ diopiError_t diopiAcoshInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) 
     return diopiSuccess;
 }
 
+diopiError_t diopiAtanh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    CALL_ATEN_CUDA_FUNC(atanh_out, atOut, atInput);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAtanhInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    CALL_ATEN_CUDA_FUNC(atanh_, atInput);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiSigmoid(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -103,6 +103,189 @@ diopiError_t diopiLeakyReluInp(diopiContextHandle_t ctx, diopiTensorHandle_t inp
     return diopiSuccess;
 }
 
+diopiError_t diopiMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride,
+                            diopiSize_t padding, diopiSize_t dilation, bool ceil_mode) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    at::IntArrayRef atKernelSize = impl::aten::buildAtIntArray(kernel_size);
+    at::IntArrayRef atStride = impl::aten::buildAtIntArray(stride);
+    at::IntArrayRef atPadding = impl::aten::buildAtIntArray(padding);
+    at::IntArrayRef atDilation = impl::aten::buildAtIntArray(dilation);
+    bool atCeilMode = ceil_mode;
+    auto atOut = CALL_ATEN_FUNC(max_pool1d, atInput, atKernelSize, atStride, atPadding, atDilation, atCeilMode);
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiMaxPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                    diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation,
+                                    bool ceil_mode, diopiConstTensorHandle_t indices) {
+    impl::aten::setCurStream(ctx);
+    auto atGradOutput = impl::aten::buildATen(grad_output);
+    auto atInput = impl::aten::buildATen(input);
+    at::IntArrayRef atKernelSize = impl::aten::buildAtIntArray(kernel_size);
+    at::IntArrayRef atStride = impl::aten::buildAtIntArray(stride);
+    at::IntArrayRef atPadding = impl::aten::buildAtIntArray(padding);
+    at::IntArrayRef atDilation = impl::aten::buildAtIntArray(dilation);
+    auto atIndices = impl::aten::buildATen(indices);
+
+    auto atGrad2d = CALL_ATEN_FUNC(max_pool2d_with_indices_backward, atGradOutput.unsqueeze(-2), atInput.unsqueeze(-2), {1, atKernelSize[0]}, {1, atStride[0]}, {0, atPadding[0]}, {1, atDilation[0]}, ceil_mode, atIndices.unsqueeze(-2));
+
+    auto atGradInput = atGrad2d.squeeze(-2);
+
+    impl::aten::updateATen2Tensor(ctx, atGradInput, grad_input);
+
+    // CALL_ATEN_FUNC(
+      //  max_pool1d_with_indices_backward_out, atGradInput, atGradOutput, atInput, atKernelSize, atStride, atPadding, atDilation, ceil_mode, atIndices);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices, diopiConstTensorHandle_t input,
+                                       diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    at::IntArrayRef atKernelSize = impl::aten::buildAtIntArray(kernel_size);
+    at::IntArrayRef atStride = impl::aten::buildAtIntArray(stride);
+    at::IntArrayRef atPadding = impl::aten::buildAtIntArray(padding);
+    at::IntArrayRef atDilation = impl::aten::buildAtIntArray(dilation);
+    auto atOut = impl::aten::buildATen(out);
+    auto atIndices = impl::aten::buildATen(indices);
+    bool atCeilMode = ceil_mode;
+    std::tuple<at::Tensor, at::Tensor> atRes = CALL_ATEN_FUNC(max_pool1d_with_indices, atInput, atKernelSize, atStride, atPadding, atDilation, atCeilMode);
+
+    impl::aten::updateATen2Tensor(ctx, std::get<0>(atRes), out);
+    impl::aten::updateATen2Tensor(ctx, std::get<1>(atRes), indices);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride,
+                            diopiSize_t padding, bool ceil_mode, bool count_include_pad) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    at::IntArrayRef atKernelSize = impl::aten::buildAtIntArray(kernel_size);
+    at::IntArrayRef atStride = impl::aten::buildAtIntArray(stride);
+    at::IntArrayRef atPadding = impl::aten::buildAtIntArray(padding);
+    auto atOut = CALL_ATEN_FUNC(avg_pool1d, atInput, atKernelSize, atStride, atPadding, ceil_mode, count_include_pad);
+
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAvgPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                    diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode,
+                                    bool count_include_pad) {
+    impl::aten::setCurStream(ctx);
+    auto atGradOutput = impl::aten::buildATen(grad_output);
+    auto atInput = impl::aten::buildATen(input);
+    at::IntArrayRef atKernelSize = impl::aten::buildAtIntArray(kernel_size);
+    at::IntArrayRef atStride = impl::aten::buildAtIntArray(stride);
+    at::IntArrayRef atPadding = impl::aten::buildAtIntArray(padding);
+
+    auto atGrad2d = CALL_ATEN_FUNC(avg_pool2d_backward, atGradOutput.unsqueeze(-2), atInput.unsqueeze(-2), {1, atKernelSize[0]}, {1, atStride[0]}, {0, atPadding[0]}, ceil_mode, count_include_pad, c10::nullopt);
+
+    auto atGradInput = atGrad2d.squeeze(-2);
+
+    impl::aten::updateATen2Tensor(ctx, atGradInput, grad_input);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAdaptiveMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t output_size) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOutSize = impl::aten::buildAtIntArray(output_size);
+    auto atOuts = at::adaptive_max_pool1d(atInput, atOutSize);
+    impl::aten::updateATen2Tensor(ctx, std::get<0>(atOuts), out);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAdaptiveMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices, diopiConstTensorHandle_t input,
+                                               diopiSize_t output_size) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOutSize = impl::aten::buildAtIntArray(output_size);
+    auto [atOut, atIndices] = CALL_ATEN_FUNC(adaptive_max_pool1d, atInput, atOutSize);
+
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+    impl::aten::updateATen2Tensor(ctx, atIndices, indices);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAdaptiveMaxPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                            diopiConstTensorHandle_t input, diopiConstTensorHandle_t indices) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atGradOutput = impl::aten::buildATen(grad_output);
+    auto atIndices = impl::aten::buildATen(indices);
+    auto atGrad2d = CALL_ATEN_FUNC(adaptive_max_pool2d_backward, atGradOutput.unsqueeze(-2), atInput.unsqueeze(-2), atIndices.squeeze(-2));
+    auto atGradInput = atGrad2d.squeeze(-2);    
+
+    impl::aten::updateATen2Tensor(ctx, atGradInput, grad_input);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAdaptiveAvgPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                            diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atGradOutput = impl::aten::buildATen(grad_output);
+    auto atInput = impl::aten::buildATen(input);
+    auto atGrad2d = CALL_ATEN_FUNC(_adaptive_avg_pool2d_backward, atGradOutput.unsqueeze(-2), atInput.unsqueeze(-2));
+    auto atGradInput = atGrad2d.squeeze(-2);
+
+    impl::aten::updateATen2Tensor(ctx, atGradInput, grad_input);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAdaptiveAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t output_size) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOutSize = impl::aten::buildAtIntArray(output_size);
+    auto atOut = CALL_ATEN_FUNC(adaptive_avg_pool1d, atInput, atOutSize);
+
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size) {
+  impl::aten::setCurStream(ctx);
+
+  if (adaptive == false && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiMaxPool1d(ctx, out, input, ksize, stride, padding, dilation, ceil_mode);
+  } else if (adaptive == false && strcmp(mode, "avg") == 0) {
+    return impl::cuda::diopiAvgPool1d(ctx, out, input, ksize, stride, padding, ceil_mode, !exclusive);
+  } else if (adaptive == true && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiAdaptiveMaxPool1d(ctx, out, input, output_size);
+  } else {
+    return impl::cuda::diopiAdaptiveAvgPool1d(ctx, out, input, output_size);
+  }
+  
+}
+
+diopiError_t diopiPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices) {
+  impl::aten::setCurStream(ctx);
+
+  if (adaptive == false && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiMaxPool1dBackward(ctx, grad_input, grad_output, input, ksize, stride, padding, dilation, ceil_mode, indices);
+  } else if (adaptive == false && strcmp(mode, "avg") == 0) {
+    return impl::cuda::diopiAvgPool1dBackward(ctx, grad_input, grad_output, input, ksize, stride, padding, ceil_mode, !exclusive);
+  } else if (adaptive == true && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiAdaptiveMaxPool1dBackward(ctx, grad_input, grad_output, input, indices);
+  } else {
+    return impl::cuda::diopiAdaptiveAvgPool1dBackward(ctx, grad_input, grad_output, input);
+  }
+  
+}
+
+
 diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride,
                             diopiSize_t padding, diopiSize_t dilation, bool ceil_mode) {
     impl::aten::setCurStream(ctx);
@@ -117,6 +300,7 @@ diopiError_t diopiMaxPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
 
     return diopiSuccess;
 }
+
 
 diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices, diopiConstTensorHandle_t input,
                                        diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode) {
@@ -2112,6 +2296,36 @@ diopiError_t diopiAvgPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, d
     CALL_ATEN_CUDA_FUNC(avg_pool2d_out, atOut, atInput, atKernelSize, atStride, atPadding, ceil_mode, count_include_pad, atDivisorOverride);
 
     return diopiSuccess;
+}
+
+diopiError_t diopiPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size) {
+  impl::aten::setCurStream(ctx);
+
+  if (adaptive == false && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiMaxPool2d(ctx, out, input, ksize, stride, padding, dilation, ceil_mode);
+  } else if (adaptive == false && strcmp(mode, "avg") == 0) {
+    return impl::cuda::diopiAvgPool2d(ctx, out, input, ksize, stride, padding, ceil_mode, !exclusive, nullptr);
+  } else if (adaptive == true && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiAdaptiveMaxPool2d(ctx, out, input, output_size);
+  } else {
+    return impl::cuda::diopiAdaptiveAvgPool2d(ctx, out, input, output_size);
+  }
+  
+}
+
+diopiError_t diopiPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices) {
+  impl::aten::setCurStream(ctx);
+
+  if (adaptive == false && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiMaxPool2dBackward(ctx, grad_input, grad_output, input, ksize, stride, padding, dilation, ceil_mode, indices);
+  } else if (adaptive == false && strcmp(mode, "avg") == 0) {
+    return impl::cuda::diopiAvgPool2dBackward(ctx, grad_input, grad_output, input, ksize, stride, padding, ceil_mode, !exclusive, nullptr);
+  } else if (adaptive == true && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiAdaptiveMaxPool2dBackward(ctx, grad_input, grad_output, input, indices);
+  } else {
+    return impl::cuda::diopiAdaptiveAvgPool2dBackward(ctx, grad_input, grad_output, input);
+  }
+  
 }
 
 diopiError_t diopiDropout(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t mask, diopiConstTensorHandle_t input, double p, bool train,
@@ -4127,6 +4341,62 @@ diopiError_t diopiMaxPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
         max_pool3d_with_indices_backward_out, atGradInput, atGradOutput, atInput, atKernelSize, atStride, atPadding, atDilation, ceil_mode, atIndices);
 
     return diopiSuccess;
+}
+
+diopiError_t diopiAvgPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad, const int64_t* divisor_override) {
+  impl::aten::setCurStream(ctx);
+
+  auto atInput = impl::aten::buildATen(input);
+  at::IntArrayRef atKernelSize = impl::aten::buildAtIntArray(kernel_size);
+  at::IntArrayRef atStride = impl::aten::buildAtIntArray(stride);
+  at::IntArrayRef atPadding = impl::aten::buildAtIntArray(padding);
+  c10::optional<int64_t> atDivisorOverride = divisor_override ? c10::optional<int64_t>(*divisor_override) : c10::nullopt;
+  auto atOut = impl::aten::buildATen(out);
+  CALL_ATEN_CUDA_FUNC(avg_pool3d_out, atOut, atInput, atKernelSize, atStride, atPadding, ceil_mode, count_include_pad, atDivisorOverride);
+
+  return diopiSuccess;
+}
+
+diopiError_t diopiAvgPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad, const int64_t* divisor_override) {
+  impl::aten::setCurStream(ctx);
+  auto atGradOutput = impl::aten::buildATen(grad_output);
+  auto atInput = impl::aten::buildATen(input);
+  at::IntArrayRef atKernelSize = impl::aten::buildAtIntArray(kernel_size);
+  at::IntArrayRef atStride = impl::aten::buildAtIntArray(stride);
+  at::IntArrayRef atPadding = impl::aten::buildAtIntArray(padding);
+  c10::optional<int64_t> atDivisorOverride = divisor_override ? c10::optional<int64_t>(*divisor_override) : c10::nullopt;
+  auto atGradInput = impl::aten::buildATen(grad_input);
+  CALL_ATEN_CUDA_FUNC(avg_pool3d_backward_out, atGradInput, atGradOutput, atInput, atKernelSize, atStride, atPadding, ceil_mode, count_include_pad, atDivisorOverride);
+}
+
+diopiError_t diopiPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size) {
+  impl::aten::setCurStream(ctx);
+
+  if (adaptive == false && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiMaxPool3d(ctx, out, input, ksize, stride, padding, dilation, ceil_mode);
+  } else if (adaptive == false && strcmp(mode, "avg") == 0) {
+    return impl::cuda::diopiAvgPool3d(ctx, out, input, ksize, stride, padding, ceil_mode, !exclusive, nullptr);
+  } else if (adaptive == true && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiAdaptiveMaxPool3d(ctx, out, input, output_size);
+  } else {
+    return impl::cuda::diopiAdaptiveAvgPool3d(ctx, out, input, output_size);
+  }
+  
+}
+
+diopiError_t diopiPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices) {
+  impl::aten::setCurStream(ctx);
+
+  if (adaptive == false && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiMaxPool3dBackward(ctx, grad_input, grad_output, input, ksize, stride, padding, dilation, ceil_mode, indices);
+  } else if (adaptive == false && strcmp(mode, "avg") == 0) {
+    return impl::cuda::diopiAvgPool3dBackward(ctx, grad_input, grad_output, input, ksize, stride, padding, ceil_mode, !exclusive, nullptr);
+  } else if (adaptive == true && strcmp(mode, "max") == 0) {
+    return impl::cuda::diopiAdaptiveMaxPool3dBackward(ctx, grad_input, grad_output, input, indices);
+  } else {
+    return impl::cuda::diopiAdaptiveAvgPool3dBackward(ctx, grad_input, grad_output, input);
+  }
+  
 }
 
 diopiError_t diopiPermute(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t dims) {

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -3429,7 +3429,8 @@ diopiError_t diopiAdam(diopiContextHandle_t ctx, diopiTensorHandle_t param, diop
     if (weight_decay != 0) {
         grad_d = grad_d.add(atParam, weight_decay);
     }
-    atExpAvg.mul_(beta1).add_(grad_d, 1 - beta1);
+    // atExpAvg.mul_(beta1).add_(grad_d, 1 - beta1);
+    atExpAvg.lerp_(grad_d, 1 - beta1);
     atExpAvgSq.mul_(beta2).addcmul_(grad_d, grad_d.conj(), 1 - beta2);
 
     at::Tensor denom;
@@ -4035,19 +4036,6 @@ diopiError_t diopiNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gra
     impl::aten::updateATen2Tensor(ctx, atGradInput, grad_input);
     return diopiSuccess;
 }
-
-/*
-diopiError_t diopiNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiConstTensorHandle_t grad_input,
-diopiConstTensorHandle_t result, const diopiScalar_t* p, diopiSize_t dim) { impl::aten::setCurStream(ctx); auto atInput = impl::aten::buildATen(input); auto
-atGradInput = impl::aten::buildATen(grad_input); auto atP = impl::aten::buildAtScalar(p); auto atResult = impl::aten::buildATen(result); at::IntArrayRef atDim =
-impl::aten::buildAtIntArray(dim);
-
-    bool keepdim = true;
-    auto atGradOutput = torch::autograd::generated::details::norm_backward(atGradInput, atInput, atP, atResult, atDim, keepdim);
-
-    return diopiSuccess;
-}
-*/
 
 diopiError_t diopiForeachnormScalar(diopiContextHandle_t ctx, diopiTensorHandle_t* outs, diopiConstTensorHandle_t* inputs, int64_t inputSize,
                                     const diopiScalar_t* ord) {

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -1026,6 +1026,23 @@ diopiError_t diopiAtanInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
     return diopiSuccess;
 }
 
+diopiError_t diopiAsinh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    CALL_ATEN_CUDA_FUNC(asinh_out, atOut, atInput);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAsinhInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    CALL_ATEN_CUDA_FUNC(asinh_, atInput);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiSigmoid(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -975,6 +975,23 @@ diopiError_t diopiSinhInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
     return diopiSuccess;
 }
 
+diopiError_t diopiCosh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    CALL_ATEN_CUDA_FUNC(cosh_out, atOut, atInput);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiCoshInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    CALL_ATEN_CUDA_FUNC(cosh_, atInput);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiTanh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -3210,6 +3210,16 @@ diopiError_t diopiArgmin(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     return diopiSuccess;
 }
 
+diopiError_t diopiArgsort(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, bool stable, const int64_t* dim, bool descending) {
+    impl::aten::setCurStream(ctx);
+    auto atOut = impl::aten::buildATen(out);
+    auto atInput = impl::aten::buildATen(input);
+    atOut = CALL_ATEN_CUDA_FUNC(argsort, atInput, stable, (dim ? *dim : -1), descending);
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiSmoothL1Loss(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t target,
                                diopiReduction_t reduction, double beta) {
     impl::aten::setCurStream(ctx);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -830,6 +830,23 @@ diopiError_t diopiCosInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
     return diopiSuccess;
 }
 
+diopiError_t diopiTan(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    CALL_ATEN_CUDA_FUNC(tan_out, atOut, atInput);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiTanInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    CALL_ATEN_CUDA_FUNC(tan_, atInput);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiAbs(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -958,6 +958,23 @@ diopiError_t diopiSign(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
     return diopiSuccess;
 }
 
+diopiError_t diopiSinh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    CALL_ATEN_CUDA_FUNC(sinh_out, atOut, atInput);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiSinhInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    CALL_ATEN_CUDA_FUNC(sinh_, atInput);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiTanh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -778,6 +778,15 @@ diopiError_t diopiComplex(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     return diopiSuccess;
 }
 
+DIOPI_API diopiError_t diopiConj(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    atOut = torch::conj(atInput);
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiTopk(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t k,
                        int64_t dim, bool largest, bool sorted) {
     impl::aten::setCurStream(ctx);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -1043,6 +1043,23 @@ diopiError_t diopiAsinhInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) 
     return diopiSuccess;
 }
 
+diopiError_t diopiAcosh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    CALL_ATEN_CUDA_FUNC(acosh_out, atOut, atInput);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiAcoshInp(diopiContextHandle_t ctx, diopiTensorHandle_t input) {
+    impl::aten::setCurStream(ctx);
+    auto atInput = impl::aten::buildATen(input);
+    CALL_ATEN_CUDA_FUNC(acosh_, atInput);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiSigmoid(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     impl::aten::setCurStream(ctx);
     auto atInput = impl::aten::buildATen(input);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -778,10 +778,19 @@ diopiError_t diopiComplex(diopiContextHandle_t ctx, diopiTensorHandle_t out, dio
     return diopiSuccess;
 }
 
-DIOPI_API diopiError_t diopiConj(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+diopiError_t diopiConj(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
     auto atInput = impl::aten::buildATen(input);
     auto atOut = impl::aten::buildATen(out);
     atOut = torch::conj(atInput);
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+
+    return diopiSuccess;
+}
+
+diopiError_t diopiImag(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    atOut = torch::imag(atInput);
     impl::aten::updateATen2Tensor(ctx, atOut, out);
 
     return diopiSuccess;

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -768,6 +768,16 @@ diopiError_t diopiSortBackward(diopiContextHandle_t ctx, diopiTensorHandle_t gra
     return diopiSuccess;
 }
 
+diopiError_t diopiComplex(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t real, diopiConstTensorHandle_t imag) {
+    auto atReal = impl::aten::buildATen(real);
+    auto atImag = impl::aten::buildATen(imag);
+    auto atOut = impl::aten::buildATen(out);
+    atOut = torch::complex(atReal, atImag);
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiTopk(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t k,
                        int64_t dim, bool largest, bool sorted) {
     impl::aten::setCurStream(ctx);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -796,6 +796,15 @@ diopiError_t diopiImag(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
     return diopiSuccess;
 }
 
+diopiError_t diopiReal(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input) {
+    auto atInput = impl::aten::buildATen(input);
+    auto atOut = impl::aten::buildATen(out);
+    atOut = torch::real(atInput);
+    impl::aten::updateATen2Tensor(ctx, atOut, out);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiTopk(diopiContextHandle_t ctx, diopiTensorHandle_t values, diopiTensorHandle_t indices, diopiConstTensorHandle_t input, int64_t k,
                        int64_t dim, bool largest, bool sorted) {
     impl::aten::setCurStream(ctx);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -4367,6 +4367,7 @@ diopiError_t diopiAvgPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_
   c10::optional<int64_t> atDivisorOverride = divisor_override ? c10::optional<int64_t>(*divisor_override) : c10::nullopt;
   auto atGradInput = impl::aten::buildATen(grad_input);
   CALL_ATEN_CUDA_FUNC(avg_pool3d_backward_out, atGradInput, atGradOutput, atInput, atKernelSize, atStride, atPadding, ceil_mode, count_include_pad, atDivisorOverride);
+  return diopiSuccess;
 }
 
 diopiError_t diopiPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size) {

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -3200,6 +3200,16 @@ diopiError_t diopiArgmax(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     return diopiSuccess;
 }
 
+diopiError_t diopiArgmin(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const int64_t* dim, bool keepdim) {
+    impl::aten::setCurStream(ctx);
+    auto atOut = impl::aten::buildATen(out);
+    auto atInput = impl::aten::buildATen(input);
+    c10::optional<int64_t> atDim = dim ? c10::optional<int64_t>(*dim) : c10::nullopt;
+    CALL_ATEN_CUDA_FUNC(argmin_out, atOut, atInput, atDim, keepdim);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiSmoothL1Loss(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t target,
                                diopiReduction_t reduction, double beta) {
     impl::aten::setCurStream(ctx);

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -3382,6 +3382,8 @@ diopiError_t diopiFusedAdamW(diopiContextHandle_t ctx, diopiTensorHandle_t* para
         std::vector<at::Tensor> tensorList;
         CALL_ATEN_CUDA_FUNC(_fused_adamw_, atParam, atGrad, atExpAvg, atExpAvgSq, tensorList, atstep, lr, beta1, beta2, weight_decay, eps, amsgrad, maximize);
     }
+
+    return diopiSuccess;
 }
 
 diopiError_t diopiAdamW(diopiContextHandle_t ctx, diopiTensorHandle_t param, diopiConstTensorHandle_t grad, diopiTensorHandle_t exp_avg,

--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -3127,6 +3127,15 @@ diopiError_t diopiCumsum(diopiContextHandle_t ctx, diopiTensorHandle_t out, diop
     return diopiSuccess;
 }
 
+diopiError_t diopiCumsumBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, int64_t dim) {
+    impl::aten::setCurStream(ctx);
+    auto atGradOutput = impl::aten::buildATen(grad_output);
+    auto atGradInput = atGradOutput;
+    impl::aten::updateATen2Tensor(ctx, atGradInput.flip(dim).cumsum(dim).flip(dim), grad_input);
+
+    return diopiSuccess;
+}
+
 diopiError_t diopiCdist(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input1, diopiConstTensorHandle_t input2, double p,
                         const int64_t* compute_mode) {
     impl::aten::setCurStream(ctx);

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -911,6 +911,21 @@ DIOPI_API diopiError_t diopiTanInp(diopiContextHandle_t ctx, diopiTensorHandle_t
 DIOPI_API diopiError_t diopiTan(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief The in-place version of diopiSinh().
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiSinhInp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
+
+/**
+ * @brief Returns a new tensor with the hyperbolic sine of the elements of input.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float16, float32, float64].
+ * @param[out] out the input tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiSinh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief The in-place version of diopiTanh().
  * @param[in] ctx Context environment.
  * @param[in] input the input tensor. type = [float16, float32, float64].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -3139,6 +3139,16 @@ DIOPI_API diopiError_t diopiFlip(diopiContextHandle_t ctx, diopiTensorHandle_t o
  */
 DIOPI_API diopiError_t diopiNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const diopiScalar_t* p, diopiSize_t dim);
 
+DIOPI_API diopiError_t diopiNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t self, diopiConstTensorHandle_t norm, diopiSize_t dim, const diopiScalar_t* p);
+/**
+ *
+ *
+ *
+ *
+ *
+ */
+DIOPI_API diopiError_t diopiLayerNormGB(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t running_mean, diopiTensorHandle_t running_var, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, const double eps, const int64_t begin_norm_axis);
+
 /**
  * @brief Returns the matrix norm or vector norm of a given tensor list.
  * @param[in] ctx Context environment.
@@ -3566,6 +3576,16 @@ DIOPI_API diopiError_t diopiLayerNormBackward(diopiContextHandle_t ctx, diopiTen
                                               diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
                                               diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiConstTensorHandle_t mean,
                                               diopiConstTensorHandle_t rstd, diopiSize_t normalized_shape);
+
+DIOPI_API diopiError_t diopiLayerNormGBBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight, diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiConstTensorHandle_t running_mean, diopiConstTensorHandle_t running_std, const int64_t begin_norm_axis);
+
+
+DIOPI_API diopiError_t diopiInstanceNorm(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const int64_t axis, diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const double eps);
+
+DIOPI_API diopiError_t diopiNormalize(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const float p, const int64_t axis, const double eps);
+
+DIOPI_API diopiError_t diopiNormalizeBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const float p, const int64_t axis, const double eps);
+
 
 /**
  * @brief Copies the elements from src into dest tensor.

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -1008,6 +1008,21 @@ DIOPI_API diopiError_t diopiAcoshInp(diopiContextHandle_t ctx, diopiTensorHandle
 DIOPI_API diopiError_t diopiAcosh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief The in-place version of diopiAtanh().
+ * @param[in] ctx Context environment.
+ * @param[inout] input the input tensor and will be stroed reuslt tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiAtanhInp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
+
+/**
+ * @brief Returns a new tensor with the arc hyperbolic tangent of the elements of input.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float16, float32, float64].
+ * @param[out] out the output tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiAtanh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief The in-place version of diopiSigmoid().
  * @param[in] ctx Context environment.
  * @param[in] input the input tensor and will be stroed reuslt tensor. type = [float16, float32].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -302,6 +302,39 @@ DIOPI_API diopiError_t diopiLeakyReluInp(diopiContextHandle_t ctx, diopiTensorHa
 DIOPI_API diopiError_t diopiLeakyReluBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                               diopiConstTensorHandle_t input, const diopiScalar_t* negative_slope, bool input_is_result);
 
+DIOPI_API diopiError_t diopiMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride,
+                            diopiSize_t padding, diopiSize_t dilation, bool ceil_mode);
+
+DIOPI_API diopiError_t diopiMaxPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                    diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation,
+                                    bool ceil_mode, diopiConstTensorHandle_t indices);
+
+DIOPI_API diopiError_t diopiMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices, diopiConstTensorHandle_t input,
+                                       diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode);
+
+DIOPI_API diopiError_t diopiAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride,
+                            diopiSize_t padding, bool ceil_mode, bool count_include_pad);
+
+DIOPI_API diopiError_t diopiAvgPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                    diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode,
+                                    bool count_include_pad);
+
+DIOPI_API diopiError_t diopiAdaptiveMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t output_size);
+
+DIOPI_API diopiError_t diopiAdaptiveMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices, diopiConstTensorHandle_t input,
+                                               diopiSize_t output_size);
+
+DIOPI_API diopiError_t diopiAdaptiveMaxPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                            diopiConstTensorHandle_t input, diopiConstTensorHandle_t indices);
+
+DIOPI_API diopiError_t diopiAdaptiveAvgPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                            diopiConstTensorHandle_t input);
+
+DIOPI_API diopiError_t diopiAdaptiveAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t output_size);
+
+DIOPI_API diopiError_t diopiPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size);
+
+DIOPI_API diopiError_t diopiPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices);
 /**
  * @brief Applies 2D average-pooling operation in kH×kW regions by step size sH×sW steps.
  * @param[in] ctx Context environment.
@@ -388,11 +421,9 @@ DIOPI_API diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTen
                                               diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding,
                                               diopiSize_t dilation, bool ceil_mode, diopiConstTensorHandle_t indices);
 
-/**
-TODO
- */
-DIOPI_API diopiError_t diopiPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t kernel_size,
-                                   diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode, bool exclusive, bool adaptive);
+DIOPI_API diopiError_t diopiPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size);
+
+DIOPI_API diopiError_t diopiPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices);
 
 /**
  * @brief Applies a 2D adaptive average pooling over an input signal composed of several input planes.
@@ -2879,6 +2910,9 @@ DIOPI_API diopiError_t diopiConvolution3dBackward(diopiContextHandle_t ctx, diop
                                                   diopiConstTensorHandle_t weight, diopiSize_t* bias_sizes, diopiSize_t stride, diopiSize_t padding,
                                                   diopiSize_t dilation, int64_t groups);
 
+DIOPI_API diopiError_t diopiAvgPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad, const int64_t* divisor_override);
+
+DIOPI_API diopiError_t diopiAvgPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad, const int64_t* divisor_override);
 /**
  * \brief Applies a 3D max pooling over an input signal composed of several input planes.
  * @param[in] ctx Context environment.
@@ -2974,6 +3008,11 @@ DIOPI_API diopiError_t diopiAdaptiveMaxPool3dWithIndices(diopiContextHandle_t ct
  */
 DIOPI_API diopiError_t diopiAdaptiveMaxPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                                       diopiConstTensorHandle_t input, diopiConstTensorHandle_t indices);
+
+DIOPI_API diopiError_t diopiPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size);
+
+DIOPI_API diopiError_t diopiPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices);
+
 
 /**
  * \brief Returns a new 1-D tensor which indexes the input tensor according to the boolean mask.

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -879,6 +879,22 @@ DIOPI_API diopiError_t diopiCosInp(diopiContextHandle_t ctx, diopiTensorHandle_t
 DIOPI_API diopiError_t diopiCos(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief The in-place version of diopiAcos().
+ * @param[in] ctx Context environment.
+ * @param[in] input the input and output tensor and will be stored result tensor,
+ * type = [float16, float32, float64, int16, int32, int64, uint8, int8].
+ */
+DIOPI_API diopiError_t diopiAcosInp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
+
+/**
+ * @brief Compute the element-wise arccosine values of the input tensor input.
+ * @param[in] ctx Context environment.
+ * @param[in] input Input tensor, type = [float16, float32, float64, int16, int32, int64, uint8, int8].
+ * @param[out] out the output tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiAcos(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief The in-place version of diopiTan().
  * @param[in] ctx Context environment.
  * @param[in] input the input and output tensor and will be stored result tensor,

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -302,39 +302,44 @@ DIOPI_API diopiError_t diopiLeakyReluInp(diopiContextHandle_t ctx, diopiTensorHa
 DIOPI_API diopiError_t diopiLeakyReluBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                               diopiConstTensorHandle_t input, const diopiScalar_t* negative_slope, bool input_is_result);
 
-DIOPI_API diopiError_t diopiMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride,
-                            diopiSize_t padding, diopiSize_t dilation, bool ceil_mode);
+DIOPI_API diopiError_t diopiMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size,
+                                      diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode);
 
 DIOPI_API diopiError_t diopiMaxPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
-                                    diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation,
-                                    bool ceil_mode, diopiConstTensorHandle_t indices);
+                                              diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding,
+                                              diopiSize_t dilation, bool ceil_mode, diopiConstTensorHandle_t indices);
 
 DIOPI_API diopiError_t diopiMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices, diopiConstTensorHandle_t input,
-                                       diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode);
+                                                 diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode);
 
-DIOPI_API diopiError_t diopiAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride,
-                            diopiSize_t padding, bool ceil_mode, bool count_include_pad);
+DIOPI_API diopiError_t diopiAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size,
+                                      diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad);
 
 DIOPI_API diopiError_t diopiAvgPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
-                                    diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode,
-                                    bool count_include_pad);
+                                              diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode,
+                                              bool count_include_pad);
 
 DIOPI_API diopiError_t diopiAdaptiveMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t output_size);
 
-DIOPI_API diopiError_t diopiAdaptiveMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices, diopiConstTensorHandle_t input,
-                                               diopiSize_t output_size);
+DIOPI_API diopiError_t diopiAdaptiveMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices,
+                                                         diopiConstTensorHandle_t input, diopiSize_t output_size);
 
 DIOPI_API diopiError_t diopiAdaptiveMaxPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
-                                            diopiConstTensorHandle_t input, diopiConstTensorHandle_t indices);
+                                                      diopiConstTensorHandle_t input, diopiConstTensorHandle_t indices);
 
 DIOPI_API diopiError_t diopiAdaptiveAvgPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
-                                            diopiConstTensorHandle_t input);
+                                                      diopiConstTensorHandle_t input);
 
 DIOPI_API diopiError_t diopiAdaptiveAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t output_size);
 
-DIOPI_API diopiError_t diopiPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size);
+DIOPI_API diopiError_t diopiPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize,
+                                   diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive,
+                                   const bool adaptive, diopiSize_t output_size);
 
-DIOPI_API diopiError_t diopiPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices);
+DIOPI_API diopiError_t diopiPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                           diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding,
+                                           diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive,
+                                           diopiConstTensorHandle_t indices);
 /**
  * @brief Applies 2D average-pooling operation in kH×kW regions by step size sH×sW steps.
  * @param[in] ctx Context environment.
@@ -421,9 +426,14 @@ DIOPI_API diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTen
                                               diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding,
                                               diopiSize_t dilation, bool ceil_mode, diopiConstTensorHandle_t indices);
 
-DIOPI_API diopiError_t diopiPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size);
+DIOPI_API diopiError_t diopiPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize,
+                                   diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive,
+                                   const bool adaptive, diopiSize_t output_size);
 
-DIOPI_API diopiError_t diopiPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices);
+DIOPI_API diopiError_t diopiPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                           diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding,
+                                           diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive,
+                                           diopiConstTensorHandle_t indices);
 
 /**
  * @brief Applies a 2D adaptive average pooling over an input signal composed of several input planes.
@@ -2944,9 +2954,12 @@ DIOPI_API diopiError_t diopiConvolution3dBackward(diopiContextHandle_t ctx, diop
                                                   diopiConstTensorHandle_t weight, diopiSize_t* bias_sizes, diopiSize_t stride, diopiSize_t padding,
                                                   diopiSize_t dilation, int64_t groups);
 
-DIOPI_API diopiError_t diopiAvgPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad, const int64_t* divisor_override);
+DIOPI_API diopiError_t diopiAvgPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size,
+                                      diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad, const int64_t* divisor_override);
 
-DIOPI_API diopiError_t diopiAvgPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad, const int64_t* divisor_override);
+DIOPI_API diopiError_t diopiAvgPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                              diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode,
+                                              bool count_include_pad, const int64_t* divisor_override);
 /**
  * \brief Applies a 3D max pooling over an input signal composed of several input planes.
  * @param[in] ctx Context environment.
@@ -3043,10 +3056,14 @@ DIOPI_API diopiError_t diopiAdaptiveMaxPool3dWithIndices(diopiContextHandle_t ct
 DIOPI_API diopiError_t diopiAdaptiveMaxPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                                       diopiConstTensorHandle_t input, diopiConstTensorHandle_t indices);
 
-DIOPI_API diopiError_t diopiPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiSize_t output_size);
+DIOPI_API diopiError_t diopiPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize,
+                                   diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive,
+                                   const bool adaptive, diopiSize_t output_size);
 
-DIOPI_API diopiError_t diopiPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive, diopiConstTensorHandle_t indices);
-
+DIOPI_API diopiError_t diopiPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                           diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding,
+                                           diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive,
+                                           diopiConstTensorHandle_t indices);
 
 /**
  * \brief Returns a new 1-D tensor which indexes the input tensor according to the boolean mask.
@@ -3212,7 +3229,8 @@ DIOPI_API diopiError_t diopiFlip(diopiContextHandle_t ctx, diopiTensorHandle_t o
  */
 DIOPI_API diopiError_t diopiNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const diopiScalar_t* p, diopiSize_t dim);
 
-DIOPI_API diopiError_t diopiNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t self, diopiConstTensorHandle_t norm, diopiSize_t dim, const diopiScalar_t* p);
+DIOPI_API diopiError_t diopiNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                         diopiConstTensorHandle_t self, diopiConstTensorHandle_t norm, diopiSize_t dim, const diopiScalar_t* p);
 /**
  *
  *
@@ -3220,7 +3238,9 @@ DIOPI_API diopiError_t diopiNormBackward(diopiContextHandle_t ctx, diopiTensorHa
  *
  *
  */
-DIOPI_API diopiError_t diopiLayerNormGB(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t running_mean, diopiTensorHandle_t running_var, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, const double eps, const int64_t begin_norm_axis);
+DIOPI_API diopiError_t diopiLayerNormGB(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t running_mean, diopiTensorHandle_t running_var,
+                                        diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, const double eps,
+                                        const int64_t begin_norm_axis);
 
 /**
  * @brief Returns the matrix norm or vector norm of a given tensor list.
@@ -3650,17 +3670,23 @@ DIOPI_API diopiError_t diopiLayerNormBackward(diopiContextHandle_t ctx, diopiTen
                                               diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiConstTensorHandle_t mean,
                                               diopiConstTensorHandle_t rstd, diopiSize_t normalized_shape);
 
-DIOPI_API diopiError_t diopiLayerNormGBBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight, diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiConstTensorHandle_t running_mean, diopiConstTensorHandle_t running_std, const int64_t begin_norm_axis);
+DIOPI_API diopiError_t diopiLayerNormGBBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight,
+                                                diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
+                                                diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiConstTensorHandle_t running_mean,
+                                                diopiConstTensorHandle_t running_std, const int64_t begin_norm_axis);
 
+DIOPI_API diopiError_t diopiInstanceNorm(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const int64_t axis,
+                                         diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const double eps);
 
-DIOPI_API diopiError_t diopiInstanceNorm(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const int64_t axis, diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const double eps);
+DIOPI_API diopiError_t diopiInstanceNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_scale,
+                                                 diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
+                                                 diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const int64_t axis, const double eps);
 
-DIOPI_API diopiError_t diopiInstanceNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_scale, diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const int64_t axis, const double eps);
+DIOPI_API diopiError_t diopiNormalize(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const float p, const int64_t axis,
+                                      const double eps);
 
-DIOPI_API diopiError_t diopiNormalize(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const float p, const int64_t axis, const double eps);
-
-DIOPI_API diopiError_t diopiNormalizeBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const float p, const int64_t axis, const double eps);
-
+DIOPI_API diopiError_t diopiNormalizeBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
+                                              diopiConstTensorHandle_t input, const float p, const int64_t axis, const double eps);
 
 /**
  * @brief Copies the elements from src into dest tensor.

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -978,6 +978,21 @@ DIOPI_API diopiError_t diopiAtan(diopiContextHandle_t ctx, diopiTensorHandle_t o
 DIOPI_API diopiError_t diopiAtanInp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
 
 /**
+ * @brief The in-place version of diopiAsinh().
+ * @param[in] ctx Context environment.
+ * @param[inout] input the input tensor and will be stroed reuslt tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiAsinhInp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
+
+/**
+ * @brief Returns a new tensor with the arc hyperbolic sine of the elements of input.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float16, float32, float64].
+ * @param[out] out the output tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiAsinh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief The in-place version of diopiSigmoid().
  * @param[in] ctx Context environment.
  * @param[in] input the input tensor and will be stroed reuslt tensor. type = [float16, float32].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -3691,6 +3691,14 @@ DIOPI_API diopiError_t diopiTriu(diopiContextHandle_t ctx, diopiTensorHandle_t o
 DIOPI_API diopiError_t diopiTriuInp(diopiContextHandle_t ctx, diopiTensorHandle_t input, int64_t diagonal);
 
 /**
+ * @brief Create a complex tensor with real part and image part.
+ * @param[in] ctx Context environment.
+ * @param[in] real the real part of the tensor.
+ * @param[in] imag the image part of the tensor.
+ */
+DIOPI_API diopiError_t diopiComplex(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t real, diopiConstTensorHandle_t imag);
+
+/**
  * @brief Create a tensor filled with one.
  * @param[in] ctx Context environment.
  * @param[in] size Out tensor size.

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -302,44 +302,172 @@ DIOPI_API diopiError_t diopiLeakyReluInp(diopiContextHandle_t ctx, diopiTensorHa
 DIOPI_API diopiError_t diopiLeakyReluBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                               diopiConstTensorHandle_t input, const diopiScalar_t* negative_slope, bool input_is_result);
 
+/**
+ * @brief Performs 1D max pooling on the input tensor.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after max pooling.
+ * @param[in] input the input tensor.
+ * @param[in] kernel_size the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ */
 DIOPI_API diopiError_t diopiMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size,
                                       diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode);
 
+/**
+ * @brief Performs the backward pass for diopiMaxPool1d(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] kernel_size the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] indices the tensor storing the indices of max elements from the forward pass.
+ */
 DIOPI_API diopiError_t diopiMaxPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                               diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding,
                                               diopiSize_t dilation, bool ceil_mode, diopiConstTensorHandle_t indices);
 
+/**
+ * @brief Performs 1D max pooling on the input tensor and returns the indices of max elements.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after max pooling.
+ * @param[out] indices the tensor storing the indices of max elements.
+ * @param[in] input the input tensor.
+ * @param[in] kernel_size the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ */
 DIOPI_API diopiError_t diopiMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices, diopiConstTensorHandle_t input,
                                                  diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode);
 
+/**
+ * @brief Performs 1D average pooling on the input tensor.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after average pooling.
+ * @param[in] input the input tensor.
+ * @param[in] kernel_size the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] count_include_pad whether to include padding in the count for averaging.
+ */
 DIOPI_API diopiError_t diopiAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size,
                                       diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad);
 
+/**
+ * @brief Performs the backward pass for diopiAvgPool1d(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] kernel_size the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] count_include_pad whether to include padding in the count for averaging.
+ */
 DIOPI_API diopiError_t diopiAvgPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                               diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode,
                                               bool count_include_pad);
 
+/**
+ * @brief Performs 1D adaptive max pooling on the input tensor.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after adaptive max pooling.
+ * @param[in] input the input tensor.
+ * @param[in] output_size the size of the output after pooling.
+ */
 DIOPI_API diopiError_t diopiAdaptiveMaxPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t output_size);
 
+/**
+ * @brief Performs 1D adaptive max pooling on the input tensor and returns the indices of max elements.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after adaptive max pooling.
+ * @param[out] indices the tensor storing the indices of max elements.
+ * @param[in] input the input tensor.
+ * @param[in] output_size the size of the output after pooling.
+ */
 DIOPI_API diopiError_t diopiAdaptiveMaxPool1dWithIndices(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t indices,
                                                          diopiConstTensorHandle_t input, diopiSize_t output_size);
 
+/**
+ * @brief Performs the backward pass for diopiAdaptiveMaxPool1d(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] indices the tensor storing the indices of max elements from the forward pass.
+ */
 DIOPI_API diopiError_t diopiAdaptiveMaxPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                                       diopiConstTensorHandle_t input, diopiConstTensorHandle_t indices);
 
+/**
+ * @brief Performs the backward pass for diopiAdaptiveAvgPool1d(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ */
 DIOPI_API diopiError_t diopiAdaptiveAvgPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                                       diopiConstTensorHandle_t input);
 
+/**
+ * @brief Performs 1D adaptive average pooling on the input tensor.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after adaptive average pooling.
+ * @param[in] input the input tensor.
+ * @param[in] output_size the size of the output after pooling.
+ */
 DIOPI_API diopiError_t diopiAdaptiveAvgPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t output_size);
 
+/**
+ * @brief General 1D pooling operation with support for multiple pooling modes.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after pooling.
+ * @param[in] input the input tensor.
+ * @param[in] mode the pooling mode, such as "max" or "avg".
+ * @param[in] ksize the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] exclusive whether to exclude padding when averaging.
+ * @param[in] adaptive whether to use adaptive pooling.
+ * @param[in] output_size the size of the output after pooling (if adaptive pooling is used).
+ */
 DIOPI_API diopiError_t diopiPool1d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize,
                                    diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive,
                                    const bool adaptive, diopiSize_t output_size);
 
+/**
+ * @brief Performs the backward pass for diopiPool1d(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] mode the pooling mode, such as "max" or "avg".
+ * @param[in] ksize the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] exclusive whether to exclude padding when averaging.
+ * @param[in] adaptive whether to use adaptive pooling.
+ * @param[in] indices the tensor storing the indices of max elements from the forward pass (if max pooling is used).
+ */
 DIOPI_API diopiError_t diopiPool1dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                            diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding,
                                            diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive,
                                            diopiConstTensorHandle_t indices);
+
 /**
  * @brief Applies 2D average-pooling operation in kH×kW regions by step size sH×sW steps.
  * @param[in] ctx Context environment.
@@ -425,11 +553,41 @@ DIOPI_API diopiError_t diopiMaxPool2dWithIndices(diopiContextHandle_t ctx, diopi
 DIOPI_API diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                               diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding,
                                               diopiSize_t dilation, bool ceil_mode, diopiConstTensorHandle_t indices);
-
+/**
+ * @brief General 2D pooling operation with support for multiple pooling modes.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after pooling.
+ * @param[in] input the input tensor.
+ * @param[in] mode the pooling mode, such as "max" or "avg".
+ * @param[in] ksize the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] exclusive whether to exclude padding when averaging.
+ * @param[in] adaptive whether to use adaptive pooling.
+ * @param[in] output_size the size of the output after pooling (if adaptive pooling is used).
+ */
 DIOPI_API diopiError_t diopiPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize,
                                    diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive,
                                    const bool adaptive, diopiSize_t output_size);
 
+/**
+ * @brief Performs the backward pass for diopiPool2d(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] mode the pooling mode, such as "max" or "avg".
+ * @param[in] ksize the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] exclusive whether to exclude padding when averaging.
+ * @param[in] adaptive whether to use adaptive pooling.
+ * @param[in] indices the tensor storing the indices of max elements from the forward pass (if max pooling is used).
+ */
 DIOPI_API diopiError_t diopiPool2dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                            diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding,
                                            diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive,
@@ -2735,10 +2893,40 @@ DIOPI_API diopiError_t diopiConvTranspose2dBackward(diopiContextHandle_t ctx, di
                                                     diopiConstTensorHandle_t weight, diopiSize_t* bias_sizes, diopiSize_t stride, diopiSize_t padding,
                                                     diopiSize_t dilation, diopiSize_t output_padding, int64_t groups);
 
+/**
+ * @brief Applies a 3D transposed convolution operator over an input image composed of several input planes, sometimes also called “deconvolution”.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float32, float16, float64].
+ * @param[in] weight the weight tensor; dimension of kernel_size must match the number of input spatial dimensions.
+ * type = [float32, float16, float64].
+ * @param[in] bias bias tensor. type = [float32, float16, float64].
+ * @param[in] stride an array with dimension matching the number of input spatial dimensions. type = [int32, int64].
+ * @param[in] padding an array with dimension matching the number of input spatial dimensions. type = [int32, int64].
+ * @param[in] output_padding an array, dimension == number of input spatial dimensions; only supported when transposed is true. type = [int32, int64].
+ * @param[in] dilation an array with dimension matching the number of input spatial dimensions. type = [int32, int64].
+ * @param[in] groups number of groups for grouped convolution. type = [int64].
+ * @param[out] out the result tensor. type = [float32, float16, float64].
+ */
 DIOPI_API diopiError_t diopiConvTranspose3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
                                             diopiConstTensorHandle_t bias, diopiSize_t stride, diopiSize_t padding, diopiSize_t output_padding, int64_t groups,
                                             diopiSize_t dilation);
 
+/**
+ * @brief Backward pass for ConvTranspose3dBackward. Computes gradients for input, weight, and bias.
+ * @param[in] ctx Context environment.
+ * @param[in] grad_output the grad tensor of output. type = [float32, float16, float64].
+ * @param[in] bias_sizes an array, indicates that a bias was used in the forward pass and contains the shape of the bias. type = [int32, int64].
+ * @param[in] input the input tensor. type = [float32, float16, float64].
+ * @param[in] weight the weight tensor; dimension of kernel_size must match the number of input spatial dimensions.
+ * @param[in] stride an array with dimension matching the number of input spatial dimensions. type = [int32, int64].
+ * @param[in] padding an array with dimension matching the number of input spatial dimensions. type = [int32, int64].
+ * @param[in] output_padding an array, dimension == number of input spatial dimensions; only supported when transposed is true. type = [int32, int64].
+ * @param[in] dilation an array with dimension matching the number of input spatial dimensions. type = [int32, int64].
+ * @param[in] groups number of groups for grouped convolution. type = [int64].
+ * @param[out] grad_input the grad of input. type = [float32, float16, float64].
+ * @param[out] grad_weight the grad of weight. type = [float32, float16, float64].
+ * @param[out] grad_bias the grad of bias. type = [float32, float16, float64].
+ */
 DIOPI_API diopiError_t diopiConvTranspose3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight,
                                                     diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
                                                     diopiConstTensorHandle_t weight, diopiSize_t* bias_sizes, diopiSize_t stride, diopiSize_t padding,
@@ -2953,13 +3141,38 @@ DIOPI_API diopiError_t diopiConvolution3dBackward(diopiContextHandle_t ctx, diop
                                                   diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
                                                   diopiConstTensorHandle_t weight, diopiSize_t* bias_sizes, diopiSize_t stride, diopiSize_t padding,
                                                   diopiSize_t dilation, int64_t groups);
-
+/**
+ * @brief Performs 3D average pooling operation.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after average pooling.
+ * @param[in] input the input tensor.
+ * @param[in] kernel_size the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] count_include_pad whether to include the zero-padding in the averaging calculation.
+ * @param[in] divisor_override if provided, it will be used as the divisor for averaging.
+ */
 DIOPI_API diopiError_t diopiAvgPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiSize_t kernel_size,
                                       diopiSize_t stride, diopiSize_t padding, bool ceil_mode, bool count_include_pad, const int64_t* divisor_override);
 
+/**
+ * @brief Performs the backward pass for diopiAvgPool3d(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] kernel_size the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] count_include_pad whether to include the zero-padding in the averaging calculation.
+ * @param[in] divisor_override if provided, it will be used as the divisor for averaging.
+ */
 DIOPI_API diopiError_t diopiAvgPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                               diopiConstTensorHandle_t input, diopiSize_t kernel_size, diopiSize_t stride, diopiSize_t padding, bool ceil_mode,
                                               bool count_include_pad, const int64_t* divisor_override);
+
 /**
  * \brief Applies a 3D max pooling over an input signal composed of several input planes.
  * @param[in] ctx Context environment.
@@ -3056,10 +3269,41 @@ DIOPI_API diopiError_t diopiAdaptiveMaxPool3dWithIndices(diopiContextHandle_t ct
 DIOPI_API diopiError_t diopiAdaptiveMaxPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                                       diopiConstTensorHandle_t input, diopiConstTensorHandle_t indices);
 
+/**
+ * @brief General 3D pooling operation with support for multiple pooling modes.
+ * @param[in] ctx Context environment.
+ * @param[out] out the output tensor after pooling.
+ * @param[in] input the input tensor.
+ * @param[in] mode the pooling mode, such as "max" or "avg".
+ * @param[in] ksize the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] exclusive whether to exclude padding when averaging.
+ * @param[in] adaptive whether to use adaptive pooling.
+ * @param[in] output_size the size of the output after pooling (if adaptive pooling is used).
+ */
 DIOPI_API diopiError_t diopiPool3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize,
                                    diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, const bool ceil_mode, const bool exclusive,
                                    const bool adaptive, diopiSize_t output_size);
 
+/**
+ * @brief Performs the backward pass for diopiPool3d(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] mode the pooling mode, such as "max" or "avg".
+ * @param[in] ksize the size of the pooling window.
+ * @param[in] stride the stride of the pooling window.
+ * @param[in] padding implicit padding added to the input.
+ * @param[in] dilation the spacing between elements in the pooling window.
+ * @param[in] ceil_mode whether to use ceil instead of floor for output shape calculation.
+ * @param[in] exclusive whether to exclude padding when averaging.
+ * @param[in] adaptive whether to use adaptive pooling.
+ * @param[in] indices the tensor storing the indices of max elements from the forward pass (if max pooling is used).
+ */
 DIOPI_API diopiError_t diopiPool3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                            diopiConstTensorHandle_t input, const char* mode, diopiSize_t ksize, diopiSize_t stride, diopiSize_t padding,
                                            diopiSize_t dilation, const bool ceil_mode, const bool exclusive, const bool adaptive,
@@ -3229,14 +3473,31 @@ DIOPI_API diopiError_t diopiFlip(diopiContextHandle_t ctx, diopiTensorHandle_t o
  */
 DIOPI_API diopiError_t diopiNorm(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const diopiScalar_t* p, diopiSize_t dim);
 
+/**
+ * @brief Compute the backward pass for diopiNorm(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[in] grad_output the grad tensor of output. type=[float32, float64, float16].
+ * @param[in] self input tensor. type=[float32, float64, float16].
+ * @param[in] norm norm tensor. type=[float32, float64, float16].
+ * @param[in] dim Specifies which dimension or dimensions of input to calculate the norm across.
+ * @param[in] p an array, the order of norm.
+ * @param[out] grad_input the grad of input. type=[float32, float64, float16].
+ */
 DIOPI_API diopiError_t diopiNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                          diopiConstTensorHandle_t self, diopiConstTensorHandle_t norm, diopiSize_t dim, const diopiScalar_t* p);
+
 /**
- *
- *
- *
- *
- *
+ * @brief Applies Layer Normalization over a mini-batch of inputs.
+ * type=[float32, float64, float16].
+ * @param[in] ctx Context environment.
+ * @param[in] save_mean Mean tensor,the mean value for each feature channel of the input tensor. type=[float32, float64, float16].
+ * @param[in] save_invstd Backup of inverse standard deviation computed during training. type=[float32, float64, float16].
+ * @param[in] input input tensor. type=[float32, float64, float16].
+ * @param[in] weight weight tensor. type=[float32, float64, float16].
+ * @param[in] bias bias tensor. type=[float32, float64, float16].
+ * @param[in] begin_norm_axis int64, Indicates which dimension to start normalization.
+ * @param[in] eps float64 a value added to the denominator for numerical stability.
+ * @param[out] out normalized result. type=[float32, float64, float16].
  */
 DIOPI_API diopiError_t diopiLayerNormGB(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiTensorHandle_t running_mean, diopiTensorHandle_t running_var,
                                         diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, const double eps,
@@ -3670,21 +3931,74 @@ DIOPI_API diopiError_t diopiLayerNormBackward(diopiContextHandle_t ctx, diopiTen
                                               diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiConstTensorHandle_t mean,
                                               diopiConstTensorHandle_t rstd, diopiSize_t normalized_shape);
 
+/**
+ * @brief Compute the backward pass for diopiLayerNormGB(). Computes gradients for input, weight, and bias.
+ * @param[in] ctx Context environment.
+ * @param[in] grad_output the grad tensor of output. type=[float32, float64, float16].
+ * @param[in] grad_bias the grad of bias. type=[float32, float64, float16].
+ * @param[in] grad_weight the grad of weight. type=[float32, float64, float16].
+ * @param[in] mean Mean tensor,the mean value for each feature channel of the input tensor. type=[float32, float64, float16].
+ * @param[in] rstd Backup of inverse standard deviation computed during training. type=[float32, float64, float16].
+ * @param[in] input input tensor. type=[float32, float64, float16].
+ * @param[in] weight weight tensor. type=[float32, float64, float16].
+ * @param[in] bias bias tensor. type=[float32, float64, float16].
+ * @param[in] begin_norm_axis int64, Indicates which dimension to start normalization.
+ * @param[out] grad_input the grad of input. type=[float32, float64, float16].
+ */
 DIOPI_API diopiError_t diopiLayerNormGBBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight,
                                                 diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
                                                 diopiConstTensorHandle_t weight, diopiConstTensorHandle_t bias, diopiConstTensorHandle_t running_mean,
                                                 diopiConstTensorHandle_t running_std, const int64_t begin_norm_axis);
 
+/**
+ * @brief Performs instance normalization on the input tensor.
+ * @param[in] ctx Context environment.
+ * @param[out] output the output tensor after instance normalization.
+ * @param[in] input the input tensor to be normalized.
+ * @param[in] axis the axis along which normalization is applied.
+ * @param[in] scale the scale tensor.
+ * @param[in] bias the bias tensor.
+ * @param[in] eps small value to avoid division by zero during normalization.
+ */
 DIOPI_API diopiError_t diopiInstanceNorm(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const int64_t axis,
                                          diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const double eps);
-
+/**
+ * @brief Performs the backward pass for diopiInstanceNorm(). Computes gradients for input, scale, and bias.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[out] grad_scale the gradient tensor of scale.
+ * @param[out] grad_bias the gradient tensor of bias.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] scale the scale tensor.
+ * @param[in] bias the bias tensor.
+ * @param[in] axis the axis along which normalization is applied.
+ * @param[in] eps small value to avoid division by zero during normalization.
+ */
 DIOPI_API diopiError_t diopiInstanceNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_scale,
                                                  diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
                                                  diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const int64_t axis, const double eps);
-
+/**
+ * @brief Normalizes the input tensor based on the p-norm along the given axis.
+ * @param[in] ctx Context environment.
+ * @param[out] output the normalized output tensor.
+ * @param[in] input the input tensor to be normalized.
+ * @param[in] p the p-norm to use for normalization.
+ * @param[in] axis the axis along which to normalize.
+ * @param[in] eps small value to avoid division by zero during normalization.
+ */
 DIOPI_API diopiError_t diopiNormalize(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const float p, const int64_t axis,
                                       const double eps);
-
+/**
+ * @brief Performs the backward pass for diopiNormalize(). Computes gradients for input.
+ * @param[in] ctx Context environment.
+ * @param[out] grad_input the gradient tensor of input.
+ * @param[in] grad_output the gradient tensor of the output.
+ * @param[in] input the input tensor.
+ * @param[in] p the p-norm used during normalization.
+ * @param[in] axis the axis along which normalization was applied.
+ * @param[in] eps small value to avoid division by zero during normalization.
+ */
 DIOPI_API diopiError_t diopiNormalizeBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output,
                                               diopiConstTensorHandle_t input, const float p, const int64_t axis, const double eps);
 

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -2699,6 +2699,14 @@ DIOPI_API diopiError_t diopiConvTranspose2dBackward(diopiContextHandle_t ctx, di
                                                     diopiConstTensorHandle_t weight, diopiSize_t* bias_sizes, diopiSize_t stride, diopiSize_t padding,
                                                     diopiSize_t dilation, diopiSize_t output_padding, int64_t groups);
 
+DIOPI_API diopiError_t diopiConvTranspose3d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t weight,
+                                            diopiConstTensorHandle_t bias, diopiSize_t stride, diopiSize_t padding, diopiSize_t output_padding, int64_t groups,
+                                            diopiSize_t dilation);
+
+DIOPI_API diopiError_t diopiConvTranspose3dBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_weight,
+                                                    diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input,
+                                                    diopiConstTensorHandle_t weight, diopiSize_t* bias_sizes, diopiSize_t stride, diopiSize_t padding,
+                                                    diopiSize_t dilation, diopiSize_t output_padding, int64_t groups);
 /**
  * @brief Extracts sliding local blocks from a batched input tensor.
  * @param[in] ctx Context environment.

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -2487,6 +2487,20 @@ DIOPI_API diopiError_t diopiSort(diopiContextHandle_t ctx, diopiTensorHandle_t v
                                  bool descending, const bool* pStable);
 
 /**
+ * @brief Computes the gradient of the input tensor with respect to the sorted output tensor during backpropagation.
+ * @param[in] ctx Context environment.
+ * @param[in] grad_output Tensor containing the gradient of the loss with respect to the sorted output.
+ * @param[in] dim The dimension along which the sorting was performed. This is used to correctly align the gradients with the corresponding dimension.
+ * @param[in] indices Tensor containing the indices that were used to sort the input tensor.
+ * @param[in] sizes The size of the tensor, which is necessary to manage the shape and alignment during gradient computation.
+ * @param[in] keepdim Boolean flag indicating whether to retain the reduced dimensions or not. If `true`, the dimensions that were reduced are retained with
+ * size one, which affects how gradients are accumulated.
+ * @param[out] grad_input Tensor to store the gradient with respect to the input tensor. This tensor will be updated with the computed gradient.
+ */
+DIOPI_API diopiError_t diopiSortBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, int64_t dim,
+                                         diopiConstTensorHandle_t indices, diopiSize_t sizes, bool keepdim);
+
+/**
  * @brief Returns the k largest elements of the given input tensor along a given dimension.
  * @param[in] ctx Context environment.
  * @param[in] input the input tesnor.type=[float16, float32, float64, int16, int32, int64, uint8, int8]

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -2695,6 +2695,15 @@ DIOPI_API diopiError_t diopiUnfoldBackward(diopiContextHandle_t ctx, diopiTensor
 DIOPI_API diopiError_t diopiCumsum(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, int64_t dim);
 
 /**
+ * @brief Computes the backward pass for diopiCumsum()
+ * @param[in] ctx Context environment.
+ * @param[in] grad_output the grad tensor of output, with the same shape as the forward pass output. type=[float16, float32, float64].
+ * @param[in] dim the dimension to do the operation over. type = [int64].
+ * @param[out] grad_input the grad tensor of input, with the same shape as the forward pass input. type=[float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiCumsumBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, int64_t dim);
+
+/**
  * @brief Computes batched the p-norm distance between each pair of the two collections of row vectors.
  * @param[in] ctx Context environment.
  * @param[in] input1 input tensor of shape B * P * M. type=[float32, float64].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -3621,6 +3621,8 @@ DIOPI_API diopiError_t diopiLayerNormGBBackward(diopiContextHandle_t ctx, diopiT
 
 DIOPI_API diopiError_t diopiInstanceNorm(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const int64_t axis, diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const double eps);
 
+DIOPI_API diopiError_t diopiInstanceNormBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiTensorHandle_t grad_scale, diopiTensorHandle_t grad_bias, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, diopiConstTensorHandle_t scale, diopiConstTensorHandle_t bias, const int64_t axis, const double eps);
+
 DIOPI_API diopiError_t diopiNormalize(diopiContextHandle_t ctx, diopiTensorHandle_t output, diopiConstTensorHandle_t input, const float p, const int64_t axis, const double eps);
 
 DIOPI_API diopiError_t diopiNormalizeBackward(diopiContextHandle_t ctx, diopiTensorHandle_t grad_input, diopiConstTensorHandle_t grad_output, diopiConstTensorHandle_t input, const float p, const int64_t axis, const double eps);

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -389,6 +389,12 @@ DIOPI_API diopiError_t diopiMaxPool2dBackward(diopiContextHandle_t ctx, diopiTen
                                               diopiSize_t dilation, bool ceil_mode, diopiConstTensorHandle_t indices);
 
 /**
+TODO
+ */
+DIOPI_API diopiError_t diopiPool2d(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const char* mode, diopiSize_t kernel_size,
+                                   diopiSize_t stride, diopiSize_t padding, diopiSize_t dilation, bool ceil_mode, bool exclusive, bool adaptive);
+
+/**
  * @brief Applies a 2D adaptive average pooling over an input signal composed of several input planes.
  * @param[in] ctx Context environment.
  * @param[in] input the input tensor. type = [float16, float32, float64]
@@ -3502,6 +3508,17 @@ DIOPI_API diopiError_t diopiNormalInp(diopiContextHandle_t ctx, diopiTensorHandl
  * @param[out] outs the output tensor. type = [float32, float64].
  */
 DIOPI_API diopiError_t diopiMeshGrid(diopiContextHandle_t ctx, diopiTensorHandle_t* outs, diopiConstTensorHandle_t* inputs, int64_t inputsNum);
+
+/**
+ * @brief Compute grid sample.
+ * @param[in] ctx Context environment.
+ * @param[in] input the original tensor to be sampled.
+ * @param[in] grid the pixel locations of sampling.
+ * @param[in] mode the sampling mode. [bilinear, nearest].
+ * @param[out] out the result sampling tensor.
+ */
+DIOPI_API diopiError_t diopiGridSample(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, diopiConstTensorHandle_t grid,
+                                       const char* mode);
 
 /**
  * @brief Returns a tensor where each row contains num_samples indices sampled from the

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -926,6 +926,21 @@ DIOPI_API diopiError_t diopiSinhInp(diopiContextHandle_t ctx, diopiTensorHandle_
 DIOPI_API diopiError_t diopiSinh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief The in-place version of diopiCosh().
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiCoshInp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
+
+/**
+ * @brief Returns a new tensor with the hyperbolic cosine of the elements of input.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float16, float32, float64].
+ * @param[out] out the input tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiCosh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief The in-place version of diopiTanh().
  * @param[in] ctx Context environment.
  * @param[in] input the input tensor. type = [float16, float32, float64].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -2714,6 +2714,16 @@ DIOPI_API diopiError_t diopiCdistBackward(diopiContextHandle_t ctx, diopiTensorH
 DIOPI_API diopiError_t diopiArgmax(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const int64_t* dim, bool keepdim);
 
 /**
+ * @brief Returns the indices of the minimum values of a tensor across a dimension.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type=[float32, float64, float16, int16, int32, int64, uint8, int8, bool].
+ * @param[in] dim the dimension to do the operation over. type=[int32, int64].
+ * @param[in] keepdim whether the output tensor has dim retained or not.
+ * @param[out] out the output tensor. type=[int32, int64].
+ */
+DIOPI_API diopiError_t diopiArgmin(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const int64_t* dim, bool keepdim);
+
+/**
  * @brief The function is used to implement the Adadelta optimizer. Its functionality is to perform a single parameter update.
  * @param[in] ctx Context environment.
  * @param[inout] param the param tensor. type=[float16, float32, float64].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -3699,6 +3699,14 @@ DIOPI_API diopiError_t diopiTriuInp(diopiContextHandle_t ctx, diopiTensorHandle_
 DIOPI_API diopiError_t diopiComplex(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t real, diopiConstTensorHandle_t imag);
 
 /**
+ * @brief Return the complex conjugate of the input tensor.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor.
+ * @param[in] out the complex conjugate of the input tensor.
+ */
+DIOPI_API diopiError_t diopiConj(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief Create a tensor filled with one.
  * @param[in] ctx Context environment.
  * @param[in] size Out tensor size.

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -3488,7 +3488,8 @@ DIOPI_API diopiError_t diopiNormBackward(diopiContextHandle_t ctx, diopiTensorHa
 
 /**
  * @brief Applies Layer Normalization over a mini-batch of inputs.
- * type=[float32, float64, float16].
+ * Note that, this is the national standard GB operator version, which is different from the diopiLayerNorm interface definition, normalized_shape has changed
+ * to begin_norm_axis. type=[float32, float64, float16].
  * @param[in] ctx Context environment.
  * @param[in] save_mean Mean tensor,the mean value for each feature channel of the input tensor. type=[float32, float64, float16].
  * @param[in] save_invstd Backup of inverse standard deviation computed during training. type=[float32, float64, float16].
@@ -3933,6 +3934,8 @@ DIOPI_API diopiError_t diopiLayerNormBackward(diopiContextHandle_t ctx, diopiTen
 
 /**
  * @brief Compute the backward pass for diopiLayerNormGB(). Computes gradients for input, weight, and bias.
+ * Note that, this is the national standard GB operator version, which is different from the diopiLayerNormBackward interface definition, normalized_shape has
+ * changed to begin_norm_axis
  * @param[in] ctx Context environment.
  * @param[in] grad_output the grad tensor of output. type=[float32, float64, float16].
  * @param[in] grad_bias the grad of bias. type=[float32, float64, float16].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -2724,6 +2724,18 @@ DIOPI_API diopiError_t diopiArgmax(diopiContextHandle_t ctx, diopiTensorHandle_t
 DIOPI_API diopiError_t diopiArgmin(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, const int64_t* dim, bool keepdim);
 
 /**
+ * @brief Returns the indices that sort a tensor along a given dimension in ascending order by value.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type=[float32, float64, float16, int16, int32, int64, uint8, int8, bool].
+ * @param[in] dim the dimension to do the operation over. type=[int32, int64].
+ * @param[in] descending controls the sorting order (ascending or descending).
+ * @param[in] stable controls the relative order of equivalent elements.
+ * @param[out] out the output tensor. type=[int32, int64].
+ */
+DIOPI_API diopiError_t diopiArgsort(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input, bool stable, const int64_t* dim,
+                                    bool descending);
+
+/**
  * @brief The function is used to implement the Adadelta optimizer. Its functionality is to perform a single parameter update.
  * @param[in] ctx Context environment.
  * @param[inout] param the param tensor. type=[float16, float32, float64].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -979,6 +979,22 @@ DIOPI_API diopiError_t diopiExpInp(diopiContextHandle_t ctx, diopiTensorHandle_t
 DIOPI_API diopiError_t diopiExp(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief The in-place version of diopiExpm1().
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor and will be stroed reuslt tensor. type = [float16, float32, float64]
+ */
+DIOPI_API diopiError_t diopiExpm1Inp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
+
+/**
+ * @brief Returns a new tensor with the exponential of the elements of the input tensor input and minus 1
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float16, float32, float64, int16, int32,
+ * int64, uint8, int8, bool].
+ * @param[out] out the output tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiExpm1(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief The in-place version of diopiLog().
  * @param[in] ctx Context environment.
  * @param[in] input the input tensor and will be stroed reuslt tensor. type = [float16, float32, float64, int16, int32, int64, uint8, int8].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -3707,6 +3707,14 @@ DIOPI_API diopiError_t diopiComplex(diopiContextHandle_t ctx, diopiTensorHandle_
 DIOPI_API diopiError_t diopiConj(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief Return the image part of the input tensor.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor.
+ * @param[in] out the image part of the input tensor.
+ */
+DIOPI_API diopiError_t diopiImag(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief Create a tensor filled with one.
  * @param[in] ctx Context environment.
  * @param[in] size Out tensor size.

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -3715,6 +3715,14 @@ DIOPI_API diopiError_t diopiConj(diopiContextHandle_t ctx, diopiTensorHandle_t o
 DIOPI_API diopiError_t diopiImag(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief Return the real part of the input tensor.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor.
+ * @param[in] out the real part of the input tensor.
+ */
+DIOPI_API diopiError_t diopiReal(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief Create a tensor filled with one.
  * @param[in] ctx Context environment.
  * @param[in] size Out tensor size.

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -879,6 +879,22 @@ DIOPI_API diopiError_t diopiCosInp(diopiContextHandle_t ctx, diopiTensorHandle_t
 DIOPI_API diopiError_t diopiCos(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief The in-place version of diopiTan().
+ * @param[in] ctx Context environment.
+ * @param[in] input the input and output tensor and will be stored result tensor,
+ * type = [float16, float32, float64, int16, int32, int64, uint8, int8].
+ */
+DIOPI_API diopiError_t diopiTanInp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
+
+/**
+ * @brief Compute the element-wise tangent values of the input tensor input.
+ * @param[in] ctx Context environment.
+ * @param[in] input Input tensor, type = [float16, float32, float64, int16, int32, int64, uint8, int8].
+ * @param[out] out the output tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiTan(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief The in-place version of diopiTanh().
  * @param[in] ctx Context environment.
  * @param[in] input the input tensor. type = [float16, float32, float64].

--- a/proto/include/diopi/functions.h
+++ b/proto/include/diopi/functions.h
@@ -993,6 +993,21 @@ DIOPI_API diopiError_t diopiAsinhInp(diopiContextHandle_t ctx, diopiTensorHandle
 DIOPI_API diopiError_t diopiAsinh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
 
 /**
+ * @brief The in-place version of diopiAcosh().
+ * @param[in] ctx Context environment.
+ * @param[inout] input the input tensor and will be stroed reuslt tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiAcoshInp(diopiContextHandle_t ctx, diopiTensorHandle_t input);
+
+/**
+ * @brief Returns a new tensor with the arc hyperbolic cosine of the elements of input.
+ * @param[in] ctx Context environment.
+ * @param[in] input the input tensor. type = [float16, float32, float64].
+ * @param[out] out the output tensor. type = [float16, float32, float64].
+ */
+DIOPI_API diopiError_t diopiAcosh(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiConstTensorHandle_t input);
+
+/**
  * @brief The in-place version of diopiSigmoid().
  * @param[in] ctx Context environment.
  * @param[in] input the input tensor and will be stroed reuslt tensor. type = [float16, float32].


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Description
<!--- Describe your changes in detail. -->
1.北大国标算子支持

完成了#1306 中7.2.10.3 ~ 7.2.15.4，7.2.4.3 ~ 7.2.11.1共24个待完善/开发的国标算子.

2.修复偶发的CI adam算子测试精度问题，将adam算子实现对齐到torch，参考https://github.com/pytorch/pytorch/blob/ba10259115b1c89292f3499cdba059ebb9ec6b4e/torch/optim/adam.py#L320

DIOPI中进行的修改如下：
```cpp
diopiError_t diopiAdam(diopiContextHandle_t ctx, diopiTensorHandle_t param, diopiConstTensorHandle_t grad, diopiTensorHandle_t exp_avg,
                       diopiTensorHandle_t exp_avg_sq, diopiTensorHandle_t max_exp_avg_sq, float lr, float beta1, float beta2, float eps, float weight_decay,
                       int64_t step, bool amsgrad) {
    impl::aten::setCurStream(ctx);
    auto atParam = impl::aten::buildATen(param);
    auto atGrad = impl::aten::buildATen(grad);
    auto atExpAvg = impl::aten::buildATen(exp_avg);
    auto atExpAvgSq = impl::aten::buildATen(exp_avg_sq);
    auto atMaxExpAvgSq = impl::aten::buildATen(max_exp_avg_sq);

    auto grad_d = atGrad.data();
    if (weight_decay != 0) {
        grad_d = grad_d.add(atParam, weight_decay);
    }
    // atExpAvg.mul_(beta1).add_(grad_d, 1 - beta1);
    atExpAvg.lerp_(grad_d, 1 - beta1);
    atExpAvgSq.mul_(beta2).addcmul_(grad_d, grad_d.conj(), 1 - beta2);

    at::Tensor denom;
    auto bias_correction1 = 1 - pow(beta1, step);
    auto bias_correction2 = 1 - pow(beta2, step);
    if (amsgrad) {
        CALL_ATEN_CUDA_FUNC(maximum_out, atMaxExpAvgSq, atMaxExpAvgSq, atExpAvgSq);
        denom = atMaxExpAvgSq.sqrt().div_(sqrt(bias_correction2)).add_(eps);
    } else {
        denom = atExpAvgSq.sqrt().div_(sqrt(bias_correction2)).add_(eps);
    }
    auto stepSize = lr / bias_correction1;
    atParam.addcdiv_(atExpAvg, denom, -1 * stepSize);

    return diopiSuccess;
}
```

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

