### PR TITLE
Fix: Use diopiConstTensorHandle_t for Sparse Tensor Functions

### DIFF
--- a/diopi_test/diopi_stub/csrc/litert.cpp
+++ b/diopi_test/diopi_stub/csrc/litert.cpp
@@ -276,7 +276,7 @@ DIOPI_RT_API diopiError_t diopiIsTensorSparse(diopiConstTensorHandle_t th, bool*
     return diopiSuccess;
 }
 
-DIOPI_RT_API diopiError_t diopiGetTensorCrowIndices(diopiConstTensorHandle_t th, diopiTensorHandle_t* crow_indices) {
+DIOPI_RT_API diopiError_t diopiGetTensorCrowIndices(diopiConstTensorHandle_t th, diopiConstTensorHandle_t* crow_indices) {
     diopiSparseCsrTensor* spTh = dynamic_cast<diopiSparseCsrTensor*>(const_cast<diopiTensor*>(th));
     if (!spTh) {
         return diopiErrorOccurred;
@@ -285,7 +285,7 @@ DIOPI_RT_API diopiError_t diopiGetTensorCrowIndices(diopiConstTensorHandle_t th,
     return diopiSuccess;
 }
 
-DIOPI_RT_API diopiError_t diopiGetTensorColIndices(diopiConstTensorHandle_t th, diopiTensorHandle_t* col_indices) {
+DIOPI_RT_API diopiError_t diopiGetTensorColIndices(diopiConstTensorHandle_t th, diopiConstTensorHandle_t* col_indices) {
     diopiSparseCsrTensor* spTh = dynamic_cast<diopiSparseCsrTensor*>(const_cast<diopiTensor*>(th));
     if (!spTh) {
         return diopiErrorOccurred;
@@ -294,7 +294,7 @@ DIOPI_RT_API diopiError_t diopiGetTensorColIndices(diopiConstTensorHandle_t th, 
     return diopiSuccess;
 }
 
-DIOPI_RT_API diopiError_t diopiGetTensorValues(diopiConstTensorHandle_t th, diopiTensorHandle_t* values) {
+DIOPI_RT_API diopiError_t diopiGetTensorValues(diopiConstTensorHandle_t th, diopiConstTensorHandle_t* values) {
     diopiSparseCsrTensor* spTh = dynamic_cast<diopiSparseCsrTensor*>(const_cast<diopiTensor*>(th));
     if (!spTh) {
         return diopiErrorOccurred;

--- a/impl/torch/functions/functions_sparse.cpp
+++ b/impl/torch/functions/functions_sparse.cpp
@@ -23,13 +23,13 @@ diopiError_t diopiSpMM(diopiContextHandle_t ctx, diopiTensorHandle_t out, diopiC
     diopiIsTensorSparse(mat2, &is_sparse_mat2);
 
     if (is_sparse_input && !is_sparse_mat2) {
-        diopiTensorHandle_t crow_indices;
+        diopiConstTensorHandle_t crow_indices;
         diopiGetTensorCrowIndices(input, &crow_indices);
 
-        diopiTensorHandle_t col_indices;
+        diopiConstTensorHandle_t col_indices;
         diopiGetTensorColIndices(input, &col_indices);
 
-        diopiTensorHandle_t values;
+        diopiConstTensorHandle_t values;
         diopiGetTensorValues(input, &values);
 
         auto atRowPtr = impl::aten::buildATen(crow_indices);

--- a/proto/include/diopi/diopirt.h
+++ b/proto/include/diopi/diopirt.h
@@ -133,9 +133,9 @@ extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorStorageOffset(dio
 extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorStorageNbytes(diopiConstTensorHandle_t th, size_t* pNbytes);
 extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorDeviceIndex(diopiConstTensorHandle_t th, diopiDeviceIndex_t* pDevIndex);
 
-extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorCrowIndices(diopiConstTensorHandle_t th, diopiTensorHandle_t* crow_indices);
-extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorColIndices(diopiConstTensorHandle_t th, diopiTensorHandle_t* col_indices);
-extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorValues(diopiConstTensorHandle_t th, diopiTensorHandle_t* values);
+extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorCrowIndices(diopiConstTensorHandle_t th, diopiConstTensorHandle_t* crow_indices);
+extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorColIndices(diopiConstTensorHandle_t th, diopiConstTensorHandle_t* col_indices);
+extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetTensorValues(diopiConstTensorHandle_t th, diopiConstTensorHandle_t* values);
 extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiIsTensorSparse(diopiConstTensorHandle_t th, bool* is_sparse);
 extern DIOPI_RT_API DIOPI_ATTR_WEAK diopiError_t diopiGetCurrentDeviceIndex(diopiDeviceIndex_t* pDevIndex);
 


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves type safety of the sparse tensor handling, by using `diopiConstTensorHandle_t` for the output parameters

## Description
<!--- Describe your changes in detail. -->
- Modified the parameter of `diopiGetTensorCrowIndices`, `diopiGetTensorColIndices`, `diopiGetTensorValues` from `diopiTensorHandle_t` to `diopiConstTensorHandle_t`.
- Updated the corresponding function declarations in diopirt.h to reflect this change. Adjusted the call sites in functions_sparse.cpp to consistently use `diopiConstTensorHandle_t` for crow_indices, col_indices, and values.
- No functional changes are expected, only improved type safety

## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] CLA has been signed and all committers have signed the CLA in this PR.

