### PR TITLE
[ascend] fix memory leak: only datatype, const char* does not release && fix index op bug

### DIFF
--- a/impl/ascend/aclnn/adaptor.hpp
+++ b/impl/ascend/aclnn/adaptor.hpp
@@ -201,6 +201,7 @@ decltype(auto) convertType(T&& param) {
     }
 }
 
+// For the case that the input is not a class or a pointer, do nothing.
 template <class T, class U = std::remove_reference_t<T>, std::enable_if_t<!std::is_class_v<U> && !std::is_pointer_v<U>, int> = 0>
 void releaseConverted(T&& param [[maybe_unused]]) {}  // no conversion, do nothing
 

--- a/impl/ascend/aclnn/adaptor.hpp
+++ b/impl/ascend/aclnn/adaptor.hpp
@@ -209,7 +209,7 @@ decltype(auto) convertType(T&& param) {
     }
 }
 
-template<class T>
+template <class T>
 struct NeedReleaseType : std::disjunction<std::is_same<std::remove_cv_t<T>, aclTensor*>, std::is_same<std::remove_cv_t<T>, aclTensorList*>,
                                           std::is_same<std::remove_cv_t<T>, aclScalar*>, std::is_same<std::remove_cv_t<T>, aclScalarList*>,
                                           std::is_same<std::remove_cv_t<T>, aclIntArray*>, std::is_same<std::remove_cv_t<T>, aclBoolArray*>,

--- a/impl/ascend/aclnn/adaptor.hpp
+++ b/impl/ascend/aclnn/adaptor.hpp
@@ -201,8 +201,11 @@ decltype(auto) convertType(T&& param) {
     }
 }
 
-template <class T>
+template <class T, class U = std::remove_reference_t<T>, std::enable_if_t<!std::is_class_v<U> && !std::is_pointer_v<U>, int> = 0>
 void releaseConverted(T&& param [[maybe_unused]]) {}  // no conversion, do nothing
+
+// Overload for const char* const&
+inline void releaseConverted(const char* const& param [[maybe_unused]]) {}
 
 #define IMPL_ASCEND_ACLNN_REGISTER_DESTRUCTOR(Type)        \
     inline void releaseConverted(const acl##Type* param) { \

--- a/impl/ascend/aclnn/adaptor.hpp
+++ b/impl/ascend/aclnn/adaptor.hpp
@@ -215,9 +215,9 @@ struct NeedReleaseType : std::disjunction<std::is_same<std::remove_cv_t<T>, aclT
                                           std::is_same<std::remove_cv_t<T>, aclIntArray*>, std::is_same<std::remove_cv_t<T>, aclBoolArray*>,
                                           std::is_same<std::remove_cv_t<T>, aclFloatArray*>> {};
 
-// For the case that the input is not a class or a pointer, do nothing.
+// For the case that the input is not NeedReleaseType , do nothing.
 template <class T, std::enable_if_t<!NeedReleaseType<T>::value, int> = 0>
-void releaseConverted(T param) {}  // no conversion, do nothing
+void releaseConverted(T param [[maybe_unused]]) {}  // no conversion, do nothing
 
 #define IMPL_ASCEND_ACLNN_REGISTER_DESTRUCTOR(Type)        \
     inline void releaseConverted(const acl##Type* param) { \

--- a/impl/ascend/functions/index.cpp
+++ b/impl/ascend/functions/index.cpp
@@ -119,7 +119,7 @@ static std::vector<AscendTensor> expandIndicesTensors(diopiContextHandle_t ctx, 
 
 static aclTensor* createEmptyAclTensor() {
     std::vector<int64_t> nShape{0};
-    std::vector<int64_t> nStride{1};
+    std::vector<int64_t> nStride{0};
     int64_t storageSize = 0;
     void* storage = nullptr;
 
@@ -269,11 +269,11 @@ diopiError_t diopiIndex(diopiContextHandle_t ctx, diopiTensorHandle_t* out, diop
     auto indicesExpanded = expandIndicesTensors(ctx, inputAt, indicesList);
 
     std::vector<aclTensor*> allDefinedIndices;
-    auto emptyTensor = createEmptyAclTensor();
     for (const auto& idx : indicesExpanded) {
         if (idx.defined()) {
             allDefinedIndices.push_back(aclnn_adaptor::createAclTensorFromAscendTensor(idx));
         } else {
+            auto emptyTensor = createEmptyAclTensor();
             allDefinedIndices.push_back(emptyTensor);
         }
     }

--- a/impl/ascend/functions/index.cpp
+++ b/impl/ascend/functions/index.cpp
@@ -119,7 +119,7 @@ static std::vector<AscendTensor> expandIndicesTensors(diopiContextHandle_t ctx, 
 
 static aclTensor* createEmptyAclTensor() {
     std::vector<int64_t> nShape{0};
-    std::vector<int64_t> nStride{0};
+    std::vector<int64_t> nStride{1};
     int64_t storageSize = 0;
     void* storage = nullptr;
 


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
修复在华为设备上的内存泄漏问题。
修复index算子实现过程中重复set同一个emptyTensor而导致的析构过程delete nullptr的问题。

## Description
<!--- Describe your changes in detail. -->
修改之前，模型训练过程有内存泄漏：
![企业微信截图_1723166040505](https://github.com/user-attachments/assets/96986f25-4b8a-4b22-81a7-e87e7104f5a0)
修复之后，无内存泄漏问题：
![image](https://github.com/user-attachments/assets/51238b37-8055-420b-9000-80c2603360b2)
