### PR TITLE
fix  a bug in fusedAdamW which will crash when amsgrad==false and refer to  uninitialized  variables

### DIFF
--- a/impl/torch/functions/functions.cpp
+++ b/impl/torch/functions/functions.cpp
@@ -3370,12 +3370,12 @@ diopiError_t diopiFusedAdamW(diopiContextHandle_t ctx, diopiTensorHandle_t* para
     DIOPI_IMPL_BUILD_ATEN_LIST(atExpAvg, exp_avgs, nums);
     DIOPI_CHECK_PTR(exp_avg_sqs);
     DIOPI_IMPL_BUILD_ATEN_LIST(atExpAvgSq, exp_avg_sqs, nums);
-    DIOPI_CHECK_PTR(max_exp_avg_sqs);
-    DIOPI_IMPL_BUILD_ATEN_LIST(atMaxExpAvgSq, max_exp_avg_sqs, nums);
     DIOPI_CHECK_PTR(state_steps);
     DIOPI_IMPL_BUILD_ATEN_LIST(atstep, state_steps, nums);
 
     if (amsgrad) {
+        DIOPI_CHECK_PTR(max_exp_avg_sqs);
+        DIOPI_IMPL_BUILD_ATEN_LIST(atMaxExpAvgSq, max_exp_avg_sqs, nums);
         CALL_ATEN_CUDA_FUNC(
             _fused_adamw_, atParam, atGrad, atExpAvg, atExpAvgSq, atMaxExpAvgSq, atstep, lr, beta1, beta2, weight_decay, eps, amsgrad, maximize);
     } else {


### PR DESCRIPTION
<!--- Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## Description
<!--- Describe your changes in detail. -->


## Use cases (Optional)
<!--- If this PR introduces a new feature, it is better to list some use cases here, and update the documentation. -->


## BC-breaking (Optional)
<!--- Does the modification introduce changes that break the backward-compatibility of the downstream repositories? -->
<!--- If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR. -->


## Checklist
**Before PR**:

- [x] I have read and followed the workflow indicated in the [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [Contributors.md](https://github.com/DeepLink-org/DIOPI/blob/main/Contributors.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] CLA has been signed and all committers have signed the CLA in this PR.

