### PR TITLE
[ascend] fix memory leak: only datatype, const char* does not release

### DIFF
--- a/impl/ascend/aclnn/adaptor.hpp
+++ b/impl/ascend/aclnn/adaptor.hpp
@@ -201,6 +201,7 @@ decltype(auto) convertType(T&& param) {
     }
 }
 
+// For the case that the input is not a class or a pointer, do nothing.
 template <class T, class U = std::remove_reference_t<T>, std::enable_if_t<!std::is_class_v<U> && !std::is_pointer_v<U>, int> = 0>
 void releaseConverted(T&& param [[maybe_unused]]) {}  // no conversion, do nothing
 

--- a/impl/ascend/aclnn/adaptor.hpp
+++ b/impl/ascend/aclnn/adaptor.hpp
@@ -201,8 +201,11 @@ decltype(auto) convertType(T&& param) {
     }
 }
 
-template <class T>
+template <class T, class U = std::remove_reference_t<T>, std::enable_if_t<!std::is_class_v<U> && !std::is_pointer_v<U>, int> = 0>
 void releaseConverted(T&& param [[maybe_unused]]) {}  // no conversion, do nothing
+
+// Overload for const char* const&
+inline void releaseConverted(const char* const& param [[maybe_unused]]) {}
 
 #define IMPL_ASCEND_ACLNN_REGISTER_DESTRUCTOR(Type)        \
     inline void releaseConverted(const acl##Type* param) { \


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
修复在华为设备上的内存泄漏问题。

## Description
<!--- Describe your changes in detail. -->
修改之前，模型训练过程有内存泄漏：
![企业微信截图_1723166040505](https://github.com/user-attachments/assets/96986f25-4b8a-4b22-81a7-e87e7104f5a0)
修复之后，无内存泄漏问题：
![image](https://github.com/user-attachments/assets/51238b37-8055-420b-9000-80c2603360b2)

换到 #1346 提交pr

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [ ] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

